### PR TITLE
Execute "Refresh Xlf" after a new xlf is created

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -36,6 +36,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Fixed:
   - When executing any of the `NAB: XML Comment - Format` functions without a selection, the cursor will now be placed inside the added formatting tag.
   - When using the function findTranslatedTexts from some *.al file in Base Application, then it fails with breaking error "Files above 50MB cannot be synchronized with extensions.". This is now fixed in [PR 157](https://github.com/jwikman/nab-al-tools/pull/157) by [zabaq](https://github.com/zabcik) - thanks!
+  - When executing `NAB: Create translation XLF for new language`, no targets was added to the resulting xlf file. Details in [issue 162](https://github.com/jwikman/nab-al-tools/issues/162). Thanks to [Steven-Bale](https://github.com/Steven-Bale) for reporting this issue.
 
 ## [1.1.0] 2021-03-30
 

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -627,6 +627,10 @@ export async function createNewTargetXlf(): Promise<void> {
       targetXlfFilepath,
       languageFunctionsSettings.replaceSelfClosingXlfTags
     );
+    await LanguageFunctions.refreshXlfFilesFromGXlf({
+      matchXlfFileUri: vscode.Uri.file(targetXlfFilepath),
+      languageFunctionsSettings,
+    });
     vscode.window.showTextDocument(vscode.Uri.file(targetXlfFilepath));
   } catch (error) {
     vscode.window.showErrorMessage(error.message);


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
Fixes #162.

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:
- After the new xlf is created via `NAB: Create translation XLF for new language`, the `NAB: Refresh XLF files from g.xlf` function is executed on the new file
- This adds target elements to all trans-units
