### PR TITLE
Dev/tooltips docs fix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
         "out": true // set this to false to include "out" folder in search results
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off"
+    "typescript.tsc.autoDetect": "off",
+    "git.suggestSmartCommit": false
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [Unreleased]
 -->
 
+## [0.3.35] Public Beta - 2020-10-15
+
+- `NAB: Generate ToolTip Documentation` updated
+  - Sort controls by type
+  - Don't add page parts that does not exist in tooltip doc
+  - No app name in header
+
 ## [0.3.34] Public Beta - 2020-09-23
 
 - New feature: `NAB: Generate ToolTip Documentation`. Generates a MarkDown (.md) file with the ToolTips for Pages and Page Extensions. Check out README for more info.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "nab-al-tools",
     "displayName": "NAB AL Tools",
     "description": "Development and translation management tool for AL language and Microsoft Dynamics 365 Business Central extensions.",
-    "version": "0.3.34",
+    "version": "0.3.35",
     "publisher": "nabsolutions",
     "repository": {
         "type": "git",

--- a/src/ToolTipsFunctions.ts
+++ b/src/ToolTipsFunctions.ts
@@ -51,7 +51,9 @@ export async function generateToolTipDocumentation() {
 
                 if (controlCaption.length > 0) {
                     if (control.type === ControlType.Part) {
-                        tableText.push(`| Sub page | ${controlCaption} | ${getPagePartText(control)} |`);
+                        if (getPagePartText(control) !== '') {
+                            tableText.push(`| Sub page | ${controlCaption} | ${getPagePartText(control)} |`);
+                        }
                     } else {
                         tableText.push(`| ${controlTypeText} | ${controlCaption} | ${toolTip} |`);
                     }
@@ -126,8 +128,10 @@ export async function generateToolTipDocumentation() {
         }
         if (!(skipDocsForPageType(pageType)) && !(skipDocsForPageId(pagePart.relatedObject.objectType, pagePart.relatedObject.objectId))) {
             const pageCaption = pagePart.relatedObject.objectCaption;
-            const anchorName = pageCaption.replace(/\./g, '').trim().toLowerCase().replace(/ /g, '-');
-            returnText = `[${pageCaption}](#${anchorName})`;
+            if (pageCaption !== '') {
+                const anchorName = pageCaption.replace(/\./g, '').trim().toLowerCase().replace(/ /g, '-');
+                returnText = `[${pageCaption}](#${anchorName})`;
+            }
         }
         return returnText;
     }

--- a/src/ToolTipsFunctions.ts
+++ b/src/ToolTipsFunctions.ts
@@ -44,7 +44,7 @@ export async function generateToolTipDocumentation() {
             tableText.push('');
             tableText.push('| Type | Caption | Description |');
             tableText.push('| ----- | --------- | ------- |');
-            currObject.controls.forEach(control => {
+            currObject.controls.sort((a, b) => a.type < b.type ? -1 : 1).forEach(control => {
                 let toolTip = control.toolTip;
                 let controlTypeText = ControlType[control.type];
                 let controlCaption = control.caption.trim();

--- a/src/ToolTipsFunctions.ts
+++ b/src/ToolTipsFunctions.ts
@@ -8,7 +8,7 @@ import * as WorkspaceFunctions from './WorkspaceFunctions';
 export async function generateToolTipDocumentation() {
     let objects: ALObject[] = await WorkspaceFunctions.getAlObjectsFromCurrentWorkspace();
     let docs: string[] = new Array();
-    docs.push('# Pages Overview | ' + Settings.getAppSettings()[Setting.AppName]);
+    docs.push('# Pages Overview');
     docs.push('');
 
     let pageObjects = objects.filter(x => x.objectType === ObjectType.Page || x.objectType === ObjectType.PageExtension);


### PR DESCRIPTION
- `NAB: Generate ToolTip Documentation` updated
  - Sort controls by type
  - Don't add page parts that does not exist in tooltip doc
  - No app name in header