### PR TITLE
Identify differently translated

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -13,6 +13,12 @@ We're out of preview no more beta!
 
 - New features:
   - `NAB: Edit Xliff Document` opens XLF-files for editing in a webview. With the goal of reducing the clutter of XML files this feature is mainly built for translators. Command available from right clicking a XLF-file and command palette. This is the first iteration of this editor and we are grateful for any feedback you are able to send our way.
+
+  Keyboard navigation:
+    - `Arrow Up` / `Arrow down` moves focus between lines.
+    - `F8`  copies the target text from the line above.
+    - `TAB` focus is moved between the target textarea and the complete checkbox and then the next line.
+    - `Space` can be used to toggle the complete checkbox when it's in focus.
   - `NAB: Create translation XLF for new language` creates and opens a new translation file for selected target language with the option to match translations from BaseApp to get you going. The new translation file is saved as `<app-name>.<language-code>.xlf` in workspace translation folder. Note that there is no validation of the new target language code.
   - `NAB: Generate External Documentation` generates documentation that is intended to be used as an external documentation. I.e. to be read by someone that wants to extend the app by API, Web Services or with an extension. The documentation is created as [markdown](https://en.wikipedia.org/wiki/Markdown) files. The markdown files could  be transformed to html files with the help of [DocFx](https://dotnet.github.io/docfx/) or other tools.
     - The content is generated from the AL code and the [XML Comments](https://docs.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-xml-comments) that are written in the AL code.

--- a/extension/README.md
+++ b/extension/README.md
@@ -276,6 +276,13 @@ The same feature as above, but with debugging
 Opens XLF-files for editing in a webview.
 
 With the goal of reducing the clutter of XML files this feature is built for translators or non-developers in mind. Command available from right clicking a XLF-file and command palette. 
+
+Keyboard navigation:
+* `Arrow Up` / `Arrow down` moves focus between lines.
+* `F8`  copies the target text from the line above.
+* `TAB` focus is moved between the target textarea and the complete checkbox and then the next line.
+* `Space` can be used to toggle the complete checkbox when it's in focus.
+
 ![Edit Xliff Document](images/gifs/XliffEditorUsage.gif)
 
 ### Snippets

--- a/extension/frontend/XliffEditor/main.js
+++ b/extension/frontend/XliffEditor/main.js
@@ -82,6 +82,14 @@
                 text: "review"
             });
         });
