### PR TITLE
Keep spaces in source/target

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -66,7 +66,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [0.3.26] Public Beta - 2020-03-31
 
 - New setting `NAB.SearchOnlyXlfFiles`
-  - If enabled, the `NAB:Find Untranslated texts` function only searches *.xlf files. Be aware of that the *.xlf file filter remains in "Find in Files" after this command has been run. This should be enabled in large projects (as Base Application) for performance reasons.
+  - If enabled, the `NAB:Find Untranslated texts` function only searches \*.xlf files. Be aware of that the \*.xlf file filter remains in "Find in Files" after this command has been run. This should be enabled in large projects (as Base Application) for performance reasons.
 - New snippet `tistemporarycheck`
   - This check prevents that a temporary parameter that is passed by reference (var) is called with a record that is not temporary.
 - Dependency updates

--- a/extension/README.md
+++ b/extension/README.md
@@ -230,11 +230,11 @@ This extension requires the [Microsoft AL Language Extension](https://marketplac
 
 This extension contributes the following settings:
 
-* `NAB.SigningCertificateName`: The name of the certificate used to sing app files. The certificate needs to be installed to the Personal store. For instructions on how to install the pfx certificate in the Personal Store, go to [Microsoft Docs](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/importing-an-spc-into-a-certificate-store).
+* `NAB.SigningCertificateName`: The name of the certificate used to sing app files. The certificate needs to be installed to the Personal store. For instructions on how to install the pfx certificate in the Personal Store, go to [Microsoft Docs](https://docs.microsoft.com/windows-hardware/drivers/install/importing-an-spc-into-a-certificate-store).
 * `NAB.SignToolPath`: The full path to signtool.exe, used for signing app files. If this is not set the extension tries to find it on the default locations, if the signtool.exe is not found it tries to download and install signtool.
 * `NAB.UseExternalTranslationTool`: Modifies the state-attribute of the translation unit when running `NAB: Refresh XLF files from g.xlf` instead of inserting a searchable string. Useful when working with external translation software.
 * `NAB.ReplaceSelfClosingXlfTags`: Replaces self closing tags like `<tag/>` with a separate closing tag `</tag>`. Activated by default.
-* `NAB.SearchOnlyXlfFiles`: If enabled, the `NAB:Find Untranslated texts` function only searches *.xlf files. Be aware of that the *.xlf file filter remains in "Find in Files" after this command has been run. This should be enabled in large projects (as Base Application) for performance reasons.
+* `NAB.SearchOnlyXlfFiles`: If enabled, the `NAB:Find Untranslated texts` function only searches \*.xlf files. Be aware of that the \*.xlf file filter remains in "Find in Files" after this command has been run. This should be enabled in large projects (as Base Application) for performance reasons.
 * `NAB.MatchTranslation`: If enabled, the `NAB: Refresh XLF files from g.xlf` function tries to match sources in the translated xlf file to reuse translations. A found match of "source" is then prefixed with `[NAB: SUGGESTION]` for manual review. If several matches are found, all matches are added as targets and you need delete the ones you do not want. Use `NAB: Find next untranslated text` (Ctrl+Alt+U) or `NAB: Find multiple targets in XLF files` to review all matches. This feature only works if "UseExternalTranslationTool" is disabled. Activated by default.
 
 ## Known Issues

--- a/extension/README.md
+++ b/extension/README.md
@@ -112,6 +112,11 @@ Updates the g.xlf file from AL files. Practical if you need to update translatio
 All new trans-units will be placed in the bottom of the g.xlf file. When a build is done later, the g.xlf will be sorted in the correct way. Use the functions `NAB: Sort XLF files as g.xlf` or `NAB: Refresh XLF files from g.xlf` to sort the translated files in the same way as g.xlf.
 The only case where this function will remove an existing trans-unit from the g.xlf file is if a text has been changed to Locked = true.
 
+Note: This function relies completely on text matching (hence no need for symbols). This has a couple of consequences:
+
+* Make sure that the code is correctly formatted. Use the auto format functionality from the AL Language extension for this.
+* There are probably cases that we just don't support yet. If you find one, please report an issue at [GitHub](https://github.com/jwikman/nab-al-tools/issues) with as much info as possible for us to reproduce the issue (the AL file, the g.xlf file etc.)
+
 ### Other Features
 
 #### NAB: Suggest ToolTips

--- a/extension/README.md
+++ b/extension/README.md
@@ -109,6 +109,8 @@ Copies the content of the \<source\> element to the \<target\> element. Use this
 #### NAB: Update g.xlf
 
 Updates the g.xlf file from AL files. Practical if you need to update translations when you don't have all symbols to compile the solution.
+All new trans-units will be placed in the bottom of the g.xlf file. When a build is done later, the g.xlf will be sorted in the correct way. Use the functions `NAB: Sort XLF files as g.xlf` or `NAB: Refresh XLF files from g.xlf` to sort the translated files in the same way as g.xlf.
+The only case where this function will remove an existing trans-unit from the g.xlf file is if a text has been changed to Locked = true.
 
 ### Other Features
 

--- a/extension/src/ALObject.ts
+++ b/extension/src/ALObject.ts
@@ -307,7 +307,7 @@ export class ALObject {
                     if (xliffIdWithNames.length > 0 && xliffIdWithNames[xliffIdWithNames.length - 1].type === 'Control' && newToken.type === 'Action') {
                         xliffIdWithNames.pop();
                     }
-                xliffIdWithNames.push(newToken);
+                    xliffIdWithNames.push(newToken);
                 }
             }
             let mlProperty = ALObject.getMlProperty(line);
@@ -563,14 +563,8 @@ export class ALObject {
             if (matchResult.groups) {
                 let mlObject = new MultiLanguageObject();
                 mlObject.name = matchResult.groups.name;
-                if (matchResult.groups.text1 && (matchResult.groups.text1 !== `''`) ){
-                    mlObject.text = matchResult.groups.text1;
-                } else if (matchResult.groups.text2) {
-                    mlObject.text = matchResult.groups.text2;
-                } else {
-                    mlObject.text = matchResult.groups.text.substr(1,matchResult.groups.text.length - 2); // Remove leading and trailing '
-                }
-                mlObject.text = Common.replaceAll(mlObject.text,`''`, `'`);
+                mlObject.text = matchResult.groups.text.substr(1, matchResult.groups.text.length - 2); // Remove leading and trailing '
+                mlObject.text = Common.replaceAll(mlObject.text, `''`, `'`);
                 if (matchResult.groups.locked) {
                     if (matchResult.groups.lockedValue.toLowerCase() === 'true') {
                         mlObject.locked = true;
@@ -584,12 +578,10 @@ export class ALObject {
                         mlObject.locked = true;
                     }
                 }
-                if (matchResult.groups.commentText1) {
-                    mlObject.comment = matchResult.groups.commentText1;
-                } else if (matchResult.groups.commentText2) {
-                    mlObject.comment = matchResult.groups.commentText2;
+                if (matchResult.groups.commentText) {
+                    mlObject.comment = matchResult.groups.commentText.substr(1, matchResult.groups.commentText.length - 2); // Remove leading and trailing '
                 }
-                mlObject.comment = Common.replaceAll(mlObject.comment,`''`, `'`);
+                mlObject.comment = Common.replaceAll(mlObject.comment, `''`, `'`);
 
                 if (matchResult.groups.maxLength) {
                     mlObject.maxLength = Number.parseInt(matchResult.groups.maxLengthValue);

--- a/extension/src/ALObject.ts
+++ b/extension/src/ALObject.ts
@@ -557,12 +557,12 @@ export class ALObject {
             if (matchResult.groups) {
                 let mlObject = new MultiLanguageObject();
                 mlObject.name = matchResult.groups.name;
-                if (matchResult.groups.text1) {
+                if (matchResult.groups.text1 && (matchResult.groups.text1 !== `''`) ){
                     mlObject.text = matchResult.groups.text1;
                 } else if (matchResult.groups.text2) {
                     mlObject.text = matchResult.groups.text2;
-                } else if (matchResult.groups.text === '\'\'') {
-                    mlObject.text = '';
+                } else {
+                    mlObject.text = matchResult.groups.text.substr(1,matchResult.groups.text.length - 2); // Remove leading and trailing '
                 }
                 if (matchResult.groups.locked) {
                     if (matchResult.groups.lockedValue.toLowerCase() === 'true') {

--- a/extension/src/ALObject.ts
+++ b/extension/src/ALObject.ts
@@ -165,7 +165,7 @@ export class ALObject {
             if (obsoleteStateRemovedResult) {
                 obsoleteStateRemoved = true;
                 obsoleteStateRemovedIndentation = indentation;
-                if (indentation > 1) {
+                if (indentation >= 1) {
                     lastMlLine.isML = false;
                 }
             }

--- a/extension/src/ALObject.ts
+++ b/extension/src/ALObject.ts
@@ -531,7 +531,7 @@ export class ALObject {
     }
 
     private static matchLabel(line: string): RegExpExecArray | null {
-        const labelTokenPattern = /^\s*(?<name>\w*): Label (?<text>('(?<text1>[^']*'{2}[^']*)*')|'(?<text2>[^']*)')(?<locked>,\s?Locked\s?=\s?(?<lockedValue>true|false))?(?<comment>,\s?Comment\s?=\s?(?<commentText>('(?<commentText1>[^']*'{2}[^']*)*')|'(?<commentText2>[^']*)'))?(?<maxLength>,\s?MaxLength\s?=\s?(?<maxLengthValue>\d*))?/i;
+        const labelTokenPattern = /^\s*(?<name>\w*): Label (?<text>('(?<text1>[^']*'{2}[^']*)*')|'(?<text2>[^']*)')(?<maxLength3>,\s?MaxLength\s?=\s?(?<maxLengthValue3>\d*))?(?<locked>,\s?Locked\s?=\s?(?<lockedValue>true|false))?(?<maxLength2>,\s?MaxLength\s?=\s?(?<maxLengthValue2>\d*))?(?<comment>,\s?Comment\s?=\s?(?<commentText>('(?<commentText1>[^']*'{2}[^']*)*')|'(?<commentText2>[^']*)'))?(?<locked2>,\s?Locked\s?=\s?(?<lockedValue2>true|false))?(?<maxLength>,\s?MaxLength\s?=\s?(?<maxLengthValue>\d*))?(?<locked3>,\s?Locked\s?=\s?(?<lockedValue3>true|false))?/i;
         let labelTokenResult = labelTokenPattern.exec(line);
         return labelTokenResult;
     }
@@ -543,7 +543,7 @@ export class ALObject {
 
 
     private static matchMlProperty(line: string): RegExpExecArray | null {
-        const mlTokenPattern = /^\s*(?<name>OptionCaption|Caption|ToolTip|InstructionalText|PromotedActionCategories|RequestFilterHeading) = (?<text>('(?<text1>[^']*'{2}[^']*)*')|'(?<text2>[^']*)')(?<locked>,\s?Locked\s?=\s?(?<lockedValue>true|false))?(?<comment>,\s?Comment\s?=\s?(?<commentText>('(?<commentText1>[^']*'{2}[^']*)*')|'(?<commentText2>[^']*)'))?(?<maxLength>,\s?MaxLength\s?=\s?(?<maxLengthValue>\d*))?/i;
+        const mlTokenPattern = /^\s*(?<name>OptionCaption|Caption|ToolTip|InstructionalText|PromotedActionCategories|RequestFilterHeading) = (?<text>('(?<text1>[^']*'{2}[^']*)*')|'(?<text2>[^']*)')(?<maxLength3>,\s?MaxLength\s?=\s?(?<maxLengthValue3>\d*))?(?<locked>,\s?Locked\s?=\s?(?<lockedValue>true|false))?(?<maxLength2>,\s?MaxLength\s?=\s?(?<maxLengthValue2>\d*))?(?<comment>,\s?Comment\s?=\s?(?<commentText>('(?<commentText1>[^']*'{2}[^']*)*')|'(?<commentText2>[^']*)'))?(?<locked2>,\s?Locked\s?=\s?(?<lockedValue2>true|false))?(?<maxLength>,\s?MaxLength\s?=\s?(?<maxLengthValue>\d*))?(?<locked3>,\s?Locked\s?=\s?(?<lockedValue3>true|false))?/i;
         let mlTokenResult = mlTokenPattern.exec(line);
         return mlTokenResult;
     }
@@ -570,6 +570,14 @@ export class ALObject {
                     if (matchResult.groups.lockedValue.toLowerCase() === 'true') {
                         mlObject.locked = true;
                     }
+                } else if (matchResult.groups.locked2) {
+                    if (matchResult.groups.lockedValue2.toLowerCase() === 'true') {
+                        mlObject.locked = true;
+                    }
+                } else if (matchResult.groups.locked3) {
+                    if (matchResult.groups.lockedValue3.toLowerCase() === 'true') {
+                        mlObject.locked = true;
+                    }
                 }
                 if (matchResult.groups.commentText1) {
                     mlObject.comment = matchResult.groups.commentText1;
@@ -580,6 +588,10 @@ export class ALObject {
 
                 if (matchResult.groups.maxLength) {
                     mlObject.maxLength = Number.parseInt(matchResult.groups.maxLengthValue);
+                } else if (matchResult.groups.maxLength2) {
+                    mlObject.maxLength = Number.parseInt(matchResult.groups.maxLengthValue2);
+                } else if (matchResult.groups.maxLength3) {
+                    mlObject.maxLength = Number.parseInt(matchResult.groups.maxLengthValue3);
                 }
                 return mlObject;
             }

--- a/extension/src/ALObject.ts
+++ b/extension/src/ALObject.ts
@@ -161,7 +161,7 @@ export class ALObject {
             let increaseResult = line.match(indentationIncrease);
             const indentationDecrease = /(^\s*}|}\s*\/{2}(.*)$|^\s*\bend\b)/i;
             let decreaseResult = line.match(indentationDecrease);
-            const xliffIdTokenPattern = /(^\s*\bdataitem\b)\((.*);.*\)|^\s*\b(column)\b\((.*);(.*)\)|^\s*\b(value)\b\(\d*;(.*)\)|^\s*\b(group)\b\((.*)\)|^\s*\b(field)\b\((.*);(.*);(.*)\)|^\s*\b(field)\b\((.*);(.*)\)|^\s*\b(part)\b\((.*);(.*)\)|^\s*\b(action)\b\((.*)\)|^\s*\b(trigger)\b (.*)\(.*\)|^\s*\b(procedure)\b (.*)\(.*\)|^\s*\blocal (procedure)\b (.*)\(.*\)|^\s*\binternal (procedure)\b (.*)\(.*\)|^\s*\b(layout)\b$|^\s*\b(actions)\b$|^\s*\b(cuegroup)\b\((.*)\)|^\s*\b(separator)\b\((.*)\)/i;
+            const xliffIdTokenPattern = /(^\s*\bdataitem\b)\((.*);.*\)|^\s*\b(column)\b\((.*);(.*)\)|^\s*\b(value)\b\(\d*;(.*)\)|^\s*\b(group)\b\((.*)\)|^\s*\b(field)\b\((.*);(.*);(.*)\)|^\s*\b(field)\b\((.*);(.*)\)|^\s*\b(part)\b\((.*);(.*)\)|^\s*\b(action)\b\((.*)\)|^\s*\b(trigger)\b (.*)\(.*\)|^\s*\b(procedure)\b (.*)\(.*\)|^\s*\blocal (procedure)\b (.*)\(.*\)|^\s*\binternal (procedure)\b (.*)\(.*\)|^\s*\b(layout)\b$|^\s*\b(actions)\b$|^\s*\b(cuegroup)\b\((.*)\)|^\s*\b(repeater)\b\((.*)\)|^\s*\b(separator)\b\((.*)\)/i;
             let obsoleteStateRemovedResult = line.match(/^\s*ObsoleteState = Removed;/i);
             if (obsoleteStateRemovedResult) {
                 obsoleteStateRemoved = true;
@@ -177,6 +177,11 @@ export class ALObject {
                 let skipToken = false;
                 switch (xliffTokenResult.filter(elmt => elmt !== undefined)[1].toLowerCase()) {
                     case 'cuegroup':
+                        newToken.type = 'Control';
+                        newToken.Name = xliffTokenResult[2];
+                        newToken.level = indentation;
+                        break;
+                    case 'repeater':
                         newToken.type = 'Control';
                         newToken.Name = xliffTokenResult[2];
                         newToken.level = indentation;

--- a/extension/src/ALObject.ts
+++ b/extension/src/ALObject.ts
@@ -1,6 +1,7 @@
 import { isNullOrUndefined } from "util";
 import { alFnv } from "./AlFunctions";
 import { Note, SizeUnit, TransUnit } from "./XLIFFDocument";
+import * as Common from './Common';
 
 export class ALObject {
     public objectFileName: string = '';
@@ -564,6 +565,7 @@ export class ALObject {
                 } else {
                     mlObject.text = matchResult.groups.text.substr(1,matchResult.groups.text.length - 2); // Remove leading and trailing '
                 }
+                mlObject.text = Common.replaceAll(mlObject.text,`''`, `'`);
                 if (matchResult.groups.locked) {
                     if (matchResult.groups.lockedValue.toLowerCase() === 'true') {
                         mlObject.locked = true;
@@ -574,6 +576,8 @@ export class ALObject {
                 } else if (matchResult.groups.commentText2) {
                     mlObject.comment = matchResult.groups.commentText2;
                 }
+                mlObject.comment = Common.replaceAll(mlObject.comment,`''`, `'`);
+
                 if (matchResult.groups.maxLength) {
                     mlObject.maxLength = Number.parseInt(matchResult.groups.maxLengthValue);
                 }

--- a/extension/src/Common.ts
+++ b/extension/src/Common.ts
@@ -1,4 +1,4 @@
-export function replaceAll(text: string, searchFor: string, replaceValue: string): string {
+export function replaceAll(text: string, searchFor: string | RegExp, replaceValue: string): string {
     var re = new RegExp(searchFor, 'g');
     return text.replace(re, replaceValue);
 }

--- a/extension/src/Common.ts
+++ b/extension/src/Common.ts
@@ -1,0 +1,4 @@
+export function replaceAll(text: string, searchFor: string, replaceValue: string): string {
+    var re = new RegExp(searchFor, 'g');
+    return text.replace(re, replaceValue);
+}

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -14,26 +14,26 @@ import { isNullOrUndefined } from 'util';
 
 const logger = Logging.ConsoleLogger.getInstance();
 
-export async function getGXlfDocument(): Promise<{ fileName: String; gXlfDoc: Xliff }> {
+export async function getGXlfDocument(): Promise<{ fileName: string; gXlfDoc: Xliff }> {
 
     let uri = await WorkspaceFunctions.getGXlfFile();
     if (isNullOrUndefined(uri)) {
         throw new Error("No g.xlf file was found");
     }
 
-    let gXlfDoc = Xliff.fromFileSync(uri.fsPath, 'UTF8');
+    let gXlfDoc = Xliff.fromFileSync(uri.fsPath, "utf8");
     return { fileName: await VSCodeFunctions.getFilename(uri.fsPath), gXlfDoc: gXlfDoc };
 
 }
 
-export async function updateGXlfFromAlFiles(replaceSelfClosingXlfTags: boolean = true, formatXml: boolean = true) {
+export async function updateGXlfFromAlFiles(replaceSelfClosingXlfTags: boolean = true, formatXml: boolean = true) : Promise<string> {
     let gXlfDocument = await getGXlfDocument();
     let alObjects = await WorkspaceFunctions.getAlObjectsFromCurrentWorkspace();
     alObjects.forEach(alObject => {
         updateGXlf(gXlfDocument.gXlfDoc, alObject.getTransUnits());
     });
     let gXlfFilePath = await WorkspaceFunctions.getGXlfFile();
-    gXlfDocument.gXlfDoc.toFileSync(gXlfFilePath.fsPath, replaceSelfClosingXlfTags, formatXml, 'utf8bom');
+    gXlfDocument.gXlfDoc.toFileSync(gXlfFilePath.fsPath, replaceSelfClosingXlfTags, formatXml, "utf8bom");
 
     return gXlfDocument.fileName;
 }

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -14,28 +14,28 @@ import { isNullOrUndefined } from 'util';
 
 const logger = Logging.ConsoleLogger.getInstance();
 
-export async function getGXlfDocument() {
-    let gXlfFilePath = await WorkspaceFunctions.getGXlfFile();
-    if (isNullOrUndefined(gXlfFilePath)) {
-        return null;
+export async function getGXlfDocument(): Promise<{ fileName: String; gXlfDoc: Xliff }> {
+
+    let uri = await WorkspaceFunctions.getGXlfFile();
+    if (isNullOrUndefined(uri)) {
+        throw new Error("No g.xlf file was found");
     }
 
-    let gxlfDoc = Xliff.fromFileSync(gXlfFilePath.fsPath, 'UTF8');
-    return gxlfDoc;
+    let gXlfDoc = Xliff.fromFileSync(uri.fsPath, 'UTF8');
+    return { fileName: await VSCodeFunctions.getFilename(uri.fsPath), gXlfDoc: gXlfDoc };
+
 }
 
 export async function updateGXlfFromAlFiles(replaceSelfClosingXlfTags: boolean = true, formatXml: boolean = true) {
-    let gXlfDoc = await getGXlfDocument();
-    if (null === gXlfDoc) {
-        throw new Error("No g.xlf file was found");
-    } else {
-        let alObjects = await WorkspaceFunctions.getAlObjectsFromCurrentWorkspace();
-        alObjects.forEach(alObject => {
-            updateGXlf(gXlfDoc, alObject.getTransUnits());
-        });
-        let gXlfFilePath = await WorkspaceFunctions.getGXlfFile();
-        gXlfDoc.toFileSync(gXlfFilePath.fsPath, replaceSelfClosingXlfTags, formatXml, 'utf8bom');
-    }
+    let gXlfDocument = await getGXlfDocument();
+    let alObjects = await WorkspaceFunctions.getAlObjectsFromCurrentWorkspace();
+    alObjects.forEach(alObject => {
+        updateGXlf(gXlfDocument.gXlfDoc, alObject.getTransUnits());
+    });
+    let gXlfFilePath = await WorkspaceFunctions.getGXlfFile();
+    gXlfDocument.gXlfDoc.toFileSync(gXlfFilePath.fsPath, replaceSelfClosingXlfTags, formatXml, 'utf8bom');
+
+    return gXlfDocument.fileName;
 }
 export function updateGXlf(gXlfDoc: Xliff | null, transUnits: TransUnit[] | null) {
     if ((null === gXlfDoc) || (null === transUnits)) {

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -287,12 +287,12 @@ function showErrorAndLog(error: Error) {
 
 export async function matchTranslations() {
     console.log('Running: MatchTranslations');
-    let replaceSelfClosingXlfTags =  Settings.getConfigSettings()[Setting.ReplaceSelfClosingXlfTags];
+    let replaceSelfClosingXlfTags = Settings.getConfigSettings()[Setting.ReplaceSelfClosingXlfTags];
     let formatXml = true;
     try {
         let langXlfFiles = await WorkspaceFunctions.getLangXlfFiles();
         console.log('Matching translations for:', langXlfFiles.toString());
-        langXlfFiles.forEach( xlfUri => {
+        langXlfFiles.forEach(xlfUri => {
             let xlfDoc = Xliff.fromFileSync(xlfUri.fsPath, 'UTF8');
             let matchResult = LanguageFunctions.matchTranslations(xlfDoc);
             if (matchResult > 0) {
@@ -309,15 +309,15 @@ export async function matchTranslations() {
 
 export async function updateGXlf() {
     console.log('Running: Update g.xlf');
-    let replaceSelfClosingXlfTags =  Settings.getConfigSettings()[Setting.ReplaceSelfClosingXlfTags];
+    let replaceSelfClosingXlfTags = Settings.getConfigSettings()[Setting.ReplaceSelfClosingXlfTags];
     let formatXml = true;
     try {
-        LanguageFunctions.updateGXlfFromAlFiles(replaceSelfClosingXlfTags,formatXml);
+        let fileName = await LanguageFunctions.updateGXlfFromAlFiles(replaceSelfClosingXlfTags, formatXml);
+        vscode.window.showInformationMessage(`${fileName} has been updated`);
     } catch (error) {
         showErrorAndLog(error);
         return;
     }
-    vscode.window.showInformationMessage(`The g.xlf has been updated`);
 
     console.log('Done: Update g.xlf');
 }

--- a/extension/src/VSCodeFunctions.ts
+++ b/extension/src/VSCodeFunctions.ts
@@ -22,3 +22,6 @@ export async function findTextInFiles(textToSearchFor: string, useRegex: boolean
     }
 }
 
+export async function getFilename(fsPath: string) {
+    return await fsPath.slice(fsPath.lastIndexOf('\\') + 1);
+}

--- a/extension/src/VSCodeFunctions.ts
+++ b/extension/src/VSCodeFunctions.ts
@@ -23,5 +23,5 @@ export async function findTextInFiles(textToSearchFor: string, useRegex: boolean
 }
 
 export async function getFilename(fsPath: string) {
-    return await fsPath.slice(fsPath.lastIndexOf('\\') + 1);
+    return await fsPath.slice(fsPath.lastIndexOf("\\") + 1);
 }

--- a/extension/src/XLIFFDocument.ts
+++ b/extension/src/XLIFFDocument.ts
@@ -7,6 +7,7 @@ import * as xmldom from 'xmldom';
 import { XliffDocumentInterface, TransUnitInterface, TargetInterface, NoteInterface } from './XLIFFInterface';
 import { XmlFormattingOptionsFactory, ClassicXmlFormatter } from './XmlFormatter';
 import { isNullOrUndefined } from 'util';
+import * as Common from './Common';
 
 export class Xliff implements XliffDocumentInterface {
     public datatype: string;
@@ -68,8 +69,7 @@ export class Xliff implements XliffDocumentInterface {
         // Workaround "> bug" in xmldom where a ">" in the Xml TextContent won't be written as "&gt;" as it should be, 
         // ref https://github.com/jwikman/nab-al-tools/issues/43 and https://github.com/xmldom/xmldom/issues/22
         var find = '(<(target|source|note from="Xliff Generator" annotates="general" priority="3"|note from="Developer" annotates="general" priority="2")>.*)>(.*<\/(target|source|note)>)';
-        var re = new RegExp(find, 'g');
-        xml = xml.replace(re, '$1&gt;$3');
+        xml = Common.replaceAll(xml,find,'$1&gt;$3');
         return xml;
     }
 

--- a/extension/src/XLIFFDocument.ts
+++ b/extension/src/XLIFFDocument.ts
@@ -54,32 +54,38 @@ export class Xliff implements XliffDocumentInterface {
 
     public toString(replaceSelfClosingTags: boolean = true, formatXml: boolean = true): string {
         let xml = new xmldom.XMLSerializer().serializeToString(this.toDocument());
+        xml = Xliff.fixGreaterThanChars(xml);
         if (replaceSelfClosingTags) {
-            xml = this.replaceSelfClosingTags(xml);
+            xml = Xliff.replaceSelfClosingTags(xml);
         }
         if (formatXml) {
-            xml = this.formatXml(xml);
+            xml = Xliff.formatXml(xml, this.lineEnding);
         }
-        xml = this.fixGreaterThanChars(xml);
 
         return xml;
     }
 
-    private fixGreaterThanChars(xml: string) {
+    static fixGreaterThanChars(xml: string) {
         // Workaround "> bug" in xmldom where a ">" in the Xml TextContent won't be written as "&gt;" as it should be, 
         // ref https://github.com/jwikman/nab-al-tools/issues/43 and https://github.com/xmldom/xmldom/issues/22
-        var find = '(<(target|source|note from="Xliff Generator" annotates="general" priority="3"|note from="Developer" annotates="general" priority="2")>.*)>(.*<\/(target|source|note)>)';
-        xml = Common.replaceAll(xml,find,'$1&gt;$3');
+        const find = /(<(target|source|note from="Xliff Generator" annotates="general" priority="3"|note from="Developer" annotates="general" priority="2")>)([^<>]*)>/mi;
+        let replaceString = '$1$3&gt;';
+        let lastXml = xml;
+        do {
+            // Replacing one > in a TextContent for each loop, loops if multiple > in any TextContent
+            lastXml = xml;
+            xml = Common.replaceAll(xml, find, replaceString);
+        } while (xml !== lastXml);
         return xml;
     }
 
-    private formatXml(xml: string): string {
+    static formatXml(xml: string, newLine: string = '\n'): string {
         let xmlFormatter = new ClassicXmlFormatter();
-        let formattingOptions = XmlFormattingOptionsFactory.getALXliffXmlFormattingOptions(this.lineEnding);
+        let formattingOptions = XmlFormattingOptionsFactory.getALXliffXmlFormattingOptions(newLine);
         return xmlFormatter.formatXml(xml, formattingOptions);
     }
 
-    private replaceSelfClosingTags(xml: string): string {
+    static replaceSelfClosingTags(xml: string): string {
         // ref https://stackoverflow.com/a/16792194/5717285
         var split = xml.split("/>");
         var newXml = "";

--- a/extension/src/XLIFFDocument.ts
+++ b/extension/src/XLIFFDocument.ts
@@ -68,8 +68,8 @@ export class Xliff implements XliffDocumentInterface {
     static fixGreaterThanChars(xml: string) {
         // Workaround "> bug" in xmldom where a ">" in the Xml TextContent won't be written as "&gt;" as it should be, 
         // ref https://github.com/jwikman/nab-al-tools/issues/43 and https://github.com/xmldom/xmldom/issues/22
-        const find = /(<(target|source|note from="Xliff Generator" annotates="general" priority="3"|note from="Developer" annotates="general" priority="2")>)([^<>]*)>/mi;
-        let replaceString = '$1$3&gt;';
+        const find = />([^<>]*)>/mi;
+        let replaceString = '>$1&gt;';
         let lastXml = xml;
         do {
             // Replacing one > in a TextContent for each loop, loops if multiple > in any TextContent

--- a/extension/src/XmlFormatter.ts
+++ b/extension/src/XmlFormatter.ts
@@ -117,7 +117,7 @@ export class ClassicXmlFormatter implements XmlFormatter {
     minifyXml(xml: string, options: XmlFormattingOptions): string {
         xml = this._stripLineBreaks(options, xml); // all line breaks outside of CDATA elements
         xml = (options.removeCommentsOnMinify) ? xml.replace(/\<![ \r\n\t]*(--([^\-]|[\r\n]|-[^\-])*--[ \r\n\t]*)\>/g, "") : xml;
-        xml = !(options.keepInsignificantWhitespaceOnMinify) ? xml.replace(/>\s{0,}</g, "><") : xml; // insignificant whitespace between tags - code removed since we need to keep 
+        xml = !(options.keepInsignificantWhitespaceOnMinify) ? xml.replace(/>\s{0,}</g, "><") : xml; // insignificant whitespace between tags
         xml = xml.replace(/"\s+(?=[^\s]+=)/g, "\" "); // spaces between attributes
         xml = xml.replace(/"\s+(?=>)/g, "\""); // spaces between the last attribute and tag close (>)
         xml = xml.replace(/"\s+(?=\/>)/g, "\" "); // spaces between the last attribute and tag close (/>)

--- a/extension/src/XmlFormatter.ts
+++ b/extension/src/XmlFormatter.ts
@@ -12,6 +12,7 @@ export interface XmlFormattingOptions {
     initialIndentLevel?: number;
     tabSize: number;
     preferSpaces: boolean;
+    keepInsignificantWhitespaceOnMinify: boolean;
 }
 export interface XmlFormatter {
     formatXml(xml: string, options: XmlFormattingOptions): string;
@@ -28,11 +29,12 @@ export class XmlFormattingOptionsFactory {
             splitXmlnsOnFormat: false,
             initialIndentLevel: 0,
             tabSize: 4,
-            preferSpaces: true
+            preferSpaces: true,
+            keepInsignificantWhitespaceOnMinify: false
         };
     }
 
-    static getALXliffXmlFormattingOptions(newLine:string = '\n'): XmlFormattingOptions {
+    static getALXliffXmlFormattingOptions(newLine: string = '\n'): XmlFormattingOptions {
         return {
             enforcePrettySelfClosingTagOnFormat: true,
             newLine: newLine,
@@ -41,7 +43,8 @@ export class XmlFormattingOptionsFactory {
             splitXmlnsOnFormat: false,
             initialIndentLevel: 0,
             tabSize: 2,
-            preferSpaces: true
+            preferSpaces: true,
+            keepInsignificantWhitespaceOnMinify: true
         };
     }
 }
@@ -114,7 +117,7 @@ export class ClassicXmlFormatter implements XmlFormatter {
     minifyXml(xml: string, options: XmlFormattingOptions): string {
         xml = this._stripLineBreaks(options, xml); // all line breaks outside of CDATA elements
         xml = (options.removeCommentsOnMinify) ? xml.replace(/\<![ \r\n\t]*(--([^\-]|[\r\n]|-[^\-])*--[ \r\n\t]*)\>/g, "") : xml;
-        xml = xml.replace(/>\s{0,}</g, "><"); // insignificant whitespace between tags
+        xml = !(options.keepInsignificantWhitespaceOnMinify) ? xml.replace(/>\s{0,}</g, "><") : xml; // insignificant whitespace between tags - code removed since we need to keep 
         xml = xml.replace(/"\s+(?=[^\s]+=)/g, "\" "); // spaces between attributes
         xml = xml.replace(/"\s+(?=>)/g, "\""); // spaces between the last attribute and tag close (>)
         xml = xml.replace(/"\s+(?=\/>)/g, "\" "); // spaces between the last attribute and tag close (/>)

--- a/extension/src/test/ALObjectTestLibrary.ts
+++ b/extension/src/test/ALObjectTestLibrary.ts
@@ -508,6 +508,23 @@ export function getCodeunitWithApostrophes(): string {
     
     }`;
 }
+export function getCodeunitWithHtmlTags(): string {
+    return `codeunit 50000 "NAB Test Codeunit"
+    {
+        var
+          MyLabel: Label '%1%1%1<hr/> <!-- Swedish above, English below -->%1%1%1';
+    
+    }`;
+}
+
+export function getCodeunitWithHtmlTagsLocked(): string {
+    return `codeunit 50000 "NAB Test Codeunit"
+    {
+        var
+          MyLabel: Label '%1%1%1<hr/> <!-- Swedish above, English below -->%1%1%1', Locked = true;
+    
+    }`;
+}
 
 export function getEnum(): string {
     return `enum 50000 "NAB TestEnum"

--- a/extension/src/test/ALObjectTestLibrary.ts
+++ b/extension/src/test/ALObjectTestLibrary.ts
@@ -288,6 +288,57 @@ export function getRoleCenterPage(): string {
 `;
 }
 
+
+
+export function getPageWithGroupsAndRepeater(): string {
+    return `page 50000 "Page with repeater"
+    {
+        Caption = 'Page with repeater';
+        ApplicationArea = All;
+        UsageCategory = Administration;
+        Editable = false;
+        PageType = NavigatePage;
+        ShowFilter = false;
+        SourceTable = "MyTable";
+        SourceTableTemporary = true;
+        SourceTableView = sorting("Sorting");
+    
+        layout
+        {
+            area(content)
+            {
+                group(InstructionNonStripeGrp)
+                {
+                    InstructionalText = 'This is an instruction';
+                    ShowCaption = false;
+                }
+                group(Instruction1Grp)
+                {
+                    InstructionalText = 'This is another instruction';
+                    ShowCaption = false;
+                }
+                repeater(Group)
+                {
+                    Caption = 'My repeater';
+                    field(Description; Description)
+                    {
+                        ApplicationArea = All;
+                        ToolTip = 'Specifies the description.';
+                    }
+                }
+    
+                group(EvaluationGroup)
+                {
+                    InstructionalText = 'Another instruction...';
+                    ShowCaption = false;
+                }
+            }
+        }
+    }
+    `;
+}
+
+
 export function getPage(): string {
     return `page 50100 MyPage
 {

--- a/extension/src/test/ALObjectTestLibrary.ts
+++ b/extension/src/test/ALObjectTestLibrary.ts
@@ -449,6 +449,15 @@ export function getCodeunit(): string {
     
     }`;
 }
+export function getCodeunitWithApostrophes(): string {
+    return `codeunit 50000 "NAB Test Codeunit"
+    {
+        var
+          CantBeTheSameAsErr: Label '''%1'' can''t be the same as ''%2''', Comment = '%1 = Field Caption 1, %2 = Field Caption 2';
+    
+    }`;
+}
+
 export function getEnum(): string {
     return `enum 50000 "NAB TestEnum"
     {

--- a/extension/src/test/ALObjectTestLibrary.ts
+++ b/extension/src/test/ALObjectTestLibrary.ts
@@ -668,6 +668,37 @@ export function getTableExt(): string {
     }`;
 }
 
+export function getPageWithEmptyString(): string {
+    return `page 50100 MyPage
+{
+    PageType = List;
+    ApplicationArea = All;
+    UsageCategory = Lists;
+    SourceTable = MyTable;
+
+    layout
+    {
+        area(Content)
+        {
+            group(GroupName)
+            {
+                Caption = ' ';
+                InstructionalText = ' ';
+                field(Name; MyField)
+                {
+
+                    ApplicationArea = All;
+
+                    Caption = ' ';
+                    ToolTip = ' ';
+
+                }
+            }
+        }
+    }
+}`;
+}
+
 export function getXlfMultipleNABTokens(): string {
     return `<?xml version="1.0" encoding="utf-8"?>
      <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">

--- a/extension/src/test/ALObjectTestLibrary.ts
+++ b/extension/src/test/ALObjectTestLibrary.ts
@@ -508,6 +508,18 @@ export function getCodeunitWithApostrophes(): string {
     
     }`;
 }
+export function getCodeunitWithFunctionsWithParenthesisParam(): string {
+    return `codeunit 50000 "NAB Test Codeunit"
+    {
+        procedure TheProcedure(Parameter: Record "Table (Tbl)"; var pvRecRef: RecordRef)
+        var
+            MyLabel: Label 'The text';
+        begin
+        end;
+    
+    }`;
+}
+
 export function getCodeunitWithHtmlTags(): string {
     return `codeunit 50000 "NAB Test Codeunit"
     {
@@ -661,14 +673,14 @@ export function getReport(): string {
             {
                 area(Content)
                 {
-                    group("GroupName")
+                    group(GroupName)
                     {
                         Caption = 'Grp';
                         InstructionalText = 'Instructions';
-                        field("Fld"; "asdf")
+                        field(Fld; "asdf")
                         {
                             Caption = 'Fld';
-                            OptionCaption = '1234,34';
+                            OptionCaption = '1234,34,43';
                             ToolTip = 'Tooltip';
                             trigger OnAssistEdit()
                             var
@@ -687,7 +699,7 @@ export function getReport(): string {
             {
                 area(processing)
                 {
-                    action("ActionName")
+                    action(ActionName)
                     {
                         ApplicationArea = All;
                         trigger OnAction()
@@ -699,6 +711,12 @@ export function getReport(): string {
                     }
                 }
             }
+            trigger OnQueryClosePage(CloseAction: Action): Boolean;
+            var
+                ReportCannotBeScheduledErr: Label 'This report cannot be scheduled';
+            begin
+                exit(true);
+            end;
         }
     
         procedure TestMethod()
@@ -743,6 +761,59 @@ export function getTableExt(): string {
         var
             TableExtLabel: Label 'TableExt Label';
     }`;
+}
+export function getXmlPort(): string {
+    return `xmlport 50000 "NAB Test XmlPort"
+    {
+        Caption = 'The Caption';
+    
+        schema
+        {
+            textelement(changedrecords)
+            {
+                XmlName = 'ChangedRecords';
+                tableelement(changelog; "NAB Test Table")
+                {
+                    MinOccurs = Zero;
+                    XmlName = 'ChangedRecord';
+                    textattribute(TypeOfChange)
+                    {
+    
+                        trigger OnBeforePassVariable()
+                        var
+                            ChangeLogTypeNotSupportedErr: Label 'ChangeLog.Type %1 not supported', Comment = '%1 = Type (Inserted, Modified, Deleted)';
+                        begin
+                        end;
+                    }
+                    tableelement(tfieldvalue; "NAB Test Table")
+                    {
+                        XmlName = 'PrimaryKeyField';
+                        UseTemporary = true;
+                        fieldattribute(No; tFieldValue."My <> & Field")
+                        {
+                        }
+                        fieldattribute(Name; tFieldValue.MyField)
+                        {
+                            trigger OnBeforePassField()
+                            var
+                                ChangeLogTypeNotSupportedErr: Label 'ChangeLog.Type %1 not supported', Comment = '%1 = Type (Inserted, Modified, Deleted)';
+                            begin
+                            end;
+                        }
+                        textattribute(TypeOfChange2)
+                        {
+                            trigger OnBeforePassVariable()
+                            var
+                                ChangeLogTypeNotSupportedErr: Label 'ChangeLog.Type %1 not supported', Comment = '%1 = Type (Inserted, Modified, Deleted)';
+                            begin
+                            end;
+                        }
+                    }
+                }
+            }
+        }
+    }    
+    `;
 }
 
 export function getPageWithEmptyString(): string {

--- a/extension/src/test/AlFunctions.test.ts
+++ b/extension/src/test/AlFunctions.test.ts
@@ -283,7 +283,7 @@ suite("AL Functions Tests", function () {
 
     // test("CodeGenerator", function () {
     //     //let alObj: ALObject.ALObject = new ALObject.ALObject(ALObjectTestLibrary.GetTable(), true);
-    //     let alObj: ALObject.ALObject = new ALObject.ALObject(ALObjectTestLibrary.getPageWithGroupsAndRepeater(), true);
+    //     let alObj: ALObject.ALObject = new ALObject.ALObject(ALObjectTestLibrary.getCodeunitWithHtmlTags(), true);
     //     let linesWithTranslation = alObj.codeLines.filter(line => line.isML);
     //     for (let index = 0; index < linesWithTranslation.length; index++) {
     //         const line = linesWithTranslation[index];

--- a/extension/src/test/AlFunctions.test.ts
+++ b/extension/src/test/AlFunctions.test.ts
@@ -61,6 +61,26 @@ suite("AL Functions Tests", function () {
     });
 
 
+    test("AL Page with groups and repeater Xliff", function () {
+        let alObj: ALObject.ALObject = new ALObject.ALObject(ALObjectTestLibrary.getPageWithGroupsAndRepeater(), true);
+        let linesWithTranslation = alObj.codeLines.filter(line => line.isML);
+        let i: { i: number } = { i: 0 };
+
+        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Page 2975601355 - Property 2879900210', 'Page Page with repeater - Property Caption');
+        assert.equal(linesWithTranslation[i.i - 1].transUnit?.toString(), '<trans-unit id="Page 2975601355 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve"><source>Page with repeater</source><note from="Developer" annotates="general" priority="2"/><note from="Xliff Generator" annotates="general" priority="3">Page Page with repeater - Property Caption</note></trans-unit>', 'Page Page with repeater - Property Caption');
+        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Page 2975601355 - Control 459968125 - Property 1968111052', 'Page Page with repeater - Control InstructionNonStripeGrp - Property InstructionalText');
+        assert.equal(linesWithTranslation[i.i - 1].transUnit?.toString(), '<trans-unit id="Page 2975601355 - Control 459968125 - Property 1968111052" size-unit="char" translate="yes" xml:space="preserve"><source>This is an instruction</source><note from="Developer" annotates="general" priority="2"/><note from="Xliff Generator" annotates="general" priority="3">Page Page with repeater - Control InstructionNonStripeGrp - Property InstructionalText</note></trans-unit>', 'Page Page with repeater - Control InstructionNonStripeGrp - Property InstructionalText');
+        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Page 2975601355 - Control 4083082504 - Property 1968111052', 'Page Page with repeater - Control Instruction1Grp - Property InstructionalText');
+        assert.equal(linesWithTranslation[i.i - 1].transUnit?.toString(), '<trans-unit id="Page 2975601355 - Control 4083082504 - Property 1968111052" size-unit="char" translate="yes" xml:space="preserve"><source>This is another instruction</source><note from="Developer" annotates="general" priority="2"/><note from="Xliff Generator" annotates="general" priority="3">Page Page with repeater - Control Instruction1Grp - Property InstructionalText</note></trans-unit>', 'Page Page with repeater - Control Instruction1Grp - Property InstructionalText');
+        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Page 2975601355 - Control 739346273 - Property 2879900210', 'Page Page with repeater - Control Group - Property Caption');
+        assert.equal(linesWithTranslation[i.i - 1].transUnit?.toString(), '<trans-unit id="Page 2975601355 - Control 739346273 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve"><source>My repeater</source><note from="Developer" annotates="general" priority="2"/><note from="Xliff Generator" annotates="general" priority="3">Page Page with repeater - Control Group - Property Caption</note></trans-unit>', 'Page Page with repeater - Control Group - Property Caption');
+        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Page 2975601355 - Control 3461834954 - Property 1295455071', 'Page Page with repeater - Control Description - Property ToolTip');
+        assert.equal(linesWithTranslation[i.i - 1].transUnit?.toString(), '<trans-unit id="Page 2975601355 - Control 3461834954 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve"><source>Specifies the description.</source><note from="Developer" annotates="general" priority="2"/><note from="Xliff Generator" annotates="general" priority="3">Page Page with repeater - Control Description - Property ToolTip</note></trans-unit>', 'Page Page with repeater - Control Description - Property ToolTip');
+        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Page 2975601355 - Control 2491558131 - Property 1968111052', 'Page Page with repeater - Control EvaluationGroup - Property InstructionalText');
+        assert.equal(linesWithTranslation[i.i - 1].transUnit?.toString(), '<trans-unit id="Page 2975601355 - Control 2491558131 - Property 1968111052" size-unit="char" translate="yes" xml:space="preserve"><source>Another instruction...</source><note from="Developer" annotates="general" priority="2"/><note from="Xliff Generator" annotates="general" priority="3">Page Page with repeater - Control EvaluationGroup - Property InstructionalText</note></trans-unit>', 'Page Page with repeater - Control EvaluationGroup - Property InstructionalText');
+    });
+
+
     test("AL Table Xliff", function () {
         let alObj: ALObject.ALObject = new ALObject.ALObject(ALObjectTestLibrary.getTable(), true);
         let linesWithTranslation = alObj.codeLines.filter(line => line._xliffIdWithNames);
@@ -113,16 +133,16 @@ suite("AL Functions Tests", function () {
         let alObj: ALObject.ALObject = new ALObject.ALObject(ALObjectTestLibrary.getCueGroupPage(), true);
         let linesWithTranslation = alObj.codeLines.filter(line => line._xliffIdWithNames);
         let i: { i: number } = { i: 0 };
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Page 1018816708','Page My Cue Part');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Page 1018816708 - Property 2879900210','Page My Cue Part - Property Caption');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Page 1018816708','Page My Cue Part');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Page 1018816708 - Control 1494066971','Page My Cue Part - Control Time Sheet Manager');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Page 1018816708 - Control 1494066971 - Property 2879900210','Page My Cue Part - Control Time Sheet Manager - Property Caption');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Page 1018816708 - Control 3616567109','Page My Cue Part - Control Field1');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Page 1018816708 - Control 3616567109 - Property 1295455071','Page My Cue Part - Control Field1 - Property ToolTip');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Page 1018816708 - Property 1295455071','Page My Cue Part - Property ToolTip');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Page 1018816708 - Property 2879900210','Page My Cue Part - Property Caption');
-            });
+        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Page 1018816708', 'Page My Cue Part');
+        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Page 1018816708 - Property 2879900210', 'Page My Cue Part - Property Caption');
+        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Page 1018816708', 'Page My Cue Part');
+        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Page 1018816708 - Control 1494066971', 'Page My Cue Part - Control Time Sheet Manager');
+        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Page 1018816708 - Control 1494066971 - Property 2879900210', 'Page My Cue Part - Control Time Sheet Manager - Property Caption');
+        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Page 1018816708 - Control 3616567109', 'Page My Cue Part - Control Field1');
+        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Page 1018816708 - Control 3616567109 - Property 1295455071', 'Page My Cue Part - Control Field1 - Property ToolTip');
+        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Page 1018816708 - Property 1295455071', 'Page My Cue Part - Property ToolTip');
+        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Page 1018816708 - Property 2879900210', 'Page My Cue Part - Property Caption');
+    });
 
     test("AL Page Xliff", function () {
         let alObj: ALObject.ALObject = new ALObject.ALObject(ALObjectTestLibrary.getPage(), true);
@@ -263,11 +283,12 @@ suite("AL Functions Tests", function () {
 
     // test("CodeGenerator", function () {
     //     //let alObj: ALObject.ALObject = new ALObject.ALObject(ALObjectTestLibrary.GetTable(), true);
-    //     let alObj: ALObject.ALObject = new ALObject.ALObject(ALObjectTestLibrary.GetEnum(), true);
-    //     let linesWithTranslation = alObj.codeLines.filter(line => line.XliffIdWithNames);
+    //     let alObj: ALObject.ALObject = new ALObject.ALObject(ALObjectTestLibrary.getPageWithGroupsAndRepeater(), true);
+    //     let linesWithTranslation = alObj.codeLines.filter(line => line.isML);
     //     for (let index = 0; index < linesWithTranslation.length; index++) {
     //         const line = linesWithTranslation[index];
-    //         console.log(`assert.equal(getNextLine(i, linesWithTranslation).GetXliffId(), '${line.GetXliffId()}', '${line.GetXliffIdWithNames()}');`)
+    //         console.log(`assert.equal(getNextLine(i, linesWithTranslation).xliffId(), '${line.xliffId()}', '${line.xliffIdWithNames()}');`);
+    //         console.log(`assert.equal(linesWithTranslation[i.i - 1].transUnit?.toString(), '${line.transUnit?.toString()}', '${line.xliffIdWithNames()}');`);
     //     }
     // });
 

--- a/extension/src/test/AlFunctions.test.ts
+++ b/extension/src/test/AlFunctions.test.ts
@@ -61,6 +61,15 @@ suite("AL Functions Tests", function () {
     });
 
 
+    test("AL Codeunit procedure(param with parenthesis) Xliff", function () {
+        let alObj: ALObject.ALObject = new ALObject.ALObject(ALObjectTestLibrary.getCodeunitWithFunctionsWithParenthesisParam(), true);
+        let linesWithTranslation = alObj.codeLines.filter(line => line.isML);
+        let i: { i: number } = { i: 0 };
+
+        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Codeunit 456387620 - Method 481402784 - NamedType 2350589126', 'Codeunit NAB Test Codeunit - Method TheProcedure - NamedType MyLabel');
+        assert.equal(linesWithTranslation[i.i - 1].transUnit?.toString(), '<trans-unit id="Codeunit 456387620 - Method 481402784 - NamedType 2350589126" size-unit="char" translate="yes" xml:space="preserve"><source>The text</source><note from="Developer" annotates="general" priority="2"/><note from="Xliff Generator" annotates="general" priority="3">Codeunit NAB Test Codeunit - Method TheProcedure - NamedType MyLabel</note></trans-unit>', 'Codeunit NAB Test Codeunit - Method TheProcedure - NamedType MyLabel');
+    });
+
     test("AL Page with groups and repeater Xliff", function () {
         let alObj: ALObject.ALObject = new ALObject.ALObject(ALObjectTestLibrary.getPageWithGroupsAndRepeater(), true);
         let linesWithTranslation = alObj.codeLines.filter(line => line.isML);
@@ -196,37 +205,6 @@ suite("AL Functions Tests", function () {
         assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Query 3258925707 - Method 1968185403', 'Query NAB Test Query - Method TestMethod');
         assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Query 3258925707 - Method 1968185403 - NamedType 1061650423', 'Query NAB Test Query - Method TestMethod - NamedType LocalTestLabelTxt');
         assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Query 3258925707 - NamedType 2688233357', 'Query NAB Test Query - NamedType GlobalTestLabelTxt');
-    });
-
-    test("AL Report Xliff", function () {
-        let alObj: ALObject.ALObject = new ALObject.ALObject(ALObjectTestLibrary.getReport(), true);
-        let linesWithTranslation = alObj.codeLines.filter(line => line._xliffIdWithNames);
-        let i: { i: number } = { i: 0 };
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Report 529985455', 'Report NAB Test Report');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Report 529985455 - Property 2879900210', 'Report NAB Test Report - Property Caption');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Report 529985455 - ReportDataItem 205381422', 'Report NAB Test Report - ReportDataItem DataItemName');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Report 529985455 - ReportDataItem 205381422 - Property 1806354803', 'Report NAB Test Report - ReportDataItem DataItemName - Property RequestFilterHeading');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Report 529985455 - ReportColumn 967337907', 'Report NAB Test Report - ReportColumn ColumnName');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Report 529985455 - ReportColumn 967337907 - Property 2879900210', 'Report NAB Test Report - ReportColumn ColumnName - Property Caption');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Report 529985455 - ReportColumn 967337907 - Property 62802879', 'Report NAB Test Report - ReportColumn ColumnName - Property OptionCaption');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Report 529985455', 'Report NAB Test Report');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Report 529985455 - Control 4105281732', 'Report NAB Test Report - Control GroupName');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Report 529985455 - Control 4105281732 - Property 2879900210', 'Report NAB Test Report - Control GroupName - Property Caption');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Report 529985455 - Control 4105281732 - Property 1968111052', 'Report NAB Test Report - Control GroupName - Property InstructionalText');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Report 529985455 - Control 3731481282', 'Report NAB Test Report - Control Fld');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Report 529985455 - Control 3731481282 - Property 2879900210', 'Report NAB Test Report - Control Fld - Property Caption');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Report 529985455 - Control 3731481282 - Property 62802879', 'Report NAB Test Report - Control Fld - Property OptionCaption');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Report 529985455 - Control 3731481282 - Property 1295455071', 'Report NAB Test Report - Control Fld - Property ToolTip');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Report 529985455 - Control 3731481282 - Method 2699620902', 'Report NAB Test Report - Control Fld - Method OnAssistEdit');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Report 529985455 - Control 3731481282 - Method 2699620902 - NamedType 1061650423', 'Report NAB Test Report - Control Fld - Method OnAssistEdit - NamedType LocalTestLabelTxt');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Report 529985455 - Control 3731481282 - Method 2699620902 - NamedType 725422852', 'Report NAB Test Report - Control Fld - Method OnAssistEdit - NamedType HelloWorldTxt');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Report 529985455', 'Report NAB Test Report');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Report 529985455 - Action 1692444235', 'Report NAB Test Report - Action ActionName');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Report 529985455 - Action 1692444235 - Method 1377591017', 'Report NAB Test Report - Action ActionName - Method OnAction');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Report 529985455 - Action 1692444235 - Method 1377591017 - NamedType 1061650423', 'Report NAB Test Report - Action ActionName - Method OnAction - NamedType LocalTestLabelTxt');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Report 529985455 - Method 1968185403', 'Report NAB Test Report - Method TestMethod');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Report 529985455 - Method 1968185403 - NamedType 1061650423', 'Report NAB Test Report - Method TestMethod - NamedType LocalTestLabelTxt');
-        assert.equal(getNextLine(i, linesWithTranslation).xliffId(), 'Report 529985455 - NamedType 2688233357', 'Report NAB Test Report - NamedType GlobalTestLabelTxt');
     });
 
     test("AL TableExt Xliff", function () {

--- a/extension/src/test/LanguageFunctions.test.ts
+++ b/extension/src/test/LanguageFunctions.test.ts
@@ -162,6 +162,79 @@ suite("ALObject TransUnit Tests", function () {
 
 suite("MlProperty Matching Tests", function () {
 
+    test("MatchMlPropertyCommentLocked()", function () {
+        let line = `Caption = 'The Caption Text', MaxLength = 250, Comment = 'A comment', Locked = true;`;
+        let MlProperty = ALObject.getMlProperty(line);
+        if (null !== MlProperty) {
+            assert.equal(MlProperty.text, 'The Caption Text');
+            assert.equal(MlProperty.name, 'Caption');
+            assert.equal(MlProperty.locked, true);
+            assert.equal(MlProperty.comment, 'A comment');
+            assert.equal(MlProperty.maxLength, 250);
+        } else {
+            assert.fail('MlProperty not identified');
+        }
+    });
+
+    test("MatchMlPropertyMaxLengthComment()", function () {
+        let line = `Caption = 'The Caption Text', MaxLength = 250, Comment = 'A comment';`;
+        let MlProperty = ALObject.getMlProperty(line);
+        if (null !== MlProperty) {
+            assert.equal(MlProperty.text, 'The Caption Text');
+            assert.equal(MlProperty.name, 'Caption');
+            assert.equal(MlProperty.locked, false);
+            assert.equal(MlProperty.comment, 'A comment');
+            assert.equal(MlProperty.maxLength, 250);
+        } else {
+            assert.fail('MlProperty not identified');
+        }
+    });
+
+    test("MatchMlPropertyMaxLengthLocked()", function () {
+        let line = `Caption = 'The Caption Text', maxlength = 128, locked = true;`;
+        let MlProperty = ALObject.getMlProperty(line);
+        if (null !== MlProperty) {
+            assert.equal(MlProperty.text, 'The Caption Text');
+            assert.equal(MlProperty.name, 'Caption');
+            assert.equal(MlProperty.locked, true);
+            assert.equal(MlProperty.comment, '');
+            assert.equal(MlProperty.maxLength, 128);
+        } else {
+            assert.fail('MlProperty not identified');
+        }
+    });
+
+
+    test("MatchMlPropertyCommentLockedMaxLength()", function () {
+        let line = `Caption = 'The Caption Text', Comment = 'A comment', Locked=true, MaxLength = 123;`;
+        let MlProperty = ALObject.getMlProperty(line);
+        if (null !== MlProperty) {
+            assert.equal(MlProperty.text, 'The Caption Text');
+            assert.equal(MlProperty.name, 'Caption');
+            assert.equal(MlProperty.locked, true);
+            assert.equal(MlProperty.comment, 'A comment');
+            assert.equal(MlProperty.maxLength, 123);
+        } else {
+            assert.fail('MlProperty not identified');
+        }
+    });
+
+    test("MatchMlPropertyCommentMaxLengthLocked()", function () {
+        let line = `Caption = 'The Caption Text', Comment = 'A comment', MaxLength = 123, Locked=true;`;
+        let MlProperty = ALObject.getMlProperty(line);
+        if (null !== MlProperty) {
+            assert.equal(MlProperty.text, 'The Caption Text');
+            assert.equal(MlProperty.name, 'Caption');
+            assert.equal(MlProperty.locked, true);
+            assert.equal(MlProperty.comment, 'A comment');
+            assert.equal(MlProperty.maxLength, 123);
+        } else {
+            assert.fail('MlProperty not identified');
+        }
+    });
+
+
+
     test("MatchMlPropertyEmpty()", function () {
         let line = 'Caption = \'\';';
         let MlProperty = ALObject.getMlProperty(line);
@@ -436,8 +509,50 @@ suite("Label Matching Tests", function () {
         }
     });
 
+    test("MatchLabelCommentLocked()", function () {
+        let line = `MyLabel: label 'The Label Text', MaxLength = 250, Comment = 'A comment', Locked = true;`;
+        let label = ALObject.getLabel(line);
+        if (null !== label) {
+            assert.equal(label.text, 'The Label Text');
+            assert.equal(label.name, 'MyLabel');
+            assert.equal(label.locked, true);
+            assert.equal(label.comment, 'A comment');
+            assert.equal(label.maxLength, 250);
+        } else {
+            assert.fail('Label not identified');
+        }
+    });
+
+    test("MatchLabelMaxLengthComment()", function () {
+        let line = `MyLabel: label 'The Label Text', MaxLength = 250, Comment = 'A comment';`;
+        let label = ALObject.getLabel(line);
+        if (null !== label) {
+            assert.equal(label.text, 'The Label Text');
+            assert.equal(label.name, 'MyLabel');
+            assert.equal(label.locked, false);
+            assert.equal(label.comment, 'A comment');
+            assert.equal(label.maxLength, 250);
+        } else {
+            assert.fail('Label not identified');
+        }
+    });
+
+    test("MatchLabelMaxLengthLocked()", function () {
+        let line = `MyLabel: label 'The Label Text', maxlength = 128, locked = true;`;
+        let label = ALObject.getLabel(line);
+        if (null !== label) {
+            assert.equal(label.text, 'The Label Text');
+            assert.equal(label.name, 'MyLabel');
+            assert.equal(label.locked, true);
+            assert.equal(label.comment, '');
+            assert.equal(label.maxLength, 128);
+        } else {
+            assert.fail('Label not identified');
+        }
+    });
+
     test("MatchLabelCommentMaxLength()", function () {
-        let line = 'MyLabel: label \'The Label Text\',Comment = \'A comment\', MaxLength = 123;';
+        let line = `MyLabel: label 'The Label Text',Comment = 'A comment', MaxLength = 123;`;
         let label = ALObject.getLabel(line);
         if (null !== label) {
             assert.equal(label.text, 'The Label Text');
@@ -449,6 +564,35 @@ suite("Label Matching Tests", function () {
             assert.fail('Label not identified');
         }
     });
+    test("MatchLabelCommentLockedMaxLength()", function () {
+        let line = 'MyLabel: label \'The Label Text\', Comment = \'A comment\', Locked=true, MaxLength = 123;';
+        let label = ALObject.getLabel(line);
+        if (null !== label) {
+            assert.equal(label.text, 'The Label Text');
+            assert.equal(label.name, 'MyLabel');
+            assert.equal(label.locked, true);
+            assert.equal(label.comment, 'A comment');
+            assert.equal(label.maxLength, 123);
+        } else {
+            assert.fail('Label not identified');
+        }
+    });
+
+    test("MatchLabelCommentMaxLengthLocked()", function () {
+        let line = 'MyLabel: label \'The Label Text\', Comment = \'A comment\', MaxLength = 123, Locked=true;';
+        let label = ALObject.getLabel(line);
+        if (null !== label) {
+            assert.equal(label.text, 'The Label Text');
+            assert.equal(label.name, 'MyLabel');
+            assert.equal(label.locked, true);
+            assert.equal(label.comment, 'A comment');
+            assert.equal(label.maxLength, 123);
+        } else {
+            assert.fail('Label not identified');
+        }
+    });
+
+
 
     test("MatchLabelLockedCommentMaxLength()", function () {
         let line = 'MyLabel: label \'The Label Text\', Locked=true, Comment = \'A comment\', MaxLength = 123;';

--- a/extension/src/test/LanguageFunctions.test.ts
+++ b/extension/src/test/LanguageFunctions.test.ts
@@ -31,6 +31,47 @@ testFiles.forEach(f => {
 
 
 suite("ALObject TransUnit Tests", function () {
+    
+    test("g.Xlf update with empty string", function () {
+        let gXlfDoc = Xliff.fromString(ALObjectTestLibrary.getEmptyGXlf());
+        let alObj: ALObject = new ALObject(ALObjectTestLibrary.getPageWithEmptyString(), true);
+        let transUnits = alObj.getTransUnits();
+        if (null !== transUnits) {
+            LanguageFunctions.updateGXlf(gXlfDoc, transUnits);
+            assert.equal(gXlfDoc.toString(true,true),`<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en-US" target-language="en-US" original="AlTestApp">
+    <body>
+      <group id="body">
+        <trans-unit id="Page 2931038265 - Control 4105281732 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source> </source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page MyPage - Control GroupName - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="Page 2931038265 - Control 4105281732 - Property 1968111052" size-unit="char" translate="yes" xml:space="preserve">
+          <source> </source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page MyPage - Control GroupName - Property InstructionalText</note>
+        </trans-unit>
+        <trans-unit id="Page 2931038265 - Control 2961552353 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source> </source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page MyPage - Control Name - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="Page 2931038265 - Control 2961552353 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
+          <source> </source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page MyPage - Control Name - Property ToolTip</note>
+        </trans-unit>
+      </group>
+    </body>
+  </file>
+</xliff>`);
+        } else {
+            assert.fail('No transunits identified');
+        }
+    });
+    
     test("g.Xlf update", function () {
         let gXlfDoc = Xliff.fromString(ALObjectTestLibrary.getEmptyGXlf());
         let alObj: ALObject = new ALObject(ALObjectTestLibrary.getTable(), true);

--- a/extension/src/test/LanguageFunctions.test.ts
+++ b/extension/src/test/LanguageFunctions.test.ts
@@ -7,7 +7,7 @@ import * as xmldom from 'xmldom';
 
 import * as ALObjectTestLibrary from './ALObjectTestLibrary';
 import * as LanguageFunctions from '../LanguageFunctions';
-import { Xliff } from '../XLIFFDocument';
+import { SizeUnit, TransUnit, Xliff } from '../XLIFFDocument';
 import { ALObject } from '../ALObject';
 
 const xmlns = 'urn:oasis:names:tc:xliff:document:1.2';
@@ -31,7 +31,26 @@ testFiles.forEach(f => {
 
 
 suite("ALObject TransUnit Tests", function () {
+
+
+    test("Labels with apostrophes", function () {
+        let alObj: ALObject = new ALObject(ALObjectTestLibrary.getCodeunitWithApostrophes(), true);
+        let transUnits = alObj.getTransUnits();
+        if (null !== transUnits) {
+            assert.equal(transUnits.length,1,'Unexpected number of trans-units');
+            assert.equal(transUnits[0].toString(),`<trans-unit id="Codeunit 456387620 - NamedType 613788221" size-unit="char" translate="yes" xml:space="preserve"><source>'%1' can't be the same as '%2'</source><note from="Developer" annotates="general" priority="2">%1 = Field Caption 1, %2 = Field Caption 2</note><note from="Xliff Generator" annotates="general" priority="3">Codeunit NAB Test Codeunit - NamedType CantBeTheSameAsErr</note></trans-unit>`);
+        } else {
+            assert.fail('No trans-units identified');
+        }
+    });
     
+
+    test("trans-unit with apostrophes", function () {
+        let tu = new TransUnit('Table 2541146604 - NamedType 613788221',true,`'%1' can't be the same as '%2'`,undefined,SizeUnit.char,'preserve');
+        assert.equal(tu.toString(),`<trans-unit id="Table 2541146604 - NamedType 613788221" size-unit="char" translate="yes" xml:space="preserve"><source>'%1' can't be the same as '%2'</source></trans-unit>`);
+    });
+    
+
     test("g.Xlf update with empty string", function () {
         let gXlfDoc = Xliff.fromString(ALObjectTestLibrary.getEmptyGXlf());
         let alObj: ALObject = new ALObject(ALObjectTestLibrary.getPageWithEmptyString(), true);
@@ -190,10 +209,10 @@ suite("MlProperty Matching Tests", function () {
         let line = 'Caption = \'The Caption\'\'s text\',Comment = \'A comment\'\'s text\', MaxLength = 123;';
         let MlProperty = ALObject.getMlProperty(line);
         if (null !== MlProperty) {
-            assert.equal(MlProperty.text, 'The Caption\'\'s text');
+            assert.equal(MlProperty.text, `The Caption's text`);
             assert.equal(MlProperty.name, 'Caption');
             assert.equal(MlProperty.locked, false);
-            assert.equal(MlProperty.comment, 'A comment\'\'s text');
+            assert.equal(MlProperty.comment, `A comment's text`);
             assert.equal(MlProperty.maxLength, 123);
         } else {
             assert.fail('MlProperty not identified');
@@ -204,7 +223,7 @@ suite("MlProperty Matching Tests", function () {
         let line = 'Caption = \'The Caption\'\'s text\',Comment = \'A comment\', MaxLength = 123;';
         let MlProperty = ALObject.getMlProperty(line);
         if (null !== MlProperty) {
-            assert.equal(MlProperty.text, 'The Caption\'\'s text');
+            assert.equal(MlProperty.text, `The Caption's text`);
             assert.equal(MlProperty.name, 'Caption');
             assert.equal(MlProperty.locked, false);
             assert.equal(MlProperty.comment, 'A comment');
@@ -378,7 +397,7 @@ suite("Label Matching Tests", function () {
         let line = `MyLabel: Label '''%1'' can''t be the same as ''%2''',Comment = 'A comment', MaxLength = 123;`;
         let label = ALObject.getLabel(line);
         if (null !== label) {
-            assert.equal(label.text, `''%1'' can''t be the same as ''%2''`);
+            assert.equal(label.text, `'%1' can't be the same as '%2'`);
             assert.equal(label.name, 'MyLabel');
             assert.equal(label.locked, false);
             assert.equal(label.comment, 'A comment');
@@ -393,7 +412,7 @@ suite("Label Matching Tests", function () {
         let line = 'MyLabel: label \'The Label\'\'s text\',Comment = \'A comment\', MaxLength = 123;';
         let label = ALObject.getLabel(line);
         if (null !== label) {
-            assert.equal(label.text, 'The Label\'\'s text');
+            assert.equal(label.text, `The Label's text`);
             assert.equal(label.name, 'MyLabel');
             assert.equal(label.locked, false);
             assert.equal(label.comment, 'A comment');
@@ -407,10 +426,10 @@ suite("Label Matching Tests", function () {
         let line = 'MyLabel: label \'The Label\'\'s text\',Comment = \'A comment\'\'s text\', MaxLength = 123;';
         let label = ALObject.getLabel(line);
         if (null !== label) {
-            assert.equal(label.text, 'The Label\'\'s text');
+            assert.equal(label.text, `The Label's text`);
             assert.equal(label.name, 'MyLabel');
             assert.equal(label.locked, false);
-            assert.equal(label.comment, 'A comment\'\'s text');
+            assert.equal(label.comment, `A comment's text`);
             assert.equal(label.maxLength, 123);
         } else {
             assert.fail('Label not identified');

--- a/extension/src/test/LanguageFunctions.test.ts
+++ b/extension/src/test/LanguageFunctions.test.ts
@@ -32,24 +32,56 @@ testFiles.forEach(f => {
 
 suite("ALObject TransUnit Tests", function () {
 
+    test("replaceSelfClosingTags(xml) with html tags", function () {
+        let xml = `<?xml version="1.0" encoding="utf-8"?><xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"><file datatype="xml" source-language="en-US" target-language="en-US" original="AlTestApp"><body><group id="body"><trans-unit id="Codeunit 456387620 - NamedType 2350589126" size-unit="char" translate="yes" xml:space="preserve"><source>%1%1%1&lt;hr/&gt; &lt;!-- Swedish above, English below --&gt;%1%1%1</source><note from="Developer" annotates="general" priority="2"></note><note from="Xliff Generator" annotates="general" priority="3">Codeunit NAB Test Codeunit - NamedType MyLabel</note></trans-unit></group></body></file></xliff>`;
+
+        let formattedXml = Xliff.replaceSelfClosingTags(xml);
+        assert.equal(formattedXml,xml);
+
+    });
+
+    test("g.Xlf update with html tags", function () {
+        let gXlfDoc = Xliff.fromString(ALObjectTestLibrary.getEmptyGXlf());
+        let alObj: ALObject = new ALObject(ALObjectTestLibrary.getCodeunitWithHtmlTags(), true);
+        let transUnits = alObj.getTransUnits();
+        if (null !== transUnits) {
+            LanguageFunctions.updateGXlf(gXlfDoc, transUnits);
+            assert.equal(gXlfDoc.toString(true, true), `<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en-US" target-language="en-US" original="AlTestApp">
+    <body>
+      <group id="body">
+        <trans-unit id="Codeunit 456387620 - NamedType 2350589126" size-unit="char" translate="yes" xml:space="preserve">
+          <source>%1%1%1&lt;hr/&gt; &lt;!-- Swedish above, English below --&gt;%1%1%1</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Codeunit NAB Test Codeunit - NamedType MyLabel</note>
+        </trans-unit>
+      </group>
+    </body>
+  </file>
+</xliff>`);
+        } else {
+            assert.fail('No transunits identified');
+        }
+    });
 
     test("Labels with apostrophes", function () {
         let alObj: ALObject = new ALObject(ALObjectTestLibrary.getCodeunitWithApostrophes(), true);
         let transUnits = alObj.getTransUnits();
         if (null !== transUnits) {
-            assert.equal(transUnits.length,1,'Unexpected number of trans-units');
-            assert.equal(transUnits[0].toString(),`<trans-unit id="Codeunit 456387620 - NamedType 613788221" size-unit="char" translate="yes" xml:space="preserve"><source>'%1' can't be the same as '%2'</source><note from="Developer" annotates="general" priority="2">%1 = Field Caption 1, %2 = Field Caption 2</note><note from="Xliff Generator" annotates="general" priority="3">Codeunit NAB Test Codeunit - NamedType CantBeTheSameAsErr</note></trans-unit>`);
+            assert.equal(transUnits.length, 1, 'Unexpected number of trans-units');
+            assert.equal(transUnits[0].toString(), `<trans-unit id="Codeunit 456387620 - NamedType 613788221" size-unit="char" translate="yes" xml:space="preserve"><source>'%1' can't be the same as '%2'</source><note from="Developer" annotates="general" priority="2">%1 = Field Caption 1, %2 = Field Caption 2</note><note from="Xliff Generator" annotates="general" priority="3">Codeunit NAB Test Codeunit - NamedType CantBeTheSameAsErr</note></trans-unit>`);
         } else {
             assert.fail('No trans-units identified');
         }
     });
-    
+
 
     test("trans-unit with apostrophes", function () {
-        let tu = new TransUnit('Table 2541146604 - NamedType 613788221',true,`'%1' can't be the same as '%2'`,undefined,SizeUnit.char,'preserve');
-        assert.equal(tu.toString(),`<trans-unit id="Table 2541146604 - NamedType 613788221" size-unit="char" translate="yes" xml:space="preserve"><source>'%1' can't be the same as '%2'</source></trans-unit>`);
+        let tu = new TransUnit('Table 2541146604 - NamedType 613788221', true, `'%1' can't be the same as '%2'`, undefined, SizeUnit.char, 'preserve');
+        assert.equal(tu.toString(), `<trans-unit id="Table 2541146604 - NamedType 613788221" size-unit="char" translate="yes" xml:space="preserve"><source>'%1' can't be the same as '%2'</source></trans-unit>`);
     });
-    
+
 
     test("g.Xlf update with empty string", function () {
         let gXlfDoc = Xliff.fromString(ALObjectTestLibrary.getEmptyGXlf());
@@ -57,7 +89,7 @@ suite("ALObject TransUnit Tests", function () {
         let transUnits = alObj.getTransUnits();
         if (null !== transUnits) {
             LanguageFunctions.updateGXlf(gXlfDoc, transUnits);
-            assert.equal(gXlfDoc.toString(true,true),`<?xml version="1.0" encoding="utf-8"?>
+            assert.equal(gXlfDoc.toString(true, true), `<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="en-US" original="AlTestApp">
     <body>
@@ -90,14 +122,14 @@ suite("ALObject TransUnit Tests", function () {
             assert.fail('No transunits identified');
         }
     });
-    
+
     test("g.Xlf update", function () {
         let gXlfDoc = Xliff.fromString(ALObjectTestLibrary.getEmptyGXlf());
         let alObj: ALObject = new ALObject(ALObjectTestLibrary.getTable(), true);
         let transUnits = alObj.getTransUnits();
         if (null !== transUnits) {
             LanguageFunctions.updateGXlf(gXlfDoc, transUnits);
-            assert.equal(gXlfDoc.toString(true,true),`<?xml version="1.0" encoding="utf-8"?>
+            assert.equal(gXlfDoc.toString(true, true), `<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="en-US" original="AlTestApp">
     <body>
@@ -423,6 +455,20 @@ suite("MlProperty Matching Tests", function () {
 
 suite("Label Matching Tests", function () {
 
+    test("MatchLabelHtmlTags()", function () {
+        let line = `MyLabel: Label '%1%1%1<hr/> <!-- Swedish above, English below -->%1%1%1', Locked = true;`;
+        let label = ALObject.getLabel(line);
+        if (null !== label) {
+            assert.equal(label.text, '%1%1%1<hr/> <!-- Swedish above, English below -->%1%1%1');
+            assert.equal(label.name, 'MyLabel');
+            assert.equal(label.locked, true);
+            assert.equal(label.comment, '');
+            assert.equal(label.maxLength, 0);
+        } else {
+            assert.fail('Label not identified');
+        }
+    });
+
     test("MatchLabelEmpty()", function () {
         let line = 'MyLabel: label \'\';';
         let label = ALObject.getLabel(line);
@@ -465,7 +511,7 @@ suite("Label Matching Tests", function () {
         }
     });
 
-    
+
     test("MatchLabelApostrophe2()", function () {
         let line = `MyLabel: Label '''%1'' can''t be the same as ''%2''',Comment = 'A comment', MaxLength = 123;`;
         let label = ALObject.getLabel(line);

--- a/extension/src/test/LanguageFunctions.test.ts
+++ b/extension/src/test/LanguageFunctions.test.ts
@@ -373,6 +373,22 @@ suite("Label Matching Tests", function () {
         }
     });
 
+    
+    test("MatchLabelApostrophe2()", function () {
+        let line = `MyLabel: Label '''%1'' can''t be the same as ''%2''',Comment = 'A comment', MaxLength = 123;`;
+        let label = ALObject.getLabel(line);
+        if (null !== label) {
+            assert.equal(label.text, `''%1'' can''t be the same as ''%2''`);
+            assert.equal(label.name, 'MyLabel');
+            assert.equal(label.locked, false);
+            assert.equal(label.comment, 'A comment');
+            assert.equal(label.maxLength, 123);
+        } else {
+            assert.fail('Label not identified');
+        }
+    });
+
+
     test("MatchLabelApostrophe()", function () {
         let line = 'MyLabel: label \'The Label\'\'s text\',Comment = \'A comment\', MaxLength = 123;';
         let label = ALObject.getLabel(line);

--- a/extension/src/test/LanguageFunctions.test.ts
+++ b/extension/src/test/LanguageFunctions.test.ts
@@ -36,8 +36,146 @@ suite("ALObject TransUnit Tests", function () {
         let xml = `<?xml version="1.0" encoding="utf-8"?><xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"><file datatype="xml" source-language="en-US" target-language="en-US" original="AlTestApp"><body><group id="body"><trans-unit id="Codeunit 456387620 - NamedType 2350589126" size-unit="char" translate="yes" xml:space="preserve"><source>%1%1%1&lt;hr/&gt; &lt;!-- Swedish above, English below --&gt;%1%1%1</source><note from="Developer" annotates="general" priority="2"></note><note from="Xliff Generator" annotates="general" priority="3">Codeunit NAB Test Codeunit - NamedType MyLabel</note></trans-unit></group></body></file></xliff>`;
 
         let formattedXml = Xliff.replaceSelfClosingTags(xml);
-        assert.equal(formattedXml,xml);
+        assert.equal(formattedXml, xml);
 
+    });
+
+
+    test("g.Xlf update Report", function () {
+        let gXlfDoc = Xliff.fromString(ALObjectTestLibrary.getEmptyGXlf());
+        let alObj: ALObject = new ALObject(ALObjectTestLibrary.getReport(), true);
+        let transUnits = alObj.getTransUnits();
+        if (null !== transUnits) {
+            LanguageFunctions.updateGXlf(gXlfDoc, transUnits);
+            assert.equal(gXlfDoc.toString(true, true), `<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en-US" target-language="en-US" original="AlTestApp">
+    <body>
+      <group id="body">
+        <trans-unit id="Report 529985455 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Report</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="Report 529985455 - ReportDataItem 205381422 - Property 1806354803" size-unit="char" translate="yes" xml:space="preserve">
+          <source>sdfa</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - ReportDataItem DataItemName - Property RequestFilterHeading</note>
+        </trans-unit>
+        <trans-unit id="Report 529985455 - ReportColumn 967337907 - Property 2879900210" maxwidth="50" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Column</source>
+          <note from="Developer" annotates="general" priority="2">ColumnComment</note>
+          <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - ReportColumn ColumnName - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="Report 529985455 - ReportColumn 967337907 - Property 62802879" size-unit="char" translate="yes" xml:space="preserve">
+          <source>asd,asdf</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - ReportColumn ColumnName - Property OptionCaption</note>
+        </trans-unit>
+        <trans-unit id="Report 529985455 - Control 4105281732 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Grp</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - Control GroupName - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="Report 529985455 - Control 4105281732 - Property 1968111052" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Instructions</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - Control GroupName - Property InstructionalText</note>
+        </trans-unit>
+        <trans-unit id="Report 529985455 - Control 3731481282 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Fld</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - Control Fld - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="Report 529985455 - Control 3731481282 - Property 62802879" size-unit="char" translate="yes" xml:space="preserve">
+          <source>1234,34,43</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - Control Fld - Property OptionCaption</note>
+        </trans-unit>
+        <trans-unit id="Report 529985455 - Control 3731481282 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Tooltip</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - Control Fld - Property ToolTip</note>
+        </trans-unit>
+        <trans-unit id="Report 529985455 - Control 3731481282 - Method 2699620902 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Local Test Label</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - Control Fld - Method OnAssistEdit - NamedType LocalTestLabelTxt</note>
+        </trans-unit>
+        <trans-unit id="Report 529985455 - Control 3731481282 - Method 2699620902 - NamedType 725422852" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Hello World!</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - Control Fld - Method OnAssistEdit - NamedType HelloWorldTxt</note>
+        </trans-unit>
+        <trans-unit id="Report 529985455 - Action 1692444235 - Method 1377591017 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Local Test Label</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - Action ActionName - Method OnAction - NamedType LocalTestLabelTxt</note>
+        </trans-unit>
+        <trans-unit id="Report 529985455 - RequestPage 2516438534 - Method 4177352842 - NamedType 1126472184" size-unit="char" translate="yes" xml:space="preserve">
+          <source>This report cannot be scheduled</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - RequestPage RequestOptionsPage - Method OnQueryClosePage - NamedType ReportCannotBeScheduledErr</note>
+        </trans-unit>
+        <trans-unit id="Report 529985455 - Method 1968185403 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Local Test Label</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - Method TestMethod - NamedType LocalTestLabelTxt</note>
+        </trans-unit>
+        <trans-unit id="Report 529985455 - NamedType 2688233357" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Global Test Label</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - NamedType GlobalTestLabelTxt</note>
+        </trans-unit>
+      </group>
+    </body>
+  </file>
+</xliff>`);
+        } else {
+            assert.fail('No transunits identified');
+        }
+    });
+
+
+
+    test("g.Xlf update XmlPort", function () {
+        let gXlfDoc = Xliff.fromString(ALObjectTestLibrary.getEmptyGXlf());
+        let alObj: ALObject = new ALObject(ALObjectTestLibrary.getXmlPort(), true);
+        let transUnits = alObj.getTransUnits();
+        if (null !== transUnits) {
+            LanguageFunctions.updateGXlf(gXlfDoc, transUnits);
+            assert.equal(gXlfDoc.toString(true, true), `<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en-US" target-language="en-US" original="AlTestApp">
+    <body>
+      <group id="body">
+        <trans-unit id="XmlPort 3951249077 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>The Caption</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">XmlPort NAB Test XmlPort - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="XmlPort 3951249077 - XmlPortNode 3374928249 - Method 828199545 - NamedType 1704108872" size-unit="char" translate="yes" xml:space="preserve">
+          <source>ChangeLog.Type %1 not supported</source>
+          <note from="Developer" annotates="general" priority="2">%1 = Type (Inserted, Modified, Deleted)</note>
+          <note from="Xliff Generator" annotates="general" priority="3">XmlPort NAB Test XmlPort - XmlPortNode TypeOfChange - Method OnBeforePassVariable - NamedType ChangeLogTypeNotSupportedErr</note>
+        </trans-unit>
+        <trans-unit id="XmlPort 3951249077 - XmlPortNode 2961552353 - Method 257022829 - NamedType 1704108872" size-unit="char" translate="yes" xml:space="preserve">
+          <source>ChangeLog.Type %1 not supported</source>
+          <note from="Developer" annotates="general" priority="2">%1 = Type (Inserted, Modified, Deleted)</note>
+          <note from="Xliff Generator" annotates="general" priority="3">XmlPort NAB Test XmlPort - XmlPortNode Name - Method OnBeforePassField - NamedType ChangeLogTypeNotSupportedErr</note>
+        </trans-unit>
+        <trans-unit id="XmlPort 3951249077 - XmlPortNode 2235475591 - Method 828199545 - NamedType 1704108872" size-unit="char" translate="yes" xml:space="preserve">
+          <source>ChangeLog.Type %1 not supported</source>
+          <note from="Developer" annotates="general" priority="2">%1 = Type (Inserted, Modified, Deleted)</note>
+          <note from="Xliff Generator" annotates="general" priority="3">XmlPort NAB Test XmlPort - XmlPortNode TypeOfChange2 - Method OnBeforePassVariable - NamedType ChangeLogTypeNotSupportedErr</note>
+        </trans-unit>
+      </group>
+    </body>
+  </file>
+</xliff>`);
+        } else {
+            assert.fail('No transunits identified');
+        }
     });
 
     test("g.Xlf update with html tags", function () {

--- a/extension/src/test/LanguageFunctions.test.ts
+++ b/extension/src/test/LanguageFunctions.test.ts
@@ -455,6 +455,20 @@ suite("MlProperty Matching Tests", function () {
 
 suite("Label Matching Tests", function () {
 
+    test("MatchLabelMultipleApostropheComment()", function () {
+        let line = `UomDoesNotExistErr: Label '%1 ''%2'' does not exist for %3 ''%4''.\\Add %5=''%2'' as %1 or use another %6', Comment = '%1=Item Unit of Measure/Resource Unit of Measure, %2=UnitOfMeasureCode, %3=Resource/Item, %4=Item/Resource No., %5=Code, %6=Unit of Measure Code. Sample: "Item Unit of Measure ''HOUR'' does not exist for Item ''1000''.\\Add Code=''HOUR'' as Item Unit of Measure or use another Unit of Measure Code"';`;
+        let label = ALObject.getLabel(line);
+        if (null !== label) {
+            assert.equal(label.text, `%1 '%2' does not exist for %3 '%4'.\\Add %5='%2' as %1 or use another %6`);
+            assert.equal(label.name, 'UomDoesNotExistErr');
+            assert.equal(label.locked, false);
+            assert.equal(label.comment, `%1=Item Unit of Measure/Resource Unit of Measure, %2=UnitOfMeasureCode, %3=Resource/Item, %4=Item/Resource No., %5=Code, %6=Unit of Measure Code. Sample: "Item Unit of Measure 'HOUR' does not exist for Item '1000'.\\Add Code='HOUR' as Item Unit of Measure or use another Unit of Measure Code"`);
+            assert.equal(label.maxLength, 0);
+        } else {
+            assert.fail('Label not identified');
+        }
+    });
+
     test("MatchLabelHtmlTags()", function () {
         let line = `MyLabel: Label '%1%1%1<hr/> <!-- Swedish above, English below -->%1%1%1', Locked = true;`;
         let label = ALObject.getLabel(line);

--- a/extension/src/test/XLIFFTypes.test.ts
+++ b/extension/src/test/XLIFFTypes.test.ts
@@ -69,6 +69,12 @@ suite("Xliff Types - Serialization", function () {
 
 
 
+  test("Xliff multiple html tags", function () {
+    const sourceXml = GetSmallXliffXmlWithMultipleHtmlTag();
+    let parsedXliff = Xliff.fromString(sourceXml);
+    assert.equal(parsedXliff.toString(), sourceXml, 'String is not matching source.');
+  });
+
   test("Xliff html tags", function () {
     const sourceXml = GetSmallXliffXmlWithHtmlTag();
     let parsedXliff = Xliff.fromString(sourceXml);
@@ -199,6 +205,31 @@ function GetTransUnitXml() {
     <note from="Xliff Generator" annotates="general" priority="3">Table MyTable - NamedType TestErr</note>
   </trans-unit>`;
 }
+
+export function GetSmallXliffXmlWithMultipleHtmlTag(): string {
+    return `<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en-US" target-language="sv-SE" original="AlTestApp">
+    <body>
+      <group id="body">
+        <trans-unit id="Table 2328808854 - NamedType 12557645" size-unit="char" translate="yes" xml:space="preserve">
+          <source>This is a test &lt;br&gt;&lt;br&gt;&lt;br&gt; in table</source>
+          <target>This is a test &lt;br&gt;&lt;br&gt;&lt;br&gt; in table</target>
+          <note from="Developer" annotates="general" priority="2">Comment &lt;&gt; Test</note>
+          <note from="Xliff Generator" annotates="general" priority="3">Table MyTable &lt;&gt;&lt;&gt; Test - NamedType TestErr</note>
+        </trans-unit>
+        <trans-unit id="Page 2931038265 - NamedType 12557645" size-unit="char" translate="yes" xml:space="preserve">
+          <source>This is &lt;br&gt;&lt;br&gt;&lt;br&gt; test ERROR</source>
+          <target>This is &lt;br&gt;&lt;br&gt;&lt;br&gt; test ERROR</target>
+          <note from="Developer" annotates="general" priority="2">Comment &lt;&gt; Test</note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page MyPage &lt;&gt;&lt;&gt; Test - NamedType TestErr</note>
+        </trans-unit>
+      </group>
+    </body>
+  </file>
+</xliff>`;
+}
+
 
 export function GetSmallXliffXmlWithHtmlTag(): string {
     return `<?xml version="1.0" encoding="utf-8"?>

--- a/extension/src/test/XmlFormatter.test.ts
+++ b/extension/src/test/XmlFormatter.test.ts
@@ -24,7 +24,7 @@ suite("XML Formatting", function () {
         const xml = GetSmallXliffXml();
         const minifiedXml = xmlFormatter.minifyXml(xml, formattingOptions);
         assert.ok(minifiedXml);
-        assert.equal(minifiedXml.split(formattingOptions.newLine).length, 1, 'Whoops! Minified XML contains to many line breaks');
+        assert.equal(minifiedXml.split(formattingOptions.newLine).length, 3, 'Whoops! Minified XML contains to many line breaks');
     });
 
     test("Leading newline is removed", function () {

--- a/test-app/Xliff-test/Translations/Al.g.xlf
+++ b/test-app/Xliff-test/Translations/Al.g.xlf
@@ -203,6 +203,11 @@
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - Action ActionName - Method OnAction - NamedType LocalTestLabelTxt</note>
         </trans-unit>
+        <trans-unit id="Report 529985455 - RequestPage 2516438534 - Method 4177352842 - NamedType 1126472184" size-unit="char" translate="yes" xml:space="preserve">
+          <source>This report cannot be scheduled</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - RequestPage RequestOptionsPage - Method OnQueryClosePage - NamedType ReportCannotBeScheduledErr</note>
+        </trans-unit>
         <trans-unit id="Report 529985455 - Method 1968185403 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve">
           <source>Local Test Label</source>
           <note from="Developer" annotates="general" priority="2"></note>
@@ -237,6 +242,26 @@
           <source>Global Test Label</source>
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Query NAB Test Query - NamedType GlobalTestLabelTxt</note>
+        </trans-unit>
+        <trans-unit id="XmlPort 3951249077 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>The Caption</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">XmlPort NAB Test XmlPort - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="XmlPort 3951249077 - XmlPortNode 3374928249 - Method 828199545 - NamedType 1704108872" size-unit="char" translate="yes" xml:space="preserve">
+          <source>ChangeLog.Type %1 not supported</source>
+          <note from="Developer" annotates="general" priority="2">%1 = Type (Inserted, Modified, Deleted)</note>
+          <note from="Xliff Generator" annotates="general" priority="3">XmlPort NAB Test XmlPort - XmlPortNode TypeOfChange - Method OnBeforePassVariable - NamedType ChangeLogTypeNotSupportedErr</note>
+        </trans-unit>
+        <trans-unit id="XmlPort 3951249077 - XmlPortNode 2961552353 - Method 257022829 - NamedType 1704108872" size-unit="char" translate="yes" xml:space="preserve">
+          <source>ChangeLog.Type %1 not supported</source>
+          <note from="Developer" annotates="general" priority="2">%1 = Type (Inserted, Modified, Deleted)</note>
+          <note from="Xliff Generator" annotates="general" priority="3">XmlPort NAB Test XmlPort - XmlPortNode Name - Method OnBeforePassField - NamedType ChangeLogTypeNotSupportedErr</note>
+        </trans-unit>
+        <trans-unit id="XmlPort 3951249077 - XmlPortNode 2235475591 - Method 828199545 - NamedType 1704108872" size-unit="char" translate="yes" xml:space="preserve">
+          <source>ChangeLog.Type %1 not supported</source>
+          <note from="Developer" annotates="general" priority="2">%1 = Type (Inserted, Modified, Deleted)</note>
+          <note from="Xliff Generator" annotates="general" priority="3">XmlPort NAB Test XmlPort - XmlPortNode TypeOfChange2 - Method OnBeforePassVariable - NamedType ChangeLogTypeNotSupportedErr</note>
         </trans-unit>
         <trans-unit id="PageExtension 3795862579 - Control 3146432722 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
           <source>Capt</source>

--- a/test-app/Xliff-test/src/TestReport.Report.al
+++ b/test-app/Xliff-test/src/TestReport.Report.al
@@ -62,6 +62,12 @@ report 50000 "NAB Test Report"
                 }
             }
         }
+        trigger OnQueryClosePage(CloseAction: Action): Boolean;
+        var
+            ReportCannotBeScheduledErr: Label 'This report cannot be scheduled';
+        begin
+            exit(true);
+        end;
     }
 
     procedure TestMethod()

--- a/test-app/Xliff-test/src/TestXmlPort.XmlPort.al
+++ b/test-app/Xliff-test/src/TestXmlPort.XmlPort.al
@@ -1,0 +1,50 @@
+xmlport 50000 "NAB Test XmlPort"
+{
+    Caption = 'The Caption';
+
+    schema
+    {
+        textelement(changedrecords)
+        {
+            XmlName = 'ChangedRecords';
+            tableelement(changelog; "NAB Test Table")
+            {
+                MinOccurs = Zero;
+                XmlName = 'ChangedRecord';
+                textattribute(TypeOfChange)
+                {
+
+                    trigger OnBeforePassVariable()
+                    var
+                        ChangeLogTypeNotSupportedErr: Label 'ChangeLog.Type %1 not supported', Comment = '%1 = Type (Inserted, Modified, Deleted)';
+                    begin
+                    end;
+                }
+                tableelement(tfieldvalue; "NAB Test Table")
+                {
+                    XmlName = 'PrimaryKeyField';
+                    UseTemporary = true;
+                    fieldattribute(No; tFieldValue."My <> & Field")
+                    {
+                    }
+                    fieldattribute(Name; tFieldValue.MyField)
+                    {
+                        trigger OnBeforePassField()
+                        var
+                            ChangeLogTypeNotSupportedErr: Label 'ChangeLog.Type %1 not supported', Comment = '%1 = Type (Inserted, Modified, Deleted)';
+                        begin
+                        end;
+                    }
+                    textattribute(TypeOfChange2)
+                    {
+                        trigger OnBeforePassVariable()
+                        var
+                            ChangeLogTypeNotSupportedErr: Label 'ChangeLog.Type %1 not supported', Comment = '%1 = Type (Inserted, Modified, Deleted)';
+                        begin
+                        end;
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
- Handles issue where "<source> </source>" got replaced with "<source></source>"
- Handle captions on obsolete objects
