### PR TITLE
Find next untranslated - Stop at multiple targets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,9 @@ npm install -g mocha # To install it globally
 ### Running the extension
 
 * Open the `nab-al-tools.code-workspace` in Visual Studio Code.
-* Open the Debug menu (`Ctrl+Shift+D`) and set the debug configuration to `Extension`.
+* Open the Debug menu (`Ctrl+Shift+D`) and set the debug configuration to `TestApp` to debug with the included AL test project.
+  * Alternatively `Test any workspace` if you wan't to debug in the context of a specific AL project.
+  * `Automatic Tests` will run all test suites.
 * Press `F5`.
 
 In the Development Extension Host window open the command palette and search for NAB.

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -43,7 +43,7 @@ We're out of preview no more beta!
 - Fixed issues
   - `NAB: Find code source of current line` did not work in some cases, [issue 93](https://github.com/jwikman/nab-al-tools/issues/93)
   - `NAB: Find Next Untranslated` now cleans up missed notes ("NAB AL Tool Refresh Xlf") that could be left behind if the refresh function wasn't run again.
-
+  - `NAB: Find Next Untranslated` also presents any occurence of multiple targets in the .xlf file.
 Bugs, issues and suggestions can be submitted on [GitHub](https://github.com/jwikman/nab-al-tools/issues)
 
 ## [0.3.38] Public Beta - 2021-01-29

--- a/extension/src/test/ALObjectTestLibrary.ts
+++ b/extension/src/test/ALObjectTestLibrary.ts
@@ -1172,6 +1172,31 @@ export function getXlfMultipleNABTokens(): string {
              </trans-unit>
              <trans-unit id="Table 2328808854 - Field 1296262074 - Method 2126772001 - NamedType 1978266064" size-unit="char" translate="yes" xml:space="preserve">
                 <source>OnValidate Error</source>
+                <target>OnValidate Error 2</target>
+                <note from="Developer" annotates="general" priority="2"></note>
+                <note from="Xliff Generator" annotates="general" priority="3">Table MyTable - Field MyField - Method OnValidate - NamedType TestOnValidateErr</note>
+            </trans-unit>
+           </group>
+         </body>
+       </file>
+     </xliff>`;
+}
+
+export function getXlfMultipleTargets(): string {
+    return `<?xml version="1.0" encoding="utf-8"?>
+     <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+       <file datatype="xml" source-language="en-US" target-language="sv-SE" original="AlTestApp">
+         <body>
+           <group id="body">
+             <trans-unit id="Table 2328808854 - Field 1296262999 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+               <source>Herro</source>
+               <target>[NAB: SUGGESTION][NAB: NOT TRANSLATED]</target>
+               <note from="Developer" annotates="general" priority="2"></note>
+               <note from="Xliff Generator" annotates="general" priority="3">Table MyTable - Field MyField - Property Caption</note>
+             </trans-unit>
+             <trans-unit id="Table 2328808854 - Field 1296262074 - Method 2126772001 - NamedType 1978266064" size-unit="char" translate="yes" xml:space="preserve">
+                <source>OnValidate Error</source>
+                <target>OnValidate Error</target>
                 <target>OnValidate Error</target>
                 <note from="Developer" annotates="general" priority="2"></note>
                 <note from="Xliff Generator" annotates="general" priority="3">Table MyTable - Field MyField - Method OnValidate - NamedType TestOnValidateErr</note>
@@ -1181,6 +1206,7 @@ export function getXlfMultipleNABTokens(): string {
        </file>
      </xliff>`;
 }
+
 export function getXlfHasNABTokens(): string {
     return `<?xml version="1.0" encoding="utf-8"?>
     <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">

--- a/extension/src/test/LanguageFunctions.test.ts
+++ b/extension/src/test/LanguageFunctions.test.ts
@@ -795,6 +795,27 @@ suite("Language Functions Tests", function () {
     const existingTargetLanguages = await LanguageFunctions.existingTargetLanguageCodes();
     assert.equal(existingTargetLanguages?.length, 2, 'Expected 2 target languages to be found');
   });
+
+  test("findNearestWordMatch()", function () {
+    const expectedPosition = 601;
+    let searchResult = LanguageFunctions.findNearestWordMatch(ALObjectTestLibrary.getXlfHasNABTokens(), 0, [TranslationToken.Review, TranslationToken.NotTranslated, TranslationToken.Suggestion]);
+    assert.equal(searchResult.foundNode, true, "Expected word to be found");
+    assert.equal(searchResult.foundAtPosition, expectedPosition, `Expected word to be found at postion ${expectedPosition}`);
+    assert.equal(searchResult.foundWord, "[NAB: SUGGESTION]", "Unexpected word found");
+  });
+
+  test("findNearestMultipleTargets()", function () {
+    const expectedPosition = 1105;
+    let searchResult = LanguageFunctions.findNearestMultipleTargets(ALObjectTestLibrary.getXlfMultipleTargets(), 0);
+    assert.equal(searchResult.foundNode, true, "Expected word to be found");
+    assert.equal(searchResult.foundAtPosition, expectedPosition, `Expected word to be found at postion ${expectedPosition}`);
+    assert.equal(
+      searchResult.foundWord,
+      `                <target>OnValidate Error</target>
+                <target>OnValidate Error</target>`
+    );
+
+  });
 });
 
 function noMultipleNABTokensInXliff(xliff: string): boolean {


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
Fixes #120.

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- New search function that searches for multiple targets.
- The closest of the findings is used as result and presented to the user.
- A small refactor to allow testing of search functions
  - Added tests for search functions

Additional comments
It's good enough but I'm not completely convinced my regex approach is the best way. I'd tried to get some grouping going so that it would be possible to mark the multiple targets line by line but my regex skills weren't enough. I'd love some input if you get any ideas :)
