### PR TITLE
#131 Setting for TimeStampServer

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -48,6 +48,7 @@ We're out of preview no more beta!
       - `NAB.DocsIgnorePaths` - When documentation are created from al files, the files that matches the patterns specified in this setting will be ignored. The paths should use glob pattern.
       - `NAB.GenerateDeprecatedFeaturesPageWithExternalDocs` - When creating external documentation, this setting specifies if a page with public obsoleted objects/procedures/controls should be created.
 - Fixed issues
+  - `NAB: Sign App File` failed since the timestamp server http://timestamp.verisign.com/ does not work anymore. This is solved by a ny setting, `NAB.SigningTimeStampServer`, where you can setup any TimeStampServer, or just use the new default one: `http://timestamp.digicert.com`
   - `NAB: Find code source of current line` did not work in some cases, [issue 93](https://github.com/jwikman/nab-al-tools/issues/93)
   - `NAB: Find Next Untranslated` now cleans up missed notes ("NAB AL Tool Refresh Xlf") that could be left behind if the refresh function wasn't run again.
   - `NAB: Find Next Untranslated` also presents any occurence of multiple targets in the .xlf file.

--- a/extension/README.md
+++ b/extension/README.md
@@ -325,6 +325,7 @@ This extension contributes the following settings:
 * `NAB.SearchOnlyXlfFiles`: If enabled, the `NAB:Find Untranslated texts` function only searches \*.xlf files. Be aware of that the \*.xlf file filter remains in "Find in Files" after this command has been run. This should be enabled in large projects (as Base Application) for performance reasons.
 * `NAB.SigningCertificateName`: The name of the certificate used to sing app files. The certificate needs to be installed to the Personal store. For instructions on how to install the pfx certificate in the Personal Store, go to [Microsoft Docs](https://docs.microsoft.com/windows-hardware/drivers/install/importing-an-spc-into-a-certificate-store).
 * `NAB.SignToolPath`: The full path to signtool.exe, used for signing app files. If this is not set the extension tries to find it on the default locations, if the signtool.exe is not found it tries to download and install signtool.
+* `NAB.SigningTimeStampServer`: Setup any TimeStampServer to be used when signing app files, or just use the new default one: `http://timestamp.digicert.com`
 
 ## Contributing
 

--- a/extension/src/Settings.ts
+++ b/extension/src/Settings.ts
@@ -10,6 +10,7 @@ export enum Setting {
     LaunchServer,
     LaunchServerInstance,
     ConfigSigningCertificateName,
+    ConfigSigningTimeStampServer,
     ConfigSignToolPath,
     ConfigPowerShellWithDocker,
     ShowXlfHighlights,
@@ -51,6 +52,7 @@ export class Settings {
         this.config = vscode.workspace.getConfiguration(this.WORKSPACEKEY, WorkspaceFiles.getWorkspaceFolder(ResourceUri).uri);
         this.SettingCollection[Setting.ConfigSignToolPath] = this.config.get('SignToolPath') + '';
         this.SettingCollection[Setting.ConfigSigningCertificateName] = this.config.get('SigningCertificateName') + '';
+        this.SettingCollection[Setting.ConfigSigningTimeStampServer] = this.config.get('SigningTimeStampServer') + '';
         this.SettingCollection[Setting.ConfigPowerShellWithDocker] = this.config.get('PowerShellWithDocker');
         this.SettingCollection[Setting.ShowXlfHighlights] = this.config.get('ShowXlfHighlights');
         this.SettingCollection[Setting.XlfHighlightsDecoration] = this.config.get('XlfHighlightsDecoration');


### PR DESCRIPTION
Fixes #131 with a new setting, `NAB.SigningTimeStampServer`.

Changes default TimeStamp server to http://timestamp.digicert.com


