### PR TITLE
Use state property in xlf-files #17

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Iterates the g.xlf file and updates all language xlf files. The default behavior
 - New translations with the sames source language as g.xlf gets copied to target, but prefixed with [NAB: REVIEW] or `<target state="needs-review-translation">`.
 - New translations with other source language than g.xlf is replaced with [NAB: NOT TRANSLATED] or `<target state="new">`
 
-_Please create an issue if you have an opinion of how the target states should be used or if you wish to se more functionality that improves the workflow when working with translation tools._
+_Please create an issue if you have an opinion of how the target states should be used or if you wish to see more functionality that improves the workflow when working with translation tools._
 
 ![Refresh XLF files from g.xlf](images/gifs/RefreshFromGXlfCorrection.gif)
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,15 @@ The workflow for working with these XLIFF tools are
 
 #### NAB: Refresh XLF files from g.xlf
 
-Iterates the g.xlf file and updates all language xlf files.
+Iterates the g.xlf file and updates all language xlf files. The default behavior is to insert the tags mentioned below. If the setting `NAB.UseExternalTranslationTool == true` the `state` attribute of `<target>` is modified instead.
 
 - The xlf files gets the same ordering as g.xlf
 - Translations marked as translate=no gets removed
-- Modified translations get's prefixed with [NAB: REVIEW]
-- New translations with the sames source language as g.xlf gets copied to target, but prefixed with [NAB: REVIEW]
-- New translations with other source language than g.xlf is replaced with [NAB: NOT TRANSLATED]
+- Modified translations get's prefixed with [NAB: REVIEW] or `<target state="needs-adaptation">`.
+- New translations with the sames source language as g.xlf gets copied to target, but prefixed with [NAB: REVIEW] or `<target state="needs-review-translation">`.
+- New translations with other source language than g.xlf is replaced with [NAB: NOT TRANSLATED] or `<target state="new">`
+
+_Please create an issue if you have an opinion of how the target states should be used or if you wish to se more functionality that improves the workflow when working with translation tools._
 
 ![Refresh XLF files from g.xlf](images/gifs/RefreshFromGXlfCorrection.gif)
 
@@ -34,9 +36,11 @@ Finds the next occurance of the tags [NAB: NOT TRANSLATED] or [NAB: REVIEW] and 
 - If the tag [NAB: NOT TRANSLATED] is selected, replace it with the translated text
 - If the tag [NAB: REVIEW] is selected, review the translation and update if needed, then you remove the tag
 
+If the setting `NAB.UseExternalTranslationTool` is set to `true` it searches for any target with a state that is considered not completed. Which is any state except `final`, `signed-off`, `translated`. The [NAB:*]-tags are not used when this setting is activated.
+
 #### NAB: Find untranslated texts (* Please read Known Issues below)
 
-Uses the Find in Files feature to search for the tags above.
+Uses the Find in Files feature to search for translation units in need of review or translation.
 
 #### NAB: Find translated texts of current line (* Please read Known Issues below)
 
