### PR TITLE
Support reading app.json and launch.json as utf8 with bom

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -3399,8 +3399,7 @@
         "strip-json-comments": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-            "dev": true
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
         },
         "stylus-lookup": {
             "version": "3.0.2",

--- a/extension/package.json
+++ b/extension/package.json
@@ -590,6 +590,7 @@
         "node-powershell": "^3.3.1",
         "original-fs": "^1.1.0",
         "semver": "^7.3.5",
+        "strip-json-comments": "^3.1.1",
         "time-stamp": "^1.1.0",
         "txml": "^4.0.1",
         "xmldom": "^0.5.0"
@@ -606,6 +607,7 @@
         "@types/node": "^12.20.12",
         "@types/node-powershell": "^3.1.1",
         "@types/semver": "^7.3.5",
+        "@types/strip-json-comments": "^3.0.0",
         "@types/vscode": "^1.50.0",
         "@types/xmldom": "^0.1.30",
         "@typescript-eslint/eslint-plugin": "^4.22.1",


### PR DESCRIPTION
Require breaks functionality and the first implementation didn't support reading utf8 with bom which app.json is encoded as.