### PR TITLE
findTranslatedTexts - Large Target File Fix

### DIFF
--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -256,7 +256,19 @@ export async function findTranslatedTexts(): Promise<void> {
         );
       }
       const transUnitId = selectedMlObject[0].xliffId();
-      if (!(await LanguageFunctions.revealTransUnitTarget(transUnitId))) {
+      
+      let revealedTransUnitTarget = false;
+        try {
+            revealedTransUnitTarget = await LanguageFunctions.revealTransUnitTarget(transUnitId);
+        }
+        catch (error) {
+            // When target file is large (50MB+) then this error occurs:
+            // cannot open file:///.../BaseApp/Translations/Base%20Application.cs-CZ.xlf. Detail: Files above 50MB cannot be synchronized with extensions.
+            vscode.window.showWarningMessage(error.message);
+            revealedTransUnitTarget = false;
+        }  
+        
+      if (!revealedTransUnitTarget) {
         let fileFilter = "";
         if (Settings.getConfigSettings()[Setting.searchOnlyXlfFiles] === true) {
           fileFilter = "*.xlf";


### PR DESCRIPTION
Hello,

When try to use use function findTranslatedTexts from some *.al file in Base Applicaiton, then it fails with breaking error "Files above 50MB cannot be synchronized with extensions."

This PR changes behavior. If unable to open TextEditor, then only open Search with search string "Page ... - Property ..."...

BR
zabaq