@@ -135,8 +139,10 @@ This extension requires the [Microsoft AL Language Extension](https://marketplac
 
 This extension contributes the following settings:
 
-- `NAB.SigningCertificateName`: The name of the certificate used to sing app files. The certificate needs to be installed to the Personal store. For instructions on how to install the pfx certificate in the Personal Store, go to [Microsoft Docs](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/importing-an-spc-into-a-certificate-store)
-- `NAB.SignToolPath`: The full path to signtool.exe, used for signing app files. If this is not set the extension tries to find it on the default locations, if the signtool.exe is not found it tries to download and install signtool
+- `NAB.SigningCertificateName`: The name of the certificate used to sing app files. The certificate needs to be installed to the Personal store. For instructions on how to install the pfx certificate in the Personal Store, go to [Microsoft Docs](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/importing-an-spc-into-a-certificate-store).
+- `NAB.SignToolPath`: The full path to signtool.exe, used for signing app files. If this is not set the extension tries to find it on the default locations, if the signtool.exe is not found it tries to download and install signtool.
+- `NAB.UseExternalTranslationTool`: Modifies the state-attribute of the translation unit when running `NAB: Refresh XLF files from g.xlf` instead of inserting a searchable string. Useful when working with external translation software.
+- `NAB.ReplaceSelfClosingXlfTags`: Replaces self closing tags like `<tag/>` with a separate closing tag `</tag>`. Activated by default.
 
 ## Known Issues
 
@@ -150,7 +156,7 @@ Beta release.
 
 Please submit issues on [GitHub](https://github.com/jwikman/nab-al-tools/issues)
 
-## Contributing 
+## Contributing
 
 You are always welcome to open an issue for enhancements and bugs. If you'd like to give it a swing yourself you can follow this little guide to get up and running: [How To Contribute](./HowToContribute.md).
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Iterates the g.xlf file and updates all language xlf files. The default behavior
 - The xlf files gets the same ordering as g.xlf
 - Translations marked as translate=no gets removed
 - Modified translations get's prefixed with [NAB: REVIEW] or `<target state="needs-adaptation">`.
-- New translations with the sames source language as g.xlf gets copied to target, but prefixed with [NAB: REVIEW] or `<target state="needs-review-translation">`.
+- New translations with the same source language as g.xlf gets copied to target, but prefixed with [NAB: REVIEW] or `<target state="needs-review-translation">`.
 - New translations with other source language than g.xlf is replaced with [NAB: NOT TRANSLATED] or `<target state="new">`
 
 _Please create an issue if you have an opinion of how the target states should be used or if you wish to see more functionality that improves the workflow when working with translation tools._

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
                 "NAB.UseExternalTranslationTool": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Sets the state-attribute of the translation unit to 'needs-adaption' when running 'NAB: Refresh XLF files from g.xlf' instead of inserting a searchable string. Useful when working with external translation software.",
+                    "description": "Modifies the state-attribute of the translation unit when running `NAB: Refresh XLF files from g.xlf` instead of inserting a searchable string. Useful when working with external translation software.",
                     "scope": "resource"
                 },
                 "NAB.ReplaceSelfClosingXlfTags": {

--- a/package.json
+++ b/package.json
@@ -152,6 +152,12 @@
                     "default": false,
                     "description": "WORK IN PROGRESS - Indicates if the PowerShell functions should work against Docker Containers or regular servers",
                     "scope": "resource"
+                },
+                "NAB.UseExternalTranslationTool": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Sets the state-attribute of the translation unit to 'needs-adaption' when running 'NAB: Refresh XLF files from g.xlf' instead of inserting a searchable string. Useful when working with external translation software.",
+                    "scope": "resource"
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -158,6 +158,12 @@
                     "default": false,
                     "description": "Sets the state-attribute of the translation unit to 'needs-adaption' when running 'NAB: Refresh XLF files from g.xlf' instead of inserting a searchable string. Useful when working with external translation software.",
                     "scope": "resource"
+                },
+                "NAB.ReplaceSelfClosingXlfTags": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Replaces self closing tags like <tag/> with a separate closing tag </tag>",
+                    "scope": "resource"
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
                 },
                 "NAB.ReplaceSelfClosingXlfTags": {
                     "type": "boolean",
-                    "default": false,
+                    "default": true,
                     "description": "Replaces self closing tags like <tag/> with a separate closing tag </tag>",
                     "scope": "resource"
                 }

