### PR TITLE
Dynamics LCS support

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -10,6 +10,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+- New features:
+  - A new setting can be used to set the Target State when importing translations from a .csv file, `NAB.Xliff CSV Import Target State`. There are basically three type of options: Leave the State as-is, update the State from the .csv file or set the State to a configured value for all modified targets.
 - Fixed:
   - When executing any of the `NAB: XML Comment - Format` functions without a selection, the cursor will now be placed inside the added formatting tag.
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -369,6 +369,8 @@ Page 2931038265 - NamedType 12557645    Cool    Sval                Page MyPage 
 
 Imports and updates targets in translation units (`trans-unit` elements) of selected XLF file from a .csv file.
 
+If the the app is configured to use an external translation tool (i.e. working with Target State attribute): Use the setting `NAB.Xliff CSV Import Target State` to configure how Target State should be handled during import. There are basically three type of options: Leave the State as-is, update the State from the .csv file or set the State to a configured value for all modified targets.
+
 **Requirements of the .csv file:**
 
 1. Column order must match the exported column order of `NAB: Export Translations to .csv`.
@@ -422,7 +424,8 @@ This extension contributes the following settings:
 * `NAB.SigningCertificateName`: The name of the certificate used to sing app files. The certificate needs to be installed to the Personal store. For instructions on how to install the pfx certificate in the Personal Store, go to [Microsoft Docs](https://docs.microsoft.com/windows-hardware/drivers/install/importing-an-spc-into-a-certificate-store).
 * `NAB.SignToolPath`: The full path to signtool.exe, used for signing app files. If this is not set the extension tries to find it on the default locations, if the signtool.exe is not found it tries to download and install signtool.
 * `NAB.SigningTimeStampServer`: Setup any TimeStampServer to be used when signing app files, or just use the new default one: `http://timestamp.digicert.com`
-* `NAB.Xliff CSV Export Path` sets the export path for `NAB: Export Translations to .csv`. Default path for export is the Translation file directory.
+* `NAB.Xliff CSV Export Path`: sets the export path for `NAB: Export Translations to .csv`. Default path for export is the Translation file directory.
+* `NAB.Xliff CSV Import Target State` Sets how the Target State property should be set when importing from a .csv file into a XLIFF file. Only the State of Targets that has been changed will get updated. This will setting will only be in effect when the setting `NAB.UseExternalTranslationTool` is enabled.
 
 ## Contributing
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -418,6 +418,40 @@
                     "default": "",
                     "description": "When exporting Xliff as .csv this setting specifies where the files will be created.",
                     "scope": "resource"
+                },
+                "NAB.Xliff CSV Import Target State": {
+                    "type": "string",
+                    "default": "translated",
+                    "description": "Sets how the Target State property should be set when importing from a .csv file into a XLIFF file. Only the State of Targets that has been changed will get updated. This will setting will only be in effect when the setting `Use External Translation Tool` is enabled.",
+                    "scope": "resource",
+                    "enum": [
+                        "(leave)",
+                        "(from csv)",
+                        "translated",
+                        "new",
+                        "final",
+                        "needs-review-translation",
+                        "needs-translation",
+                        "needs-adaptation",
+                        "needs-l10n",
+                        "needs-review-adaptation",
+                        "needs-review-l10n",
+                        "signed-off"
+                    ],
+                    "enumDescriptions": [
+                        "Do not change the Target State",
+                        "Sets the Target State from the CSV file",
+                        "Sets the Target State to 'translated'",
+                        "Sets the Target State to 'new'",
+                        "Sets the Target State to 'final'",
+                        "Sets the Target State to 'needs-review-translation'",
+                        "Sets the Target State to 'needs-translation'",
+                        "Sets the Target State to 'needs-adaptation'",
+                        "Sets the Target State to 'needs-l10n'",
+                        "Sets the Target State to 'needs-review-adaptation'",
+                        "Sets the Target State to 'needs-review-l10n'",
+                        "Sets the Target State to 'signed-off'"
+                    ]
                 }
             }
         }

--- a/extension/src/CSV/CSV.ts
+++ b/extension/src/CSV/CSV.ts
@@ -31,6 +31,15 @@ export class CSV {
         return path.join(this.path, this.filename);
     }
 
