### PR TITLE
Skipping slow tests locally

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "nab-al-tools",
-    "version": "0.3.36",
+    "version": "0.3.37",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/extension/src/test/BaseAppTranslationFiles.test.ts
+++ b/extension/src/test/BaseAppTranslationFiles.test.ts
@@ -5,12 +5,20 @@ import * as BaseAppTranslationFiles from '../externalresources/BaseAppTranslatio
 suite("Base App Translation Files Tests", function () {
 
     test("BaseAppTranslationFiles.getBlobs()", async function () {
+        // Only run in GitHub Workflow
+        if (!process.env.GITHUB_ACTION) {
+            this.skip();
+        }
         this.timeout(240000); // Takes some time to download all files synchronously on GitHubs Ubuntu servers...
         const result = await BaseAppTranslationFiles.BaseAppTranslationFiles.getBlobs(); // Gets all the blobs, and I mean aaaall of them.
         assert.equal(result, 25, 'Unexpected number of files downloaded');
     });
 
     test("localTranslationFiles", async function () {
+        // Only run in GitHub Workflow
+        if (!process.env.GITHUB_ACTION) {
+            this.skip();
+        }
         this.timeout(20000); // Take some time to download blobs on Ubuntu...
         let result = await BaseAppTranslationFiles.BaseAppTranslationFiles.getBlobs(['sv-se']);
         const localTranslationFiles = BaseAppTranslationFiles.localBaseAppTranslationFiles();

--- a/extension/src/test/ExternalResources.test.ts
+++ b/extension/src/test/ExternalResources.test.ts
@@ -15,6 +15,10 @@ suite("External Resources Tests", function () {
     const baseUrl = 'https://nabaltools.file.core.windows.net/shared/base_app_lang_files/';
 
     test("ExternalResource.get()", async function () {
+        // Only run in GitHub Workflow
+        if (!process.env.GITHUB_ACTION) {
+            this.skip();
+        }
         this.timeout(10000);
         const extResource = new ExternalResource('sv-se.json', href);
         const writeStream = createWriteStream(path.resolve(__dirname, "test.json"), "utf8");
@@ -33,6 +37,10 @@ suite("External Resources Tests", function () {
     });
 
     test("AzureBlobContainer.getBlobs()", async function () {
+        // Only run in GitHub Workflow
+        if (!process.env.GITHUB_ACTION) {
+            this.skip();
+        }
         this.timeout(5000);
         const exportPath = path.resolve(__dirname);
         let blobContainer = new BlobContainer(exportPath, baseUrl, sasToken);


### PR DESCRIPTION
Some tests are slow and may be unnecessary to run every time locally. Hopefully this little check & skip will speed things up. It also marks the tests as pending so that you know they didn't run. This is achieved by checking for a GitHub environment variable like this:
```TypeScript
if (!process.env.GITHUB_ACTION) {
    this.skip();
}
``` 
`GITHUB_ACTION` is an environment variable set by GitHub when creating the containers. [More info here](https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables)

This is how it should look like when running locally. 
![image](https://user-images.githubusercontent.com/17023248/102725953-07dc7b00-431b-11eb-9a21-f40ef79e264f.png)
![image](https://user-images.githubusercontent.com/17023248/102725976-335f6580-431b-11eb-82c6-bf53d4ca1e45.png)

The pending test should run in the GitHub workflow. At this point all tests should run in the GitHub workflow. As seen in the test runs for this PR.