--- a/src/LanguageFunctions.ts
+++ b/src/LanguageFunctions.ts
@@ -217,7 +217,12 @@ export async function RefreshXlfFilesFromGXlf(sortOnly?: boolean): Promise<{
                                 let targetText: string = langTargetElement.textContent ? langTargetElement.textContent : '';
                                 if (useExternalTranslationTool) {
                                     if (targetText !== langSourceElement.textContent) {
-                                        langTargetElement.setAttribute('state', XliffTargetState.NeedsAdaptation);
+                                        if (langIsSameAsGXlf) {
+                                            langTargetElement.setAttribute('state', XliffTargetState.NeedsReviewTranslation);
+                                            langTargetElement.textContent = langSourceElement.textContent;
+                                        } else {
+                                            langTargetElement.setAttribute('state', XliffTargetState.NeedsAdaptation);
+                                        }
                                     }
                                 } else {
                                     if ((!targetText.startsWith(GetReviewToken())) && (!targetText.startsWith(GetNotTranslatedToken())) && (targetText !== langSourceElement.textContent)) {
@@ -301,7 +306,8 @@ function GetNoteElement(parentElement: Element, xmlns: string, fromValue: string
 function UpdateTargetElement(targetElement: Element, cloneElement: Element, langIsSameAsGXlf: boolean, useExternalTranslationTool: boolean, xmlns: string, targetState: string = '') {
     if (langIsSameAsGXlf) {
         if (useExternalTranslationTool) {
-            targetElement.setAttribute('state', targetState);
+            targetElement.setAttribute('state', XliffTargetState.NeedsReviewTranslation);
+            targetElement.textContent = cloneElement.getElementsByTagNameNS(xmlns, 'source')[0].textContent;
         } else {
             targetElement.textContent = GetReviewToken() + cloneElement.getElementsByTagNameNS(xmlns, 'source')[0].textContent;
         }

--- a/src/LanguageFunctions.ts
+++ b/src/LanguageFunctions.ts
@@ -52,7 +52,8 @@ async function FindNextUntranslatedByToken(xlfUri: vscode.Uri, startOffset: numb
 
 async function FindNextUntranslatedByState(xlfUri: vscode.Uri, startOffset: number): Promise<boolean> {
     let targetStates = GetTargetStateActionNeededAsList();
-    for (const state of targetStates) {
+    for (const s of targetStates) {
+        let state = `state="${s}"`;
         let searchResult = await DocumentFunctions.searchTextFile(xlfUri, startOffset, state);
         if (searchResult.foundNode) {
             await DocumentFunctions.openTextFileWithSelection(xlfUri, searchResult.foundAtPosition, state.length);
@@ -298,13 +299,17 @@ function GetNoteElement(parentElement: Element, xmlns: string, fromValue: string
     return;
 }
 function UpdateTargetElement(targetElement: Element, cloneElement: Element, langIsSameAsGXlf: boolean, useExternalTranslationTool: boolean, xmlns: string, targetState: string = '') {
-    if (useExternalTranslationTool) {
-        targetElement.setAttribute('state', targetState);
-    } else {
-        if (langIsSameAsGXlf) {
-            targetElement.textContent = GetReviewToken() + cloneElement.getElementsByTagNameNS(xmlns, 'source')[0].textContent;
+    if (langIsSameAsGXlf) {
+        if (useExternalTranslationTool) {
+            targetElement.setAttribute('state', targetState);
         } else {
-            cloneElement.textContent = GetNotTranslatedToken();
+            targetElement.textContent = GetReviewToken() + cloneElement.getElementsByTagNameNS(xmlns, 'source')[0].textContent;
+        }
+    } else {
+        if (useExternalTranslationTool) {
+            targetElement.setAttribute('state', targetState);
+        } else {
+            targetElement.textContent = GetNotTranslatedToken();
         }
     }
 }
@@ -377,7 +382,7 @@ function GetTransUnitLineType(TextLine: string): number {
 }
 
 function RemoveSelfClosingTags(xml: string): string {
-    if (!Settings.GetConfigSettings()[Setting.ReplaceSelfClosingXlfTags]) { return xml; }
+    if (Settings.GetConfigSettings()[Setting.ReplaceSelfClosingXlfTags] === false) { return xml; }
     // ref https://stackoverflow.com/a/16792194/5717285
     var split = xml.split("/>");
     var newXml = "";

--- a/src/LanguageFunctions.ts
+++ b/src/LanguageFunctions.ts
@@ -395,13 +395,13 @@ function RemoveSelfClosingTags(xml: string): string {
 
 function GetXmlStub(): string {
     return `<?xml version="1.0" encoding="utf-8"?>
-    <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-      <file datatype="xml" source-language="" target-language="" original="">
-        <body>
-          <group id="body"></group>
-        </body>
-      </file>
-    </xliff>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="" target-language="" original="">
+    <body>
+      <group id="body"></group>
+    </body>
+  </file>
+</xliff>
     `;
 }
 // <trans-unit id="Table 3710665244 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">

--- a/src/LanguageFunctions.ts
+++ b/src/LanguageFunctions.ts
@@ -366,7 +366,7 @@ function GetTransUnitLineType(TextLine: string): number {
     if (null !== TextLine.match(/\s*<source\/?>.*/i)) {
         return 1;
     }
-    if (null !== TextLine.match(/\s*<target\/?>.*/i)) {
+    if (null !== TextLine.match(/\s*<target.*\/?>.*/i)) {
         return 2;
     }
     if (null !== TextLine.match(/\s*<note from="Developer" annotates="general" priority="2".*/i)) {

--- a/src/LanguageFunctions.ts
+++ b/src/LanguageFunctions.ts
@@ -73,7 +73,7 @@ export async function CopySourceToTarget(): Promise<boolean> {
             let docText = vscode.window.activeTextEditor.document.getText();
             const lineEnding = whichLineEnding(docText);
             let docArray = docText.split(lineEnding);
-            if (docArray[vscode.window.activeTextEditor.selection.active.line].match(/<target>.*<\/target>/i)) {
+            if (docArray[vscode.window.activeTextEditor.selection.active.line].match(/<target.*>.*<\/target>/i)) {
                 // on a target line
                 let sourceLine = docArray[vscode.window.activeTextEditor.selection.active.line - 1].match(/<source>(.*)<\/source>/i);
                 if (sourceLine) {

--- a/src/NABfunctions.ts
+++ b/src/NABfunctions.ts
@@ -123,12 +123,11 @@ export async function FindTranslatedTexts() {
                 throw new Error('The current document is not an al file');
             }
             let navObj: ALObject = new ALObject(vscode.window.activeTextEditor.document.getText(), true);
-            //console.log(navObj);
             const textToSearchFor = navObj.codeLines[vscode.window.activeTextEditor.selection.start.line].GetXliffId();
             if (textToSearchFor === '') {
                 throw new Error('This line does not contain any translated property or label.');
             }
-            await VSCodeFunctions.FindTextInFiles(textToSearchFor, false);
+            await VSCodeFunctions.FindTextInFiles(textToSearchFor, false, '*.xlf');
         }
     } catch (error) {
         vscode.window.showErrorMessage(error.message);

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -11,12 +11,11 @@ export enum Setting {
     LaunchServerInstance,
     ConfigSigningCertificateName,
     ConfigSignToolPath,
-    ConfigPowerShellWithDocker
+    ConfigPowerShellWithDocker,
+    UseExternalTranslationTool
 }
 
 export class Settings {
-
-
     // static readonly AppName = 'name';
     // static readonly AppVersion = 'AppVersion';
     // static readonly AppIdRangeFrom = 'AppIdRangeFrom';
@@ -40,11 +39,10 @@ export class Settings {
 
     private static getConfigSettings(ResourceUri?: vscode.Uri) {
         this.config = vscode.workspace.getConfiguration(this.WORKSPACEKEY, WorkspaceFiles.GetWorkspaceFolder(ResourceUri).uri);
-
         this.SettingCollection[Setting.ConfigSignToolPath] = this.config.get('SignToolPath') + '';
         this.SettingCollection[Setting.ConfigSigningCertificateName] = this.config.get('SigningCertificateName') + '';
         this.SettingCollection[Setting.ConfigPowerShellWithDocker] = this.config.get('PowerShellWithDocker') ? this.config.get('PowerShellWithDocker') : false;
-
+        this.SettingCollection[Setting.UseExternalTranslationTool] = this.config.get('UseExternalTranslationTool') ? this.config.get('UseExternalTranslationTool') : false;
     }
 
     private static getAppSettings(ResourceUri?: vscode.Uri) {

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -44,7 +44,7 @@ export class Settings {
         this.SettingCollection[Setting.ConfigSigningCertificateName] = this.config.get('SigningCertificateName') + '';
         this.SettingCollection[Setting.ConfigPowerShellWithDocker] = this.config.get('PowerShellWithDocker') ? this.config.get('PowerShellWithDocker') : false;
         this.SettingCollection[Setting.UseExternalTranslationTool] = this.config.get('UseExternalTranslationTool') ? this.config.get('UseExternalTranslationTool') : false;
-        this.SettingCollection[Setting.ReplaceSelfClosingXlfTags] = this.config.get('ReplaceSelfClosingXlfTags') ? this.config.get('ReplaceSelfClosingXlfTags') : false;
+        this.SettingCollection[Setting.ReplaceSelfClosingXlfTags] = this.config.get('ReplaceSelfClosingXlfTags') ? this.config.get('ReplaceSelfClosingXlfTags') : true;
     }
 
     private static getAppSettings(ResourceUri?: vscode.Uri) {

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -12,7 +12,8 @@ export enum Setting {
     ConfigSigningCertificateName,
     ConfigSignToolPath,
     ConfigPowerShellWithDocker,
-    UseExternalTranslationTool
+    UseExternalTranslationTool,
+    ReplaceSelfClosingXlfTags
 }
 
 export class Settings {
@@ -43,6 +44,7 @@ export class Settings {
         this.SettingCollection[Setting.ConfigSigningCertificateName] = this.config.get('SigningCertificateName') + '';
         this.SettingCollection[Setting.ConfigPowerShellWithDocker] = this.config.get('PowerShellWithDocker') ? this.config.get('PowerShellWithDocker') : false;
         this.SettingCollection[Setting.UseExternalTranslationTool] = this.config.get('UseExternalTranslationTool') ? this.config.get('UseExternalTranslationTool') : false;
+        this.SettingCollection[Setting.ReplaceSelfClosingXlfTags] = this.config.get('ReplaceSelfClosingXlfTags') ? this.config.get('ReplaceSelfClosingXlfTags') : false;
     }
 
     private static getAppSettings(ResourceUri?: vscode.Uri) {

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -44,7 +44,7 @@ export class Settings {
         this.SettingCollection[Setting.ConfigSigningCertificateName] = this.config.get('SigningCertificateName') + '';
         this.SettingCollection[Setting.ConfigPowerShellWithDocker] = this.config.get('PowerShellWithDocker') ? this.config.get('PowerShellWithDocker') : false;
         this.SettingCollection[Setting.UseExternalTranslationTool] = this.config.get('UseExternalTranslationTool') ? this.config.get('UseExternalTranslationTool') : false;
-        this.SettingCollection[Setting.ReplaceSelfClosingXlfTags] = this.config.get('ReplaceSelfClosingXlfTags') ? this.config.get('ReplaceSelfClosingXlfTags') : true;
+        this.SettingCollection[Setting.ReplaceSelfClosingXlfTags] = this.config.get('ReplaceSelfClosingXlfTags');
     }
 
     private static getAppSettings(ResourceUri?: vscode.Uri) {

--- a/src/VSCodeFunctions.ts
+++ b/src/VSCodeFunctions.ts
@@ -3,9 +3,9 @@ import * as compareVersions from 'compare-versions';
 
 
 
-export async function FindTextInFiles(textToSearchFor: string, useRegex: boolean) {
+export async function FindTextInFiles(textToSearchFor: string, useRegex: boolean, filesToIncludeFilter: string='') {
     if ((compareVersions(vscode.version, '1.34.0') >= 0) || (vscode.env.appRoot === "d:\\VSCode\\Git\\vscode")) {
-        await vscode.commands.executeCommand('workbench.action.findInFiles', { query: textToSearchFor, triggerSearch: true, isRegex: useRegex, isCaseSensitive: false, matchWholeWord: false });
+        await vscode.commands.executeCommand('workbench.action.findInFiles', { query: textToSearchFor, triggerSearch: true, isRegex: useRegex, isCaseSensitive: false, matchWholeWord: false, filesToInclude: filesToIncludeFilter });
     } else {
         await vscode.env.clipboard.writeText(textToSearchFor);
         await vscode.commands.executeCommand('workbench.action.findInFiles');

--- a/src/XlfFunctions.ts
+++ b/src/XlfFunctions.ts
@@ -1,3 +1,16 @@
+export enum XliffTargetState {
+    /* https://docs.oasis-open.org/xliff/xliff-core/xliff-core.html */
+    Final = 'final', 	                                    // Indicates the terminating state.
+    NeedsAdaptation = 'needs-adaptation', 	                // Indicates only non-textual information needs adaptation.
+    NeedsL10n = 'needs-l10n',                               // Indicates both text and non-textual information needs adaptation.
+    NeedsReviewAdaptation = 'needs-review-adaptation',      // Indicates only non-textual information needs review.
+    NeedsReviewL10n = 'needs-review-l10n', 	                // Indicates both text and non-textual information needs review.
+    NeedsReviewTranslation = 'needs-review-translation', 	// Indicates that only the text of the item needs to be reviewed.
+    NeedsTranslation = 'needs-translation', 	            // Indicates that the item needs to be translated.
+    New = 'new', 	                                        // Indicates that the item is new. For example, translation units that were not in a previous version of the document.
+    SignedOff = 'signed-off',                               // Indicates that changes are reviewed and approved.
+    Translated = 'translated'                               // Indicates that the item has been translated. 
+}
 
 // https://www.yammer.com/dynamicsnavdev/threads/1002744300 - Peter Sørensen
 // The algorithm used on the names is the Roslyn hash method

--- a/src/XlfFunctions.ts
+++ b/src/XlfFunctions.ts
@@ -15,13 +15,13 @@ export enum XliffTargetState {
 }
 
 export function GetTargetStateActionNeededToken(): string {
-    return `${escapeStringRegexp(XliffTargetState.NeedsAdaptation)}|` +
-        `${escapeStringRegexp(XliffTargetState.NeedsL10n)}|` +
-        `${escapeStringRegexp(XliffTargetState.NeedsReviewAdaptation)}|` +
-        `${escapeStringRegexp(XliffTargetState.NeedsReviewL10n)}|` +
-        `${escapeStringRegexp(XliffTargetState.NeedsReviewTranslation)}|` +
-        `${escapeStringRegexp(XliffTargetState.NeedsTranslation)}|` +
-        `${escapeStringRegexp(XliffTargetState.New)}`;
+    return  `state="${escapeStringRegexp(XliffTargetState.NeedsAdaptation)}"|` +
+            `state="${escapeStringRegexp(XliffTargetState.NeedsL10n)}"|` +
+            `state="${escapeStringRegexp(XliffTargetState.NeedsReviewAdaptation)}"|` +
+            `state="${escapeStringRegexp(XliffTargetState.NeedsReviewL10n)}"|` +
+            `state="${escapeStringRegexp(XliffTargetState.NeedsReviewTranslation)}"|` +
+            `state="${escapeStringRegexp(XliffTargetState.NeedsTranslation)}"|` +
+            `state="${escapeStringRegexp(XliffTargetState.New)}"`;
 }
 export function GetTargetStateActionNeededAsList(): string[] {
     return [

--- a/src/XlfFunctions.ts
+++ b/src/XlfFunctions.ts
@@ -1,3 +1,5 @@
+import * as escapeStringRegexp from 'escape-string-regexp';
+
 export enum XliffTargetState {
     /* https://docs.oasis-open.org/xliff/xliff-core/xliff-core.html */
     Final = 'final', 	                                    // Indicates the terminating state.
@@ -11,6 +13,28 @@ export enum XliffTargetState {
     SignedOff = 'signed-off',                               // Indicates that changes are reviewed and approved.
     Translated = 'translated'                               // Indicates that the item has been translated. 
 }
+
+export function GetTargetStateActionNeededToken(): string {
+    return `${escapeStringRegexp(XliffTargetState.NeedsAdaptation)}|` +
+        `${escapeStringRegexp(XliffTargetState.NeedsL10n)}|` +
+        `${escapeStringRegexp(XliffTargetState.NeedsReviewAdaptation)}|` +
+        `${escapeStringRegexp(XliffTargetState.NeedsReviewL10n)}|` +
+        `${escapeStringRegexp(XliffTargetState.NeedsReviewTranslation)}|` +
+        `${escapeStringRegexp(XliffTargetState.NeedsTranslation)}|` +
+        `${escapeStringRegexp(XliffTargetState.New)}`;
+}
+export function GetTargetStateActionNeededAsList(): string[] {
+    return [
+        XliffTargetState.NeedsAdaptation,
+        XliffTargetState.NeedsL10n,
+        XliffTargetState.NeedsReviewAdaptation,
+        XliffTargetState.NeedsReviewL10n,
+        XliffTargetState.NeedsReviewTranslation,
+        XliffTargetState.NeedsTranslation,
+        XliffTargetState.New
+    ];
+}
+
 
 // https://www.yammer.com/dynamicsnavdev/threads/1002744300 - Peter Sørensen
 // The algorithm used on the names is the Roslyn hash method


### PR DESCRIPTION
Changes to solve issue #17 .

- [x] New setting `NAB.UseExternalTranslationTool` this setting modifies the target state attribute instead of inserting a searchable string.
- [x] When searching for all and next untranslated texts and `NAB.UseExternalTranslationTool == true` the state attribute is searched. 
- [x] New setting `NAB.ReplaceSelfClosingXlfTags` default true. This regulates the use of functionality was added for issue #5. If set to false no self-closed tags are replaced in xlf-files.

- [x] Update README.md.