+    public get headerIndexMap(): Map<string, number> {
+        let headerMap = new Map<string, number>();
+        for (let index = 0; index < this.headers.length; index++) {
+            const header = this.headers[index];
+            headerMap.set(header, index);
+        }
+        return headerMap;
+    }
+
     public addLine(line: string[]) {
         this.lines.push(line);
     }

--- a/extension/src/CSV/ExportXliffCSV.ts
+++ b/extension/src/CSV/ExportXliffCSV.ts
@@ -26,7 +26,7 @@ export function createXliffCSV(xlf: Xliff): CSV {
         csv.addLine([
             tu.id,
             checkNoInvalidCharacters(tu.source, csv.headers[1], tu.id),
-            checkNoInvalidCharacters(tu.targetTextContent, csv.headers[2], tu.id),
+            checkNoInvalidCharacters(tu.target.textContent, csv.headers[2], tu.id),
             isNullOrUndefined(developerNote?.textContent) ? "" : checkNoInvalidCharacters(developerNote.textContent, csv.headers[3], tu.id),
             isNullOrUndefined(tu.maxwidth) ? "" : tu.maxwidth.toString(),
             "", // comment

--- a/extension/src/CSV/ImportXliffCSV.ts
+++ b/extension/src/CSV/ImportXliffCSV.ts
@@ -15,8 +15,8 @@ export function importXliffCSV(updateXlf: Xliff, csvPath: string): number {
         if (transunit.source !== values.source) {
             throw new Error(`Sources doesn't match for id ${transunit.id}.\nExisting Source: "${transunit.source}".\nImported source: "${values.source}"`);
         }
-        if (transunit.targetTextContent !== values.target) {
-            transunit.targets[0].textContent = values.target;
+        if (transunit.target.textContent !== values.target) {
+            transunit.target.textContent = values.target;
             updatedTargets++;
         }
     });

--- a/extension/src/CSV/ImportXliffCSV.ts
+++ b/extension/src/CSV/ImportXliffCSV.ts
@@ -1,9 +1,11 @@
-import { Xliff } from "../XLIFFDocument";
+import { Setting, Settings } from "../Settings";
+import { CustomNoteType, TargetState, Xliff } from "../XLIFFDocument";
 import { CSV } from "./CSV";
 
 const requiredHeaders: string[] = ["Id", "Source", "Target"];
 
 export function importXliffCSV(updateXlf: Xliff, csvPath: string): number {
+    const useExternalTranslationTool = Settings.getConfigSettings()[Setting.UseExternalTranslationTool];
     let updatedTargets: number = 0;
     let csv = new CSV();
     csv.encoding = "utf8bom";
@@ -17,6 +19,11 @@ export function importXliffCSV(updateXlf: Xliff, csvPath: string): number {
         }
         if (transunit.target.textContent !== values.target) {
             transunit.target.textContent = values.target;
+            if (useExternalTranslationTool) {
+                transunit.target.stateQualifier = undefined;
+                transunit.target.state = TargetState.Translated; // TODO: when import column mapping is fixed in  more flexible way -> Setting for State after import: Translated (default), From CSV, Leave, A fixed configured TargetState
+            }
+            transunit.removeCustomNote(CustomNoteType.RefreshXlfHint);
             updatedTargets++;
         }
     });

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -284,15 +284,15 @@ export async function __refreshXlfFilesFromGXlf(gXlfFilePath: vscode.Uri, langFi
                     numberOfAddedTransUnitElements++;
                 }
                 if (langTransUnit.source !== gTransUnit.source) {
-                    if (langIsSameAsGXlf && langTransUnit.targets.length === 1 && langTransUnit.targets[0].textContent === langTransUnit.source) {
-                        langTransUnit.targets[0].textContent = gTransUnit.source;
+                    if (langIsSameAsGXlf && langTransUnit.targets.length === 1 && langTransUnit.target.textContent === langTransUnit.source) {
+                        langTransUnit.target.textContent = gTransUnit.source;
                     }
                     // Source has changed
                     if (gTransUnit.source !== '') {
                         if (useExternalTranslationTool) {
-                            langTransUnit.targets[0].state = TargetState.NeedsAdaptation;
+                            langTransUnit.target.state = TargetState.NeedsAdaptation;
                         } else {
-                            langTransUnit.targets[0].translationToken = TranslationToken.Review;
+                            langTransUnit.target.translationToken = TranslationToken.Review;
                         }
                         langTransUnit.insertCustomNote(CustomNoteType.RefreshXlfHint, RefreshXlfHint.ModifiedSource);
                     }
@@ -331,7 +331,7 @@ export async function __refreshXlfFilesFromGXlf(gXlfFilePath: vscode.Uri, langFi
             addMapToSuggestionMap(suggestionsMaps, langXliff.targetLanguage, langMatchMap);
         }
         numberOfSuggestionsAdded += matchTranslationsFromTranslationMaps(newLangXliff, suggestionsMaps);
-        newLangXliff.transunit.filter(tu => tu.hasCustomNote(CustomNoteType.RefreshXlfHint) && ((isNullOrUndefined(tu.targets[0].translationToken) && isNullOrUndefined(tu.targets[0].state)) || tu.targets[0].state === 'translated')).forEach(tu => {
+        newLangXliff.transunit.filter(tu => tu.hasCustomNote(CustomNoteType.RefreshXlfHint) && ((isNullOrUndefined(tu.target.translationToken) && isNullOrUndefined(tu.target.state)) || tu.target.state === 'translated')).forEach(tu => {
             tu.removeCustomNote(CustomNoteType.RefreshXlfHint);
             numberOfRemovedNotes++;
         });
@@ -448,7 +448,7 @@ export function matchTranslationsFromTranslationMaps(xlfDocument: Xliff, suggest
 export function matchTranslationsFromTranslationMap(xlfDocument: Xliff, matchMap: Map<string, string[]>): number {
     let numberOfMatchedTranslations = 0;
     let xlf = xlfDocument;
-    xlf.transunit.filter(tu => !tu.hasTargets() || tu.targets[0].translationToken === TranslationToken.NotTranslated).forEach(transUnit => {
+    xlf.transunit.filter(tu => !tu.hasTargets() || tu.target.translationToken === TranslationToken.NotTranslated).forEach(transUnit => {
         let suggestionAdded = false;
         matchMap.get(transUnit.source)?.forEach(target => {
             transUnit.addTarget(new Target(TranslationToken.Suggestion + target));

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -303,8 +303,12 @@ export async function __refreshXlfFilesFromGXlf(gXlfFilePath: vscode.Uri, langFi
                     langTransUnit.maxwidth = gTransUnit.maxwidth;
                     numberOfUpdatedMaxWidths++;
                 }
-                if (langTransUnit.developerNote().textContent !== gTransUnit.developerNote().textContent) {
-                    langTransUnit.developerNote().textContent = gTransUnit.developerNote().textContent;
+                if (langTransUnit.developerNoteContent() !== gTransUnit.developerNoteContent()) {
+                    if (isNullOrUndefined(langTransUnit.developerNote())) {
+                        langTransUnit.notes.push(gTransUnit.developerNote());
+                    } else {
+                        langTransUnit.developerNote().textContent = gTransUnit.developerNote().textContent;
+                    }
                     numberOfUpdatedNotes++;
                 }
                 newLangXliff.transunit.push(langTransUnit);

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -504,6 +504,8 @@ export async function importTranslationCSV() {
     console.log("Running: importTranslationCSV");
     try {
         const replaceSelfClosingXlfTags = Settings.getConfigSettings()[Setting.ReplaceSelfClosingXlfTags]
+        const useExternalTranslationTool: boolean = Settings.getConfigSettings()[Setting.UseExternalTranslationTool];
+        const xliffCSVImportTargetState: string = Settings.getConfigSettings()[Setting.XliffCSVImportTargetState];
         const translationFilePaths = (await WorkspaceFunctions.getLangXlfFiles()).map(t => { return t.fsPath });
         let pickedFile = await getQuickPickResult(translationFilePaths, { canPickMany: false, placeHolder: "Select xlf file to update" });
         let updateXlfFilePath = isArray(pickedFile) ? pickedFile[0] : pickedFile;
@@ -515,7 +517,8 @@ export async function importTranslationCSV() {
             throw new Error("No file selected for import");
         }
         let xlf = Xliff.fromFileSync(updateXlfFilePath);
-        let updatedTransUnits = importXliffCSV(xlf, importCSV[0].fsPath);
+
+        let updatedTransUnits = importXliffCSV(xlf, importCSV[0].fsPath, useExternalTranslationTool, xliffCSVImportTargetState);
         if (updatedTransUnits > 0) {
             xlf.toFileSync(updateXlfFilePath, replaceSelfClosingXlfTags)
 

--- a/extension/src/Settings.ts
+++ b/extension/src/Settings.ts
@@ -32,7 +32,8 @@ export enum Setting {
     DocsIgnorePaths,
     DocsRootPath,
     CreateTocFilesForDocs,
-    XliffCSVExportPath
+    XliffCSVExportPath,
+    XliffCSVImportTargetState
 }
 
 export class Settings {
@@ -75,6 +76,7 @@ export class Settings {
         this.SettingCollection[Setting.DocsIgnorePaths] = this.config.get('DocsIgnorePaths');
         this.SettingCollection[Setting.CreateTocFilesForDocs] = this.config.get('CreateTocFilesForDocs');
         this.SettingCollection[Setting.XliffCSVExportPath] = this.config.get('Xliff CSV Export Path');
+        this.SettingCollection[Setting.XliffCSVImportTargetState] = this.config.get('Xliff CSV Import Target State');
     }
 
     private static _getAppSettings(ResourceUri?: vscode.Uri) {

--- a/extension/src/XLIFFDocument.ts
+++ b/extension/src/XLIFFDocument.ts
@@ -8,6 +8,8 @@ import { XliffDocumentInterface, TransUnitInterface, TargetInterface, NoteInterf
 import { XmlFormattingOptionsFactory, ClassicXmlFormatter } from './XmlFormatter';
 import { isNullOrUndefined } from 'util';
 import * as Common from './Common';
+import { targetStateActionNeededAsList } from './XlfFunctions';
+import { Setting, Settings } from './Settings';
 
 export class Xliff implements XliffDocumentInterface {
     public datatype: string;
@@ -311,6 +313,20 @@ export class TransUnit implements TransUnitInterface {
     get targetStateQualifier(): string { return isNullOrUndefined(this.targets[0].stateQualifier) ? "" : this.targets[0].stateQualifier; }
     get targetTranslationToken(): string { return isNullOrUndefined(this.targets[0].translationToken) ? "" : this.targets[0].translationToken; }
 
+    public get target(): Target {
+        if (this.targets.length = 0) {
+            return new Target('');
+        }
+        return this.targets[0];
+    }
+    public set target(newTarget: Target) {
+        if (this.targets.length = 0) {
+            this.targets.push(newTarget)
+        } else {
+            this.targets[0] = newTarget;
+        }
+    }
+
     static fromString(xml: string): TransUnit {
         let dom = xmldom.DOMParser;
         let transUnit = new dom().parseFromString(xml).getElementsByTagName('trans-unit')[0];
@@ -447,6 +463,13 @@ export class TransUnit implements TransUnitInterface {
 
     public hasTranslationToken(): boolean {
         return this.targets.filter(t => !isNullOrUndefined(t.translationToken)).length > 0;
+    }
+
+    public needsReview(): boolean {
+        const useExternalTranslationTool = Settings.getConfigSettings()[Setting.UseExternalTranslationTool];
+        return (this.targets[0].translationToken !== undefined) ||
+            (this.hasCustomNote(CustomNoteType.RefreshXlfHint)) ||
+            (useExternalTranslationTool && !isNullOrUndefined(this.targetState) && targetStateActionNeededAsList().includes(this.targetState));
     }
 }
 

--- a/extension/src/XLIFFDocument.ts
+++ b/extension/src/XLIFFDocument.ts
@@ -376,7 +376,7 @@ export class TransUnit implements TransUnitInterface {
                 transUnit.appendChild(t.toElement());
             });
         }
-        this.notes.forEach(n => {
+        this.notes.sort((a, b) => a.priority - b.priority).forEach(n => {
             transUnit.appendChild(n.toElement());
         });
         return transUnit;
@@ -425,12 +425,24 @@ export class TransUnit implements TransUnitInterface {
     public customNote(customNoteType: CustomNoteType) {
         return this.notes.filter(x => x.from === customNoteType)[0];
     }
+    public customNoteContent(customNoteType: CustomNoteType) {
+        const note = this.customNote(customNoteType);
+        return note ? note.textContent : '';
+    }
 
     public developerNote() {
         return this.notes.filter(x => x.from === 'Developer')[0];
     }
+    public developerNoteContent() {
+        const note = this.developerNote();
+        return note ? note.textContent : '';
+    }
     public xliffGeneratorNote() {
         return this.notes.filter(x => x.from === 'Xliff Generator')[0];
+    }
+    public xliffGeneratorNoteContent() {
+        const note = this.xliffGeneratorNote();
+        return note ? note.textContent : '';
     }
 
     public hasTranslationToken(): boolean {

--- a/extension/src/XLIFFDocument.ts
+++ b/extension/src/XLIFFDocument.ts
@@ -173,11 +173,11 @@ export class Xliff implements XliffDocumentInterface {
         let transMap = new Map<string, string[]>();
         this.transunit.filter(tu => tu.targetsHasTextContent()).forEach(unit => {
             if (!transMap.has(unit.source)) {
-                transMap.set(unit.source, [unit.targets[0].textContent]);
+                transMap.set(unit.source, [unit.target.textContent]);
             } else {
                 let mapElements = transMap.get(unit.source);
-                if (!mapElements?.includes(unit.targets[0].textContent)) {
-                    mapElements?.push(unit.targets[0].textContent);
+                if (!mapElements?.includes(unit.target.textContent)) {
+                    mapElements?.push(unit.target.textContent);
                 }
                 if (!isNullOrUndefined(mapElements)) {
                     transMap.set(unit.source, mapElements);
@@ -205,7 +205,7 @@ export class Xliff implements XliffDocumentInterface {
      * @returns TransUnit[]
      */
     public getSameSourceDifferentTarget(transUnit: TransUnit): TransUnit[] {
-        return this.transunit.filter(t => ((t.source === transUnit.source) && (t.targetTextContent !== transUnit.targetTextContent)));
+        return this.transunit.filter(t => ((t.source === transUnit.source) && (t.target.textContent !== transUnit.target.textContent)));
     }
 
     /**
@@ -308,19 +308,18 @@ export class TransUnit implements TransUnitInterface {
         this.alObjectTarget = alObjectTarget;
     }
 
-    get targetTextContent(): string { return isNullOrUndefined(this.targets[0]) ? "" : this.targets[0].textContent; }
-    get targetState(): string { return isNullOrUndefined(this.targets[0].state) ? "" : this.targets[0].state; }
-    get targetStateQualifier(): string { return isNullOrUndefined(this.targets[0].stateQualifier) ? "" : this.targets[0].stateQualifier; }
-    get targetTranslationToken(): string { return isNullOrUndefined(this.targets[0].translationToken) ? "" : this.targets[0].translationToken; }
+    get targetState(): string { return isNullOrUndefined(this.target.state) ? "" : this.target.state; }
+    get targetStateQualifier(): string { return isNullOrUndefined(this.target.stateQualifier) ? "" : this.target.stateQualifier; }
+    get targetTranslationToken(): string { return isNullOrUndefined(this.target.translationToken) ? "" : this.target.translationToken; }
 
     public get target(): Target {
-        if (this.targets.length = 0) {
+        if (this.targets.length === 0) {
             return new Target('');
         }
         return this.targets[0];
     }
     public set target(newTarget: Target) {
-        if (this.targets.length = 0) {
+        if (this.targets.length === 0) {
             this.targets.push(newTarget)
         } else {
             this.targets[0] = newTarget;
@@ -467,7 +466,7 @@ export class TransUnit implements TransUnitInterface {
 
     public needsReview(): boolean {
         const useExternalTranslationTool = Settings.getConfigSettings()[Setting.UseExternalTranslationTool];
-        return (this.targets[0].translationToken !== undefined) ||
+        return (this.target.translationToken !== undefined) ||
             (this.hasCustomNote(CustomNoteType.RefreshXlfHint)) ||
             (useExternalTranslationTool && !isNullOrUndefined(this.targetState) && targetStateActionNeededAsList().includes(this.targetState));
     }

--- a/extension/src/XlfFunctions.ts
+++ b/extension/src/XlfFunctions.ts
@@ -10,7 +10,7 @@ export function targetStateActionNeededToken(): string {
         `state="${escapeStringRegexp(TargetState.NeedsTranslation)}"|` +
         `state="${escapeStringRegexp(TargetState.New)}"`;
 }
-function targetStateActionNeededAsList(): string[] {
+export function targetStateActionNeededAsList(): string[] {
     return [
         TargetState.NeedsAdaptation,
         TargetState.NeedsL10n,

--- a/extension/src/XliffEditor/XliffEditorPanel.ts
+++ b/extension/src/XliffEditor/XliffEditorPanel.ts
@@ -297,11 +297,13 @@ function getNotesHtml(transunit: TransUnit): string {
     const useExternalTranslationTool = Settings.getConfigSettings()[Setting.UseExternalTranslationTool];
     let content = '';
     if (useExternalTranslationTool) {
-        content += `${transunit.targetState}`;
-        if (transunit.targetStateQualifier !== '') {
-            content += ` - ${transunit.targetStateQualifier}`;
+        if (transunit.targetState !== TargetState.Translated) {
+            content += `${transunit.targetState}`;
+            if (transunit.targetStateQualifier !== '') {
+                content += ` - ${transunit.targetStateQualifier}`;
+            }
+            content += `${html.br(2)}`;
         }
-        content += `${html.br(2)}`;
     }
     if (transunit.target.translationToken && transunit.target.translationToken !== TranslationToken.Suggestion) {
         // Since all suggestions are listed we don't want to add an extra line just for the suggestion token.

--- a/extension/src/XliffEditor/XliffEditorPanel.ts
+++ b/extension/src/XliffEditor/XliffEditorPanel.ts
@@ -302,7 +302,7 @@ function getNotesHtml(transunit: TransUnit): string {
             if (transunit.targetStateQualifier !== '') {
                 content += ` - ${transunit.targetStateQualifier}`;
             }
-            content += `${html.br(2)}`;
+            content += html.br(2);
         }
     }
     if (transunit.target.translationToken && transunit.target.translationToken !== TranslationToken.Suggestion) {
@@ -310,8 +310,8 @@ function getNotesHtml(transunit: TransUnit): string {
         content += `${transunit.target.translationToken}${html.br(2)}`;
     }
     if (transunit.targets.length > 1) {
-        transunit.targets.slice(1).forEach(trgt => {
-            content += `${trgt.translationToken} ${trgt.textContent}${html.br()}`;
+        transunit.targets.slice(1).forEach(target => {
+            content += `${target.translationToken} ${target.textContent}${html.br()}`;
         });
     }
     transunit.notes?.forEach(note => {

--- a/extension/src/test/CSV.test.ts
+++ b/extension/src/test/CSV.test.ts
@@ -13,11 +13,11 @@ suite("CSV Import / Export Tests", function () {
     let csv = createXliffCSV(xlf);
     assert.equal(csv.headers.length, 10, "unexpected number of header columns");
     assert.equal(csv.lines.length, 2, "Unexpected number of lines");
-    assert.equal(csv.lines[0].length, 10, "Undexpected number of columns on line 0");
+    assert.equal(csv.lines[0].length, 10, "Unexpected number of columns on line 0");
     assert.equal(csv.lines[0].filter(col => col === "").length, 1, "Expected only one empty column for line 0 (Comment).");
-    assert.equal(csv.lines[1].length, 10, "Undexpected number of columns on line 1");
+    assert.equal(csv.lines[1].length, 10, "Unexpected number of columns on line 1");
     let csvAsText = csv.toString();
-    assert.equal(csvAsText.split("\r\n").length, csv.lines.length + 1, "Unexpexted number of exported lines.");
+    assert.equal(csvAsText.split("\r\n").length, csv.lines.length + 1, "Unexpected number of exported lines.");
   });
 
   test("ExportXliffCSV.exportXliffCSV()", async function () {

--- a/extension/src/test/CSV.test.ts
+++ b/extension/src/test/CSV.test.ts
@@ -32,10 +32,10 @@ suite("CSV Import / Export Tests", function () {
     let exportPath = path.resolve(__dirname, testResourcesPath, "temp");
     let importPath = path.resolve(exportPath, `${name}.csv`);
     let csv = exportXliffCSV(exportPath, name, xlf);
-    assert.equal(importXliffCSV(xlf, importPath), 0, "Expected no changes in xlf");
+    assert.equal(importXliffCSV(xlf, importPath, false, '(leave)'), 0, "Expected no changes in xlf");
     csv.lines[1][2] = "Cool";
     csv.writeFileSync();
-    assert.equal(importXliffCSV(xlf, importPath), 1, "Expected 1 change in xlf");
+    assert.equal(importXliffCSV(xlf, importPath, false, '(leave)'), 1, "Expected 1 change in xlf");
   });
 });
 

--- a/extension/src/test/LanguageFunctions.test.ts
+++ b/extension/src/test/LanguageFunctions.test.ts
@@ -553,17 +553,17 @@ suite("Language Functions Tests", function () {
     assert.equal(matchResult, 2, 'NumberOfMatchedTranslations should equal 2');
     assert.notEqual(xlfDoc.transunit[0].targets.length, 0, 'No targets in trans-unit.');
     if (!isNullOrUndefined(xlfDoc.transunit[0].targets)) {
-      assert.equal(xlfDoc.transunit[0].targets[0].textContent, 'Has Token', 'Unexpected textContent');
+      assert.equal(xlfDoc.transunit[0].target.textContent, 'Has Token', 'Unexpected textContent');
     } else { assert.fail('transunit[0]: No target found.'); }
     if (!isNullOrUndefined(xlfDoc.transunit[1].targets)) {
-      assert.equal(xlfDoc.transunit[1].targets[0].textContent, 'Has Token', 'Unexpected textConstant');
-      assert.equal(xlfDoc.transunit[1].targets[0].translationToken, TranslationToken.Suggestion, 'Expected token [NAB: SUGGESTION]');
+      assert.equal(xlfDoc.transunit[1].target.textContent, 'Has Token', 'Unexpected textConstant');
+      assert.equal(xlfDoc.transunit[1].target.translationToken, TranslationToken.Suggestion, 'Expected token [NAB: SUGGESTION]');
     } else {
       assert.fail('transunit[1]: No target found.');
     }
     if (!isNullOrUndefined(xlfDoc.transunit[2].targets)) {
-      assert.equal(xlfDoc.transunit[2].targets[0].textContent, 'Has Token', 'Unexpected textConstant 2');
-      assert.equal(xlfDoc.transunit[2].targets[0].translationToken, TranslationToken.Suggestion, 'Expected token [NAB: SUGGESTION] 2');
+      assert.equal(xlfDoc.transunit[2].target.textContent, 'Has Token', 'Unexpected textConstant 2');
+      assert.equal(xlfDoc.transunit[2].target.translationToken, TranslationToken.Suggestion, 'Expected token [NAB: SUGGESTION] 2');
     } else {
       assert.fail('transunit[2]: No target found.');
     }
@@ -571,15 +571,15 @@ suite("Language Functions Tests", function () {
     matchResult = LanguageFunctions.matchTranslations(xlfDoc);
     assert.equal(matchResult, 0, 'NumberOfMatchedTranslations should equal 0');
     if (!isNullOrUndefined(xlfDoc.transunit[0].targets)) {
-      assert.equal(xlfDoc.transunit[0].targets[0].textContent, 'Has Token', 'Unexpected textConstant 0');
-      assert.equal(xlfDoc.transunit[0].targets[0].translationToken, TranslationToken.Suggestion, 'Expected token [NAB: SUGGESTION] 0');
+      assert.equal(xlfDoc.transunit[0].target.textContent, 'Has Token', 'Unexpected textConstant 0');
+      assert.equal(xlfDoc.transunit[0].target.translationToken, TranslationToken.Suggestion, 'Expected token [NAB: SUGGESTION] 0');
     } else {
       assert.fail('transunit[0]: No target found.');
     }
     assert.notEqual(xlfDoc.transunit[1].targets.length, 0, 'No targets in trans-unit.');
     if (!isNullOrUndefined(xlfDoc.transunit[1].targets)) {
-      assert.equal(xlfDoc.transunit[1].targets[0].textContent, 'No Token', 'Unexpected textContent 3');
-      assert.equal(isNullOrUndefined(xlfDoc.transunit[1].targets[0].translationToken), true, 'Unexpected token 3');
+      assert.equal(xlfDoc.transunit[1].target.textContent, 'No Token', 'Unexpected textContent 3');
+      assert.equal(isNullOrUndefined(xlfDoc.transunit[1].target.translationToken), true, 'Unexpected token 3');
     } else {
       assert.fail('transunit[1]: No target found.');
     }
@@ -602,8 +602,8 @@ suite("Language Functions Tests", function () {
     assert.notEqual(xlfDoc.transunit[0].targets.length, 0, 'No targets in trans-unit.');
     assert.equal(xlfDoc.transunit[0].targets.length, 3, 'Expected 3 targets.');
     if (!isNullOrUndefined(xlfDoc.transunit[0].targets)) {
-      assert.equal(xlfDoc.transunit[0].targets[0].textContent, 'Tillstånd', 'Unexpected textContent 0');
-      assert.equal(xlfDoc.transunit[0].targets[0].translationToken, TranslationToken.Suggestion, 'Unexpected token 0');
+      assert.equal(xlfDoc.transunit[0].target.textContent, 'Tillstånd', 'Unexpected textContent 0');
+      assert.equal(xlfDoc.transunit[0].target.translationToken, TranslationToken.Suggestion, 'Unexpected token 0');
       assert.equal(xlfDoc.transunit[0].targets[1].textContent, 'Status', 'Unexpected textContent 1');
       assert.equal(xlfDoc.transunit[0].targets[1].translationToken, TranslationToken.Suggestion, 'Unexpected token 1');
       assert.equal(xlfDoc.transunit[0].targets[2].textContent, 'Delstat', 'Unexpected textContent 2');

--- a/extension/src/test/XLIFFTypes.test.ts
+++ b/extension/src/test/XLIFFTypes.test.ts
@@ -36,7 +36,7 @@ suite("Xliff Types - Deserialization", function () {
     assert.deepEqual(parsedTransUnit, manualTransUnit);
     assert.equal(parsedTransUnit.id, manualTransUnit.id);
     assert.equal(parsedTransUnit.targets.length, manualTransUnit.targets.length, "Expected same number of targets");
-    assert.equal(parsedTransUnit.targets[0].textContent, manualTransUnit.targets[0].textContent);
+    assert.equal(parsedTransUnit.target.textContent, manualTransUnit.target.textContent);
     assert.equal(parsedTransUnit.notes.length, manualTransUnit.notes.length, "Expected same number of notes");
     assert.equal(parsedTransUnit.sizeUnit, SizeUnit.char, 'Unexpected value for attribute size-unit');
     assert.equal(parsedTransUnit.notes.length, 2, 'Unexpected number of notes in trans-unit.');
@@ -48,7 +48,7 @@ suite("Xliff Types - Deserialization", function () {
 
   test("Transunit - get properties", function () {
     let transUnit = TransUnit.fromString(GetTransUnitXml());
-    assert.equal(transUnit.targetTextContent, transUnit.targets[0].textContent, "targetTextContent should equal the first element of TransUnitTargets.");
+    assert.equal(transUnit.target.textContent, transUnit.target.textContent, "targetTextContent should equal the first element of TransUnitTargets.");
     assert.equal(transUnit.targetState, TargetState.New, "Unexpected state");
     assert.equal(transUnit.targetTranslationToken, "", "Expected translation token to be empty string");
   });


### PR DESCRIPTION
<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- Support for xlf files from Dynamics LCS (removes empty dev notes)
- Shows Target State (and State Qualifier) in the Xliff Editor, if "Use External Translation Tool" is enabled.
- Added a default `target` property on TransUnit, instead of using `targets[0]` everywhere
- Added a setting to let the user configure how Target State should be handled when importing from .csv file