+    document.getElementById("btn-filter-differently-translated").addEventListener(
+        "click",
+        (e) => {
+            vscode.postMessage({
+                command: "filter",
+                text: "differently-translated"
+            });
+        });
     document.getElementById("btn-reload").addEventListener(
         "click",
         (e) => {

--- a/extension/frontend/XliffEditor/main.js
+++ b/extension/frontend/XliffEditor/main.js
@@ -140,22 +140,17 @@
         let currentRow = document.getElementById(e.target.closest("tr").id);
         let previousRow = currentRow.previousElementSibling;
         let nextRow = currentRow.nextElementSibling;
-        // console.log("Current Row:", currentRow);
-        // console.log("Previous Row:", previousRow);
-        // console.log("Next Row:", nextRow);
         switch (e.key) {
             case ValidKeys.ArrowDown:
                 if (isNullOrUndefined(nextRow)) {
                     return;
                 }
-                // console.log("Moving down");
                 nextRow.getElementsByClassName("target-cell")[0].getElementsByTagName("textarea")[0].focus();
                 break;
             case ValidKeys.ArrowUp:
                 if (isNullOrUndefined(previousRow)) {
                     return;
                 }
-                // console.log("Moving up");
                 previousRow.getElementsByClassName("target-cell")[0].getElementsByTagName("textarea")[0].focus();
                 break;
             case ValidKeys.F8:
@@ -163,8 +158,8 @@
                     return;
                 }
                 let copyValue = previousRow.getElementsByClassName("target-cell")[0].getElementsByTagName("textarea")[0].value;
-                // console.log(`Copy "${copyValue}" from row id "${previousRow.id}"`);
                 e.target.value = copyValue;
+                e.target.dispatchEvent(new Event("change"));
                 break;
             default:
                 throw new Error(`Invalid key: ${e.key}`)

--- a/extension/frontend/XliffEditor/main.js
+++ b/extension/frontend/XliffEditor/main.js
@@ -4,8 +4,16 @@
  */
 (function () {
     const vscode = acquireVsCodeApi();
+    const ValidKeys = {
+        ArrowDown: "ArrowDown",
+        ArrowUp: "ArrowUp",
+        F8: "F8"
+    }
 
 
+    function isNullOrUndefined(value) {
+        return (value === null || value === undefined);
+    }
 
     window.onload = function () {
         const oldState = vscode.getState();
@@ -125,29 +133,44 @@
         );
     }
 
-    /**
-     * Copy Source //TODO: Maybe add back in at a later date
-     */
-    // let buttons = document.getElementsByClassName("btn-cpy-src");
-    // for (let i = 0; i < buttons.length; i++) {
-    //     const checkbox = buttons[i];
-    //     // Complete translation
-    //     checkbox.addEventListener(
-    //         "click",
-    //         (e) => {
-    //             let id = e.target.id.replace('-copy-source', '');
-    //             let sourceText = document.getElementById(`${id}-source`).innerText;
-    //             document.getElementById(id).value = sourceText;
-    //             vscode.postMessage({
-    //                 command: 'update',
-    //                 text: `Updated transunit: ${id}`,
-    //                 transunitId: id,
-    //                 targetText: sourceText
-    //             })
-    //         },
-    //         false
-    //     );
-    // }
+    document.addEventListener("keyup", (e) => {
+        if (Object.keys(ValidKeys).indexOf(e.key) === -1) {
+            return;
+        }
+        let currentRow = document.getElementById(e.target.closest("tr").id);
+        let previousRow = currentRow.previousElementSibling;
+        let nextRow = currentRow.nextElementSibling;
+        // console.log("Current Row:", currentRow);
+        // console.log("Previous Row:", previousRow);
+        // console.log("Next Row:", nextRow);
+        switch (e.key) {
+            case ValidKeys.ArrowDown:
+                if (isNullOrUndefined(nextRow)) {
+                    return;
+                }
+                // console.log("Moving down");
+                nextRow.getElementsByClassName("target-cell")[0].getElementsByTagName("textarea")[0].focus();
+                break;
+            case ValidKeys.ArrowUp:
+                if (isNullOrUndefined(previousRow)) {
+                    return;
+                }
+                // console.log("Moving up");
+                previousRow.getElementsByClassName("target-cell")[0].getElementsByTagName("textarea")[0].focus();
+                break;
+            case ValidKeys.F8:
+                if (isNullOrUndefined(previousRow)) {
+                    return;
+                }
+                let copyValue = previousRow.getElementsByClassName("target-cell")[0].getElementsByTagName("textarea")[0].value;
+                // console.log(`Copy "${copyValue}" from row id "${previousRow.id}"`);
+                e.target.value = copyValue;
+                break;
+            default:
+                throw new Error(`Invalid key: ${e.key}`)
+        }
+    });
+
     function updateState(state = { position: undefined }) {
         vscode.setState(state);
     }

--- a/extension/frontend/XliffEditor/main.js
+++ b/extension/frontend/XliffEditor/main.js
@@ -133,8 +133,11 @@
         );
     }
 
-    document.addEventListener("keyup", (e) => {
+    document.addEventListener("keydown", (e) => {
         if (Object.keys(ValidKeys).indexOf(e.key) === -1) {
+            return;
+        }
+        if (isNullOrUndefined(e.target.closest("tr"))) {
             return;
         }
         let currentRow = document.getElementById(e.target.closest("tr").id);
@@ -145,13 +148,13 @@
                 if (isNullOrUndefined(nextRow)) {
                     return;
                 }
-                nextRow.getElementsByClassName("target-cell")[0].getElementsByTagName("textarea")[0].focus();
+                setFocus(nextRow.getElementsByClassName("target-cell")[0].getElementsByTagName("textarea")[0]);
                 break;
             case ValidKeys.ArrowUp:
                 if (isNullOrUndefined(previousRow)) {
                     return;
                 }
-                previousRow.getElementsByClassName("target-cell")[0].getElementsByTagName("textarea")[0].focus();
+                setFocus(previousRow.getElementsByClassName("target-cell")[0].getElementsByTagName("textarea")[0]);
                 break;
             case ValidKeys.F8:
                 if (isNullOrUndefined(previousRow)) {
@@ -165,6 +168,13 @@
                 throw new Error(`Invalid key: ${e.key}`)
         }
     });
+
+    function setFocus(textArea) {
+        if (isNullOrUndefined(textArea)) {
+            return;
+        }
+        textArea.focus();
+    }
 
     function updateState(state = { position: undefined }) {
         vscode.setState(state);

--- a/extension/frontend/XliffEditor/reset.css
+++ b/extension/frontend/XliffEditor/reset.css
@@ -49,11 +49,21 @@ textarea {
 
 table {
     width: 100%;
-     border-collapse: collapse;
+    border-collapse: collapse;
     /* table-layout: fixed; */
 }
-table, th, td {
+
+table, td {
     position: relative;
+}
+
+th {
+    position: sticky;
+    margin-top: 5px;
+    top: 30px;
+    z-index: 99;
+    box-shadow: 0 2px 2px -1px rgba(0, 0, 0, 0.4);
+    background-color: #4b4b4b;
 }
 th.complete {
     width: 2%;
@@ -74,6 +84,7 @@ div.sticky {
   position: sticky;
   top: 0;
   z-index: 100;
+  background-color: #4b4b4b;
 }
 input[type=checkbox] {
     width: 25px;

--- a/extension/frontend/XliffEditor/reset.css
+++ b/extension/frontend/XliffEditor/reset.css
@@ -83,3 +83,32 @@ input[type=checkbox] {
 input[type=checkbox]:focus {
     outline:4px solid;
 }
+
+/* The container <div> - needed to position the dropdown content */
+.dropdown {
+    position: relative;
+    display: inline-block;
+    width: 100%;
+}
+
+/* Dropdown Button */
+.dropbtn {
+    width: 100%;
+} 
+/* Dropdown Content (Hidden by Default) */
+.dropdown-content {
+  display: none;
+  position: absolute;  
+  box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+  width: 100%;
+}
+
+/* Links inside the dropdown */
+.dropdown-content a {
+  padding-top: 2px;
+  text-decoration: none;
+  display: block;
+}
+
+/* Show the dropdown menu on hover */
+.dropdown:hover .dropdown-content {display: block;}

--- a/extension/src/XLIFFDocument.ts
+++ b/extension/src/XLIFFDocument.ts
@@ -203,7 +203,7 @@ export class Xliff implements XliffDocumentInterface {
      * @returns TransUnit[]
      */
     public getSameSourceDifferentTarget(transUnit: TransUnit): TransUnit[] {
-        return this.transunit.filter(t => ((t.source === transUnit.source) && (t.targets[0].textContent !== transUnit.targets[0].textContent)));
+        return this.transunit.filter(t => ((t.source === transUnit.source) && (t.targetTextContent !== transUnit.targetTextContent)));
     }
 
     /**
@@ -284,7 +284,6 @@ export class TransUnit implements TransUnitInterface {
     translate: boolean;
     source: string;
     targets: Target[] = [];
-    // target = (): Target => { return this.targets[0] }; //TODO: Test
     notes: Note[] = [];
     sizeUnit?: SizeUnit;
     xmlSpace: string;
@@ -306,6 +305,10 @@ export class TransUnit implements TransUnitInterface {
         this.maxwidth = maxwidth;
         this.alObjectTarget = alObjectTarget;
     }
+
+    get targetTextContent(): string { return isNullOrUndefined(this.targets[0]) ? "" : this.targets[0].textContent; }
+    get targetState(): string { return isNullOrUndefined(this.targets[0].state) ? "" : this.targets[0].state; }
+    get targetTranslationToken(): string { return isNullOrUndefined(this.targets[0].translationToken) ? "" : this.targets[0].translationToken; }
 
     static fromString(xml: string): TransUnit {
         let dom = xmldom.DOMParser;

--- a/extension/src/XLIFFDocument.ts
+++ b/extension/src/XLIFFDocument.ts
@@ -197,18 +197,37 @@ export class Xliff implements XliffDocumentInterface {
         this.transunit.sort(CompareTransUnitId);
     }
 
+    /**
+     * Returns an array of trans-units where source matches and the translation differs from the input TransUnit
+     * @param transUnit trans-unit to match with.
+     * @returns TransUnit[]
+     */
     public getSameSourceDifferentTarget(transUnit: TransUnit): TransUnit[] {
         return this.transunit.filter(t => ((t.source === transUnit.source) && (t.target().textContent !== transUnit.target().textContent)));
     }
 
+    /**
+     * Checks if source exists more than once.
+     * @param source Source string to search for.
+     * @returns boolean
+     */
     public sourceHasDuplicates(source: string): boolean {
         return this.getTransUnitsBySource(source).length > 1;
     }
 
+    /**
+     * Returns an array of trans-units where source matches the input.
+     * @param source Source string to search for.
+     * @returns TransUnit[]
+     */
     public getTransUnitsBySource(source: string): TransUnit[] {
         return this.transunit.filter(t => t.source === source);
     }
 
+    /**
+     * Returns an array of trans-units with matching sources and different translations.
+     * @returns TransUnit[]
+     */
     public differentlyTranslatedTransunits(): TransUnit[] {
         let transUnits: TransUnit[] = [];
         this.transunit.forEach(tu => {

--- a/extension/src/XLIFFDocument.ts
+++ b/extension/src/XLIFFDocument.ts
@@ -203,7 +203,7 @@ export class Xliff implements XliffDocumentInterface {
      * @returns TransUnit[]
      */
     public getSameSourceDifferentTarget(transUnit: TransUnit): TransUnit[] {
-        return this.transunit.filter(t => ((t.source === transUnit.source) && (t.target().textContent !== transUnit.target().textContent)));
+        return this.transunit.filter(t => ((t.source === transUnit.source) && (t.targets[0].textContent !== transUnit.targets[0].textContent)));
     }
 
     /**
@@ -284,7 +284,7 @@ export class TransUnit implements TransUnitInterface {
     translate: boolean;
     source: string;
     targets: Target[] = [];
-    target = (): Target => { return this.targets[0] }; //TODO: Test
+    // target = (): Target => { return this.targets[0] }; //TODO: Test
     notes: Note[] = [];
     sizeUnit?: SizeUnit;
     xmlSpace: string;
@@ -377,10 +377,6 @@ export class TransUnit implements TransUnitInterface {
         });
         return transUnit;
     }
-
-    // public target(): Target {
-    //     return this.targets[0];
-    // }
 
     public addTarget(target: Target) {
         this.targets.push(target);

--- a/extension/src/XLIFFDocument.ts
+++ b/extension/src/XLIFFDocument.ts
@@ -197,8 +197,8 @@ export class Xliff implements XliffDocumentInterface {
         this.transunit.sort(CompareTransUnitId);
     }
 
-    public differentTranslations(transUnit: TransUnit): TransUnit[] {//TODO: TEST
-        return this.transunit.filter(t => t.source === transUnit.source && t.targets[0] !== transUnit.targets[0]);
+    public getSameSourceDifferentTarget(transUnit: TransUnit): TransUnit[] {
+        return this.transunit.filter(t => ((t.source === transUnit.source) && (t.target().textContent !== transUnit.target().textContent)));
     }
 
     public sourceHasDuplicates(source: string): boolean {
@@ -209,13 +209,14 @@ export class Xliff implements XliffDocumentInterface {
         return this.transunit.filter(t => t.source === source);
     }
 
-    public differentlyTranslatedTransunits(): TransUnit[] {//TODO: TEST
+    public differentlyTranslatedTransunits(): TransUnit[] {
         let transUnits: TransUnit[] = [];
         this.transunit.forEach(tu => {
-            if (this.sourceHasDuplicates(tu.source)) {
-                transUnits.push(tu);
-                transUnits = transUnits.concat(this.differentTranslations(tu));
-            }
+            this.getSameSourceDifferentTarget(tu).forEach(duplicate => {
+                if (transUnits.filter(a => a.id === duplicate.id).length === 0) {
+                    transUnits.push(duplicate);
+                }
+            });
         });
         return transUnits;
     }
@@ -264,6 +265,7 @@ export class TransUnit implements TransUnitInterface {
     translate: boolean;
     source: string;
     targets: Target[] = [];
+    target = (): Target => { return this.targets[0] }; //TODO: Test
     notes: Note[] = [];
     sizeUnit?: SizeUnit;
     xmlSpace: string;
@@ -356,6 +358,10 @@ export class TransUnit implements TransUnitInterface {
         });
         return transUnit;
     }
+
+    // public target(): Target {
+    //     return this.targets[0];
+    // }
 
     public addTarget(target: Target) {
         this.targets.push(target);

--- a/extension/src/XLIFFDocument.ts
+++ b/extension/src/XLIFFDocument.ts
@@ -196,6 +196,30 @@ export class Xliff implements XliffDocumentInterface {
     public sortTransUnits() {
         this.transunit.sort(CompareTransUnitId);
     }
+
+    public differentTranslations(transUnit: TransUnit): TransUnit[] {//TODO: TEST
+        return this.transunit.filter(t => t.source === transUnit.source && t.targets[0] !== transUnit.targets[0]);
+    }
+
+    public sourceHasDuplicates(source: string): boolean {
+        return this.getTransUnitsBySource(source).length > 1;
+    }
+
+    public getTransUnitsBySource(source: string): TransUnit[] {
+        return this.transunit.filter(t => t.source === source);
+    }
+
+    public differentlyTranslatedTransunits(): TransUnit[] {//TODO: TEST
+        let transUnits: TransUnit[] = [];
+        this.transunit.forEach(tu => {
+            if (this.sourceHasDuplicates(tu.source)) {
+                transUnits.push(tu);
+                transUnits = transUnits.concat(this.differentTranslations(tu));
+            }
+        });
+        return transUnits;
+    }
+
     static detectLineEnding(xml: string): string {
         const temp = xml.indexOf('\n');
         if (xml[temp - 1] === '\r') {

--- a/extension/src/XliffEditor/HTML.ts
+++ b/extension/src/XliffEditor/HTML.ts
@@ -1,9 +1,12 @@
+import { isNullOrUndefined } from "util";
+
 export function checkbox(a: HTMLAttributes): string {
-    return `<input type="checkbox" ${a.id ? 'id="' + a.id + '"' : ''} ${a.name ? 'name="' + a.name + '"' : ''} ${a.checked ? " checked " : ""} ${a.disabled ? " disabled " : ""}>`;
+    a.type = "checkbox";
+    return `<input ${attributeString(a)}>`;
 }
 
 export function table(a: HTMLAttributes, columns: HTMLTag[]): string {
-    return `<table ${a.id ? 'id="' + a.id + '"' : ''}>${tr({}, columns)}</table>`;
+    return `<table ${attributeString(a)}>${tr({}, columns)}</table>`;
 }
 
 export function tableHeader(headers: string[]): string {
@@ -16,11 +19,11 @@ export function tableHeader(headers: string[]): string {
 }
 
 function th(a: HTMLAttributes, content: string): string {
-    return `<th class="${a.class}">${content}</th>`;
+    return `<th ${attributeString(a)}>${content}</th>`;
 }
 
 export function tr(a: HTMLAttributes, columns: HTMLTag[]): string {
-    let row: string = `<tr ${a.id ? 'id="' + a.id + '"' : ''}>`;
+    let row: string = `<tr ${attributeString(a)}>`;
     columns.forEach(c => {
         row += td(c);
     });
@@ -29,25 +32,26 @@ export function tr(a: HTMLAttributes, columns: HTMLTag[]): string {
 }
 
 function td(param: HTMLTag): string {
-    return `<td ${param.a?.align ? 'align="' + param.a.align + '"' : ''}>${param.content}</td>`;
+    return `<td ${attributeString(param.a)}>${param.content}</td>`;
 }
 
 export function div(a: HTMLAttributes, content: string): string {
-    let _div: string = `<div ${a.id ? 'id="' + a.id + '"' : ''} ${a.class ? 'class="' + a.class + '"' : ''} ${a.name ? 'name="' + a.name + '"' : ''}>`;
+    let _div: string = `<div ${attributeString(a)}>`;
     _div += content;
     _div += "</div>";
     return _div;
 }
 
 export function textArea(a: HTMLAttributes, content: string): string {
-    let tarea: string = `<textarea ${a.id ? 'id="' + a.id + '"' : ''} ${a.class ? 'class="' + a.class + '"' : ''} ${a.name ? 'name="' + a.name + '"' : ''} ${a.type ? 'type="' + a.type + '"' : ''}>`;
+    let tarea: string = `<textarea ${attributeString(a)}>`;
     tarea += content;
     tarea += "</textarea>";
     return tarea;
 }
 
 export function button(a: HTMLAttributes, content: string): string {
-    let btn: string = `<button ${a.id ? 'id="' + a.id + '"' : ''} ${a.class ? 'class="' + a.class + '"' : ''} ${a.onClick ? 'onClick="' + a.onClick + '"' : ''}>`;
+    // let btn: string = `<button ${a.id ? 'id="' + a.id + '"' : ''} ${a.class ? 'class="' + a.class + '"' : ''} ${a.onClick ? 'onClick="' + a.onClick + '"' : ''}>`;
+    let btn: string = `<button ${attributeString(a)}>`;
     btn += content;
     btn += "</button>";
     return btn;
@@ -57,7 +61,27 @@ export function br(noOfLinebreaks: number = 1): string {
     return (new Array<string>(noOfLinebreaks)).fill("<br/>").join("");
 }
 
-interface HTMLAttributes {
+export function attributeString(attributes?: HTMLAttributes): string {
+    let a = "";
+    if (!isNullOrUndefined(attributes)) {
+        Object.entries(attributes).forEach(attrib => {
+            switch (attrib[0]) {
+                case "checked":
+                    a += attrib[1] ? " checked" : "";
+                    break;
+                case "disabled":
+                    a += attrib[1] ? " disabled" : "";
+                    break;
+                default:
+                    a += ` ${attrib[0]}="${attrib[1]}"`;
+                    break;
+            }
+            a.trim();
+        });
+    }
+    return a.trim();
+}
+export interface HTMLAttributes {
     id?: string;
     class?: string;
     name?: string;

--- a/extension/src/XliffEditor/XliffEditorPanel.ts
+++ b/extension/src/XliffEditor/XliffEditorPanel.ts
@@ -262,7 +262,7 @@ export class XliffEditorPanel {
             let hasCustomNote = transunit.hasCustomNote(CustomNoteType.RefreshXlfHint);
             let columns: html.HTMLTag[] = [
                 { content: html.div({ id: `${transunit.id}-source`, }, transunit.source), a: undefined },
-                { content: html.textArea({ id: transunit.id, type: "text" }, transunit.targets[0].textContent), a: undefined },
+                { content: html.textArea({ id: transunit.id, type: "text" }, transunit.targets[0].textContent), a: { class: "target-cell" } },
                 { content: html.checkbox({ id: `${transunit.id}-complete`, checked: !hasTranslationToken && !hasCustomNote, class: "complete-checkbox" }), a: { align: "center" } },
                 { content: html.div({ class: "transunit-notes", id: `${transunit.id}-notes` }, getNotesHtml(transunit)), a: undefined }
             ];

--- a/extension/src/XliffEditor/XliffEditorPanel.ts
+++ b/extension/src/XliffEditor/XliffEditorPanel.ts
@@ -285,7 +285,7 @@ function getNonce() {
 function getNotesHtml(transunit: TransUnit): string {
     let content = '';
     if (transunit.targets[0].translationToken && transunit.targets[0].translationToken !== TranslationToken.Suggestion) {
-        // Since all suggestions are listed we don't want to add an extra line just for the token.
+        // Since all suggestions are listed we don't want to add an extra line just for the sugestion token.
         content += `${transunit.targets[0].translationToken}${html.br(2)}`;
     }
     if (transunit.targets.length > 1) {

--- a/extension/src/XliffEditor/XliffEditorPanel.ts
+++ b/extension/src/XliffEditor/XliffEditorPanel.ts
@@ -187,7 +187,12 @@ export class XliffEditorPanel {
             xlfDocument.original
         );
         filteredXlf._path = xlfDocument._path;
-        filteredXlf.transunit = xlfDocument.transunit.filter(u => (u.targets[0].translationToken !== undefined) || (u.hasCustomNote(CustomNoteType.RefreshXlfHint) || filter === "all"));
+        if (filter === "differently-translated") {
+            filteredXlf.transunit = xlfDocument.differentlyTranslatedTransunits();//.sort((a, b) => (a.source > b.source) ? 1 : ((b.source > a.source) ? -1 : 0)));
+        } else {
+            filteredXlf.transunit = xlfDocument.transunit.filter(u => (u.targets[0].translationToken !== undefined) || (u.hasCustomNote(CustomNoteType.RefreshXlfHint) || filter === "all"));
+
+        }
         return filteredXlf;
     }
 
@@ -245,9 +250,8 @@ export class XliffEditorPanel {
     xlfTable(xlfDoc: Xliff): string {
         let menu = html.div({ class: "sticky" }, html.table({}, [
             { content: html.button({ id: "btn-reload", title: "Reload file" }, "&#8635 Reload"), a: undefined },
-            { content: html.button({ id: "btn-filter-clear" }, "Show all"), a: undefined },
-            { content: html.button({ id: "btn-filter-review" }, "Show translations in need of review"), a: undefined },
-            { content: `Showing ${xlfDoc.transunit.length} of ${this.totalTransUnitCount} translation units`, a: undefined }
+            { content: dropdownMenu(), a: undefined },
+            { content: `Showing ${xlfDoc.transunit.length} of ${this.totalTransUnitCount} translation units.${html.br()}Filter: ${this.state.filter}`, a: undefined }
         ]));
         let table = menu;
         table += '<table>';
@@ -296,6 +300,17 @@ function getNotesHtml(transunit: TransUnit): string {
     });
 
     return content;
+}
+
+function dropdownMenu(): string {
+    return `<div class="dropdown">
+    ${html.button({ class: "dropbtn" }, "&#8801 Filter")}
+  <div class="dropdown-content">
+    <a href="#">${html.button({ id: "btn-filter-clear", class: "filter-btn" }, "Show all")}</a>
+    <a href="#">${html.button({ id: "btn-filter-review", class: "filter-btn" }, "Show translations in need of review")}</a>
+    <a href="#">${html.button({ id: "btn-filter-differently-translated", class: "filter-btn" }, "Show differently translated")}</a>
+  </div>
+</div> `;
 }
 
 interface EditorState {

--- a/extension/src/XliffEditor/XliffEditorPanel.ts
+++ b/extension/src/XliffEditor/XliffEditorPanel.ts
@@ -188,7 +188,8 @@ export class XliffEditorPanel {
         );
         filteredXlf._path = xlfDocument._path;
         if (filter === "differently-translated") {
-            filteredXlf.transunit = xlfDocument.differentlyTranslatedTransunits();//.sort((a, b) => (a.source > b.source) ? 1 : ((b.source > a.source) ? -1 : 0)));
+            filteredXlf.transunit = xlfDocument.differentlyTranslatedTransunits();
+            filteredXlf.transunit.sort((a, b) => (a.source > b.source) ? 1 : ((b.source > a.source) ? -1 : 0));
         } else {
             filteredXlf.transunit = xlfDocument.transunit.filter(u => (u.targets[0].translationToken !== undefined) || (u.hasCustomNote(CustomNoteType.RefreshXlfHint) || filter === "all"));
 
@@ -285,7 +286,7 @@ function getNonce() {
 function getNotesHtml(transunit: TransUnit): string {
     let content = '';
     if (transunit.targets[0].translationToken && transunit.targets[0].translationToken !== TranslationToken.Suggestion) {
-        // Since all suggestions are listed we don't want to add an extra line just for the sugestion token.
+        // Since all suggestions are listed we don't want to add an extra line just for the suggestion token.
         content += `${transunit.targets[0].translationToken}${html.br(2)}`;
     }
     if (transunit.targets.length > 1) {

--- a/extension/src/test/ExternalResources.test.ts
+++ b/extension/src/test/ExternalResources.test.ts
@@ -13,13 +13,14 @@ suite("External Resources Tests", function () {
     const fullUrl = 'https://nabaltools.file.core.windows.net/shared/base_app_lang_files/sv-se.json?sv=2019-12-12&ss=f&srt=o&sp=r&se=2021-11-25T05:28:10Z&st=2020-11-24T21:28:10Z&spr=https&sig=JP3RwQVCZBo16vJCznojVIMvPOHgnDuH937ppzPmEqQ%3D';
     const sasToken = 'sv=2019-12-12&ss=f&srt=o&sp=r&se=2021-11-25T05:28:10Z&st=2020-11-24T21:28:10Z&spr=https&sig=JP3RwQVCZBo16vJCznojVIMvPOHgnDuH937ppzPmEqQ%3D';
     const baseUrl = 'https://nabaltools.file.core.windows.net/shared/base_app_lang_files/';
+    const TIMEOUT = 10000;
 
     test("ExternalResource.get()", async function () {
         // Only run in GitHub Workflow
         if (!process.env.GITHUB_ACTION) {
             this.skip();
         }
-        this.timeout(10000);
+        this.timeout(TIMEOUT);
         const extResource = new ExternalResource('sv-se.json', href);
         const writeStream = createWriteStream(path.resolve(__dirname, "test.json"), "utf8");
         await extResource.get(writeStream);
@@ -41,7 +42,7 @@ suite("External Resources Tests", function () {
         if (!process.env.GITHUB_ACTION) {
             this.skip();
         }
-        this.timeout(5000);
+        this.timeout(TIMEOUT);
         const exportPath = path.resolve(__dirname);
         let blobContainer = new BlobContainer(exportPath, baseUrl, sasToken);
         blobContainer.addBlob('sv-se.json');

--- a/extension/src/test/ExternalResources.test.ts
+++ b/extension/src/test/ExternalResources.test.ts
@@ -13,7 +13,7 @@ suite("External Resources Tests", function () {
     const fullUrl = 'https://nabaltools.file.core.windows.net/shared/base_app_lang_files/sv-se.json?sv=2019-12-12&ss=f&srt=o&sp=r&se=2021-11-25T05:28:10Z&st=2020-11-24T21:28:10Z&spr=https&sig=JP3RwQVCZBo16vJCznojVIMvPOHgnDuH937ppzPmEqQ%3D';
     const sasToken = 'sv=2019-12-12&ss=f&srt=o&sp=r&se=2021-11-25T05:28:10Z&st=2020-11-24T21:28:10Z&spr=https&sig=JP3RwQVCZBo16vJCznojVIMvPOHgnDuH937ppzPmEqQ%3D';
     const baseUrl = 'https://nabaltools.file.core.windows.net/shared/base_app_lang_files/';
-    const TIMEOUT = 10000;
+    const TIMEOUT = 30000;
 
     test("ExternalResource.get()", async function () {
         // Only run in GitHub Workflow

--- a/extension/src/test/XLIFFTypes.test.ts
+++ b/extension/src/test/XLIFFTypes.test.ts
@@ -224,6 +224,21 @@ suite("Xliff Types - Functions", function () {
     assert.equal(xlf.getTransUnitsBySource('Nope!').length, 0, 'Unexpected number of transunits found');
   });
 
+  test.only("getSameSourceDifferentTarget", function () {
+    const xlf = Xliff.fromString(xliffXmlWithDuplicateSources());
+    let transUnits = xlf.getSameSourceDifferentTarget(xlf.transunit[1]);
+    assert.equal(transUnits.length, 1, "Unexpected number of trans-units returned.");
+  });
+
+  test.only("differentlyTranslatedTransunits", function () {
+    let xlf = Xliff.fromString(xliffXmlWithDuplicateSources());
+    let transUnits = xlf.differentlyTranslatedTransunits();
+    assert.notEqual(transUnits.length, xlf.transunit.length, "Same number of transunit as the total was returned. No bueno!");
+    assert.equal(transUnits.length, 3, "Unexpected number of transunits returned.");
+    const id = transUnits.map(t => { return t.id });
+    assert.equal(id.length, new Set(id).size, "Duplicate trans-units in result");
+  });
+
 });
 
 function GetNoteXml(): string {
@@ -423,11 +438,24 @@ export function xliffXmlWithDuplicateSources(): string {
         <note from="Developer" annotates="general" priority="2"/>
         <note from="Xliff Generator" annotates="general" priority="3">Table MyTable - NamedType TestErr</note>
       </trans-unit>
+      <trans-unit id="Page 22931038265 - NamedType 212557645" size-unit="char" translate="yes" xml:space="preserve">
+        <source>Duplicate</source>
+        <target>This is a test ERROR</target>
+        <note from="Developer" annotates="general" priority="2"/>
+        <note from="Xliff Generator" annotates="general" priority="3">Page MyPage - NamedType TestErr</note>
+      </trans-unit>
       <trans-unit id="Page 2931038265 - NamedType 12557645" size-unit="char" translate="yes" xml:space="preserve">
         <source>Duplicate</source>
         <target>This is a test ERROR</target>
         <note from="Developer" annotates="general" priority="2"/>
         <note from="Xliff Generator" annotates="general" priority="3">Page MyPage - NamedType TestErr</note>
+      </trans-unit>
+      <trans-unit id="Page 596208023 - Control 2961552353 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
+        <source>Tooltup 3</source>
+        <target>[NAB: REVIEW]Tooltup</target>
+        <note from="NAB AL Tool Refresh Xlf" annotates="general" priority="3">Source has been modified.</note>
+        <note from="Developer" annotates="general" priority="2"></note>
+        <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Control Name - Property ToolTip</note>
       </trans-unit>
     </group>
   </body>

--- a/extension/src/test/XLIFFTypes.test.ts
+++ b/extension/src/test/XLIFFTypes.test.ts
@@ -1,5 +1,4 @@
 import * as assert from 'assert';
-import * as os from 'os';
 import { Xliff, TransUnit, Target, Note, TargetState, SizeUnit, CustomNoteType } from '../XLIFFDocument';
 
 suite("Xliff Types - Deserialization", function () {
@@ -23,9 +22,7 @@ suite("Xliff Types - Deserialization", function () {
     ];
     let transUnit2 = new TransUnit('Page 2931038265 - NamedType 12557645', true, 'This is a test ERROR', new Target('This is a test ERROR', null), SizeUnit.char, 'preserve', manualNotes2);
     manualXliff.transunit.push(transUnit2);
-    if (os.platform() !== "linux") {
-      assert.deepEqual(parsedXliff, manualXliff); // Something is up with linux here
-    }
+    assert.deepEqual(parsedXliff, manualXliff);
   });
 
   test("Transunit fromString", function () {
@@ -36,9 +33,11 @@ suite("Xliff Types - Deserialization", function () {
       new Note('Xliff Generator', 'general', 3, 'Table MyTable - NamedType TestErr')
     ];
     let manualTransUnit = new TransUnit('Table 2328808854 - NamedType 12557645', true, 'This is a test ERROR in table', manualTarget, SizeUnit.char, 'preserve', manualNotes);
-    if (os.platform() !== "linux") {
-      assert.equal(parsedTransUnit, manualTransUnit); // Something is up with linux here
-    }
+    // assert.equal(parsedTransUnit, manualTransUnit); // This suddenly broke for some reason yet to be discovered.
+    assert.equal(parsedTransUnit.id, manualTransUnit.id);
+    assert.equal(parsedTransUnit.targets.length, manualTransUnit.targets.length, "Expected same number of targets");
+    assert.equal(parsedTransUnit.targets[0].textContent, manualTransUnit.targets[0].textContent);
+    assert.equal(parsedTransUnit.notes.length, manualTransUnit.notes.length, "Expected same number of notes");
     assert.equal(parsedTransUnit.sizeUnit, SizeUnit.char, 'Unexpected value for attribute size-unit');
     assert.equal(parsedTransUnit.notes.length, 2, 'Unexpected number of notes in trans-unit.');
     assert.equal(parsedTransUnit.translate, true, 'Unexpected value for attribute translate');

--- a/extension/src/test/XLIFFTypes.test.ts
+++ b/extension/src/test/XLIFFTypes.test.ts
@@ -224,13 +224,13 @@ suite("Xliff Types - Functions", function () {
     assert.equal(xlf.getTransUnitsBySource('Nope!').length, 0, 'Unexpected number of transunits found');
   });
 
-  test.only("getSameSourceDifferentTarget", function () {
+  test("getSameSourceDifferentTarget", function () {
     const xlf = Xliff.fromString(xliffXmlWithDuplicateSources());
     let transUnits = xlf.getSameSourceDifferentTarget(xlf.transunit[1]);
     assert.equal(transUnits.length, 1, "Unexpected number of trans-units returned.");
   });
 
-  test.only("differentlyTranslatedTransunits", function () {
+  test("differentlyTranslatedTransunits", function () {
     let xlf = Xliff.fromString(xliffXmlWithDuplicateSources());
     let transUnits = xlf.differentlyTranslatedTransunits();
     assert.notEqual(transUnits.length, xlf.transunit.length, "Same number of transunit as the total was returned. No bueno!");

--- a/extension/src/test/XLIFFTypes.test.ts
+++ b/extension/src/test/XLIFFTypes.test.ts
@@ -210,6 +210,20 @@ suite("Xliff Types - Functions", function () {
     assert.equal(xlfNoTranslationTokens.translationTokensExists(), false, "Expected xliff not to have translation tokens.");
   });
 
+  test("Xliff.sourceHasDuplicates()", function () {
+    let xlf = Xliff.fromString(xliffXmlWithDuplicateSources());
+    assert.equal(xlf.sourceHasDuplicates('Duplicate'), true, 'Expected duplicate to be found');
+    assert.equal(xlf.sourceHasDuplicates('Nope!'), false, 'Unexpected duplicate found');
+    xlf = Xliff.fromString(getSmallXliffXml());
+    assert.equal(xlf.sourceHasDuplicates('This is a test ERROR in table'), false, 'Unexpected duplicate found');
+  });
+
+  test("Xliff.getTransUnitsBySource()", function () {
+    let xlf = Xliff.fromString(xliffXmlWithDuplicateSources());
+    assert.equal(xlf.getTransUnitsBySource('Duplicate').length, 2, 'Expected 2 transunits to be found');
+    assert.equal(xlf.getTransUnitsBySource('Nope!').length, 0, 'Unexpected number of transunits found');
+  });
+
 });
 
 function GetNoteXml(): string {
@@ -394,5 +408,29 @@ function xlfWithCustomNotes(): string {
       </group>
     </body>
   </file>
+</xliff>`;
+}
+
+export function xliffXmlWithDuplicateSources(): string {
+  return `<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+<file datatype="xml" source-language="en-US" target-language="sv-SE" original="AlTestApp">
+  <body>
+    <group id="body">
+      <trans-unit id="Table 2328808854 - NamedType 12557645" size-unit="char" translate="yes" xml:space="preserve">
+        <source>Duplicate</source>
+        <target>This is a test ERROR in table</target>
+        <note from="Developer" annotates="general" priority="2"/>
+        <note from="Xliff Generator" annotates="general" priority="3">Table MyTable - NamedType TestErr</note>
+      </trans-unit>
+      <trans-unit id="Page 2931038265 - NamedType 12557645" size-unit="char" translate="yes" xml:space="preserve">
+        <source>Duplicate</source>
+        <target>This is a test ERROR</target>
+        <note from="Developer" annotates="general" priority="2"/>
+        <note from="Xliff Generator" annotates="general" priority="3">Page MyPage - NamedType TestErr</note>
+      </trans-unit>
+    </group>
+  </body>
+</file>
 </xliff>`;
 }

--- a/extension/src/test/XLIFFTypes.test.ts
+++ b/extension/src/test/XLIFFTypes.test.ts
@@ -33,7 +33,7 @@ suite("Xliff Types - Deserialization", function () {
       new Note('Xliff Generator', 'general', 3, 'Table MyTable - NamedType TestErr')
     ];
     let manualTransUnit = new TransUnit('Table 2328808854 - NamedType 12557645', true, 'This is a test ERROR in table', manualTarget, SizeUnit.char, 'preserve', manualNotes);
-    // assert.equal(parsedTransUnit, manualTransUnit); // This suddenly broke for some reason yet to be discovered.
+    assert.deepEqual(parsedTransUnit, manualTransUnit);
     assert.equal(parsedTransUnit.id, manualTransUnit.id);
     assert.equal(parsedTransUnit.targets.length, manualTransUnit.targets.length, "Expected same number of targets");
     assert.equal(parsedTransUnit.targets[0].textContent, manualTransUnit.targets[0].textContent);

--- a/extension/src/test/XLIFFTypes.test.ts
+++ b/extension/src/test/XLIFFTypes.test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert';
+import * as os from 'os';
 import { Xliff, TransUnit, Target, Note, TargetState, SizeUnit, CustomNoteType } from '../XLIFFDocument';
 
 suite("Xliff Types - Deserialization", function () {
@@ -22,7 +23,9 @@ suite("Xliff Types - Deserialization", function () {
     ];
     let transUnit2 = new TransUnit('Page 2931038265 - NamedType 12557645', true, 'This is a test ERROR', new Target('This is a test ERROR', null), SizeUnit.char, 'preserve', manualNotes2);
     manualXliff.transunit.push(transUnit2);
-    assert.deepEqual(parsedXliff, manualXliff);
+    if (os.platform() !== "linux") {
+      assert.deepEqual(parsedXliff, manualXliff); // Something is up with linux here
+    }
   });
 
   test("Transunit fromString", function () {
@@ -33,7 +36,9 @@ suite("Xliff Types - Deserialization", function () {
       new Note('Xliff Generator', 'general', 3, 'Table MyTable - NamedType TestErr')
     ];
     let manualTransUnit = new TransUnit('Table 2328808854 - NamedType 12557645', true, 'This is a test ERROR in table', manualTarget, SizeUnit.char, 'preserve', manualNotes);
-    assert.deepEqual(parsedTransUnit, manualTransUnit);
+    if (os.platform() !== "linux") {
+      assert.equal(parsedTransUnit, manualTransUnit); // Something is up with linux here
+    }
     assert.equal(parsedTransUnit.sizeUnit, SizeUnit.char, 'Unexpected value for attribute size-unit');
     assert.equal(parsedTransUnit.notes.length, 2, 'Unexpected number of notes in trans-unit.');
     assert.equal(parsedTransUnit.translate, true, 'Unexpected value for attribute translate');
@@ -220,7 +225,7 @@ suite("Xliff Types - Functions", function () {
 
   test("Xliff.getTransUnitsBySource()", function () {
     let xlf = Xliff.fromString(xliffXmlWithDuplicateSources());
-    assert.equal(xlf.getTransUnitsBySource('Duplicate').length, 2, 'Expected 2 transunits to be found');
+    assert.equal(xlf.getTransUnitsBySource('Duplicate').length, 3, 'Expected 2 transunits to be found');
     assert.equal(xlf.getTransUnitsBySource('Nope!').length, 0, 'Unexpected number of transunits found');
   });
 

--- a/extension/src/test/XLIFFTypes.test.ts
+++ b/extension/src/test/XLIFFTypes.test.ts
@@ -45,6 +45,14 @@ suite("Xliff Types - Deserialization", function () {
     assert.equal(parsedTransUnit.source, 'This is a test ERROR in table', 'Unexpected textContent in source element');
   });
 
+
+  test("Transunit - get properties", function () {
+    let transUnit = TransUnit.fromString(GetTransUnitXml());
+    assert.equal(transUnit.targetTextContent, transUnit.targets[0].textContent, "targetTextContent should equal the first element of TransUnitTargets.");
+    assert.equal(transUnit.targetState, TargetState.New, "Unexpected state");
+    assert.equal(transUnit.targetTranslationToken, "", "Expected translation token to be empty string");
+  });
+
   test("Target with state fromString", function () {
     let parsedTarget = Target.fromString(GetTargetXml());
     let manualTarget = new Target('This is a test ERROR in table', TargetState.Final);

--- a/extension/src/test/XliffEditor.test.ts
+++ b/extension/src/test/XliffEditor.test.ts
@@ -1,0 +1,22 @@
+import * as assert from 'assert';
+import * as html from '../XliffEditor/HTML';
+
+suite("Xliff Editor Tests", function () {
+
+
+    test("html.attributeString()", async function () {
+        const attributes: html.HTMLAttributes = {
+            id: "test-id",
+            class: "test-class",
+            name: "test-name",
+            onClick: "testOnClick()",
+            type: "text",
+            checked: true,
+            disabled: true,
+            title: "cool title",
+            align: "center",
+        };
+        assert.equal(html.attributeString(attributes), `id="test-id" class="test-class" name="test-name" onClick="testOnClick()" type="text" checked disabled title="cool title" align="center"`, "Unexpted attribute string");
+    });
+
+});


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
Fixes #13 

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- Filter and display transunits with matching source and different translations.
- Move focus with arrow up / down.
- copy value with `F8`

Additional comments:

Adds new properties to class `TransUnit` that returns value from `Target[0]` or empty string if null or undefined.
- `targetTextContent`
- `targetState`
- `targetTranslationToken`
