### PR TITLE
Cannot have the target value when using Create xlf file for a new language

### DIFF
--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -594,11 +594,10 @@ export async function createNewTargetXlf(): Promise<void> {
     const appName = WorkspaceFunctions.alAppName();
     const gXlfFile = await WorkspaceFunctions.getGXlfFile();
     const translationFolderPath = WorkspaceFunctions.getTranslationFolderPath();
-    const matchBaseAppTranslation: boolean = isNullOrUndefined(
-      selectedMatchBaseApp
-    )
-      ? false
-      : selectedMatchBaseApp[0] === "Yes";
+    const matchBaseAppTranslation =
+      undefined === selectedMatchBaseApp
+        ? false
+        : selectedMatchBaseApp.join("").toLowerCase() === "yes";
     const targetXlfFilename = `${appName}.${targetLanguage}.xlf`;
     const targetXlfFilepath = path.join(
       translationFolderPath,
@@ -653,6 +652,9 @@ async function getQuickPickResult(
   await vscode.window.showQuickPick(items, options).then((result) => {
     input = result;
   });
+  if (input !== undefined && !isArray(input)) {
+    input = [input];
+  }
   return input;
 }
 


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
Fixes #162  .

`NABFunctions.getQuickPickResult` is supposed to return `string[]` but instead returned `string` when selecting a single value in quick picker.

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- assert that a string array is returned from `NABFunctions.getQuickPickResult` 

