### PR TITLE
Dev/#175 run refresh xlf

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -7,6 +7,14 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 -->
 
+## [1.4.0] - 2021-
+
+- Changes:
+  - To ensure that that xliff files is in sync with g.xlf when finishing translation work we've added a call to `NAB: Refresh XLF files from g.xlf` as the last step in `NAB: Set Translation Unit to "..." (Ctrl+Alt+Q)` and `NAB: Find next untranslated text (Ctrl+Alt+U)`
+    - This is regulated by a new setting `NAB.RefreshXlfAfterFindNextUntranslated` specifies if `NAB: Refresh XLF files from g.xlf` should run after no more trans-units in need of action are found.
+- Fixed:
+  - When running `NAB: Refresh XLF files from g.xlf` the information message would say "Nothing changed in x XLF files" even though 1 or more targets could have been marked for review.
+
 ## [1.3.0] - 2021-06-21
 
 - Changes:

--- a/extension/package.json
+++ b/extension/package.json
@@ -552,6 +552,12 @@
                     "default": true,
                     "description": "Specifies if symbols should be loaded from the .alpackages folder. This is used when documentation is generated, ToolTips are added etc.",
                     "scope": "resource"
+                },
+                "NAB.RefreshXlfAfterFindNextUntranslated": {
+                    "type": "boolean",
+                    "default":false,
+                    "description": "Specifies if \"NAB: Refresh XLF files from g.xlf\" should run after no more trans-units in need of action is found.",
+                    "scope": "resource"
                 }
             }
         }

--- a/extension/package.json
+++ b/extension/package.json
@@ -555,7 +555,7 @@
                 },
                 "NAB.RefreshXlfAfterFindNextUntranslated": {
                     "type": "boolean",
-                    "default":false,
+                    "default": false,
                     "description": "Specifies if \"NAB: Refresh XLF files from g.xlf\" should run after no more trans-units in need of action is found.",
                     "scope": "resource"
                 }

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -511,7 +511,7 @@ export function refreshSelectedXlfFileFromGXlf(
       (x) => x.id === gTransUnit.id
     )[0];
 
-    if (!isNullOrUndefined(langTransUnit)) {
+    if (langTransUnit !== undefined) {
       if (!sortOnly) {
         if (!langTransUnit.hasTargets()) {
           langTransUnit.targets.push(
@@ -576,7 +576,7 @@ export function refreshSelectedXlfFileFromGXlf(
           langTransUnit.developerNoteContent() !==
           gTransUnit.developerNoteContent()
         ) {
-          if (isNullOrUndefined(langTransUnit.developerNote())) {
+          if (langTransUnit.developerNote() === undefined) {
             langTransUnit.notes.push(gTransUnit.developerNote());
           } else {
             langTransUnit.developerNote().textContent = gTransUnit.developerNote().textContent;
@@ -588,6 +588,9 @@ export function refreshSelectedXlfFileFromGXlf(
           langTransUnit
         );
         detectInvalidValues(langTransUnit, languageFunctionsSettings);
+        if (langTransUnit.needsReview(true)) {
+          refreshResult.numberOfReviewsAdded++;
+        }
       }
       newLangXliff.transunit.push(langTransUnit);
       langXliff.transunit.splice(langXliff.transunit.indexOf(langTransUnit), 1); // Remove all handled TransUnits -> The rest will be deleted.
@@ -619,6 +622,9 @@ export function refreshSelectedXlfFileFromGXlf(
           newTransUnit
         );
         detectInvalidValues(newTransUnit, languageFunctionsSettings);
+        if (newTransUnit.needsReview(true)) {
+          refreshResult.numberOfReviewsAdded++;
+        }
         newLangXliff.transunit.push(newTransUnit);
         refreshResult.numberOfAddedTransUnitElements++;
       }
@@ -1272,6 +1278,7 @@ export class RefreshResult {
   numberOfRemovedNotes = 0;
   numberOfCheckedFiles = 0;
   numberOfSuggestionsAdded = 0;
+  numberOfReviewsAdded = 0;
   fileName?: string;
 
   getReport(): string {
@@ -1311,6 +1318,14 @@ export class RefreshResult {
     }
 
     return msg;
+  }
+
+  isChanged(): boolean {
+    return (
+      Object.entries(this)
+        .filter((e) => !["numberOfCheckedFiles"].includes(e[0]))
+        .filter((e) => e[1] > 0).length > 0
+    );
   }
 }
 
@@ -1482,7 +1497,7 @@ function isTranslatedState(state: TargetState | undefined | null): boolean {
   ].includes(state);
 }
 function isExactMatch(stateQualifier: string | undefined): boolean {
-  if (isNullOrUndefined(stateQualifier)) {
+  if (stateQualifier === undefined) {
     return false;
   }
   return [StateQualifier.exactMatch, StateQualifier.msExactMatch].includes(

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -38,9 +38,9 @@ export class LanguageFunctionsSettings {
   matchBaseAppTranslation: boolean;
   useMatchingSetting: boolean;
   replaceSelfClosingXlfTags: boolean;
-
   exactMatchState?: TargetState;
   formatXml = true;
+  refreshXlfAfterFindNextUntranslated: boolean;
 
   constructor(settings: Settings) {
     this.translationMode = this.getTranslationMode(settings);
@@ -52,6 +52,8 @@ export class LanguageFunctionsSettings {
     this.useMatchingSetting = settings.matchTranslation;
     this.replaceSelfClosingXlfTags = settings.replaceSelfClosingXlfTags;
     this.exactMatchState = this.getDtsExactMatchToState(settings);
+    this.refreshXlfAfterFindNextUntranslated =
+      settings.refreshXlfAfterFindNextUntranslated;
   }
   private getDtsExactMatchToState(settings: Settings): TargetState | undefined {
     const setDtsExactMatchToState: string = settings.setDtsExactMatchToState;
@@ -90,7 +92,7 @@ export async function getGXlfDocument(
   gXlfDoc: Xliff;
 }> {
   const gXlfPath = WorkspaceFunctions.getGXlfFilePath(settings, appManifest);
-  if (isNullOrUndefined(gXlfPath)) {
+  if (gXlfPath === undefined) {
     throw new Error("No g.xlf file was found");
   }
 

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -1271,6 +1271,45 @@ export class RefreshResult {
   numberOfCheckedFiles = 0;
   numberOfSuggestionsAdded = 0;
   fileName?: string;
+
+  getReport(): string {
+    let msg = "";
+    if (this.numberOfAddedTransUnitElements > 0) {
+      msg += `${this.numberOfAddedTransUnitElements} inserted translations, `;
+    }
+    if (this.numberOfUpdatedMaxWidths > 0) {
+      msg += `${this.numberOfUpdatedMaxWidths} updated maxwidth, `;
+    }
+    if (this.numberOfUpdatedNotes > 0) {
+      msg += `${this.numberOfUpdatedNotes} updated notes, `;
+    }
+    if (this.numberOfRemovedNotes > 0) {
+      msg += `${this.numberOfRemovedNotes} removed notes, `;
+    }
+    if (this.numberOfUpdatedSources > 0) {
+      msg += `${this.numberOfUpdatedSources} updated sources, `;
+    }
+    if (this.numberOfRemovedTransUnits > 0) {
+      msg += `${this.numberOfRemovedTransUnits} removed translations, `;
+    }
+    if (this.numberOfSuggestionsAdded) {
+      if (this.numberOfSuggestionsAdded > 0) {
+        msg += `${this.numberOfSuggestionsAdded} added suggestions, `;
+      }
+    }
+    if (msg !== "") {
+      msg = msg.substr(0, msg.length - 2); // Remove trailing ,
+    } else {
+      msg = "Nothing changed";
+    }
+    if (this.numberOfCheckedFiles) {
+      msg += ` in ${this.numberOfCheckedFiles} XLF files`;
+    } else if (this.fileName) {
+      msg += ` in ${this.fileName}`;
+    }
+
+    return msg;
+  }
 }
 
 function removeCustomNotesFromFile(

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -199,7 +199,7 @@ export async function findNextUnTranslatedText(
         lowerThanTargetState
       );
     }
-    // Run refresh from g.xlf then run again.
+    // Run refresh from g.xlf then search again.
     if (languageFunctionsSettings.refreshXlfAfterFindNextUntranslated) {
       if (!foundAnything) {
         await refreshXlfFilesFromGXlf(true);

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -384,10 +384,8 @@ function getRefreshXlfMessage(changes: RefreshResult): string {
   if (changes.numberOfUpdatedNotes > 0) {
     msg += `${changes.numberOfUpdatedNotes} updated notes, `;
   }
-  if (!isNullOrUndefined(changes.numberOfRemovedNotes)) {
-    if (changes.numberOfRemovedNotes > 0) {
-      msg += `${changes.numberOfRemovedNotes} removed notes, `;
-    }
+  if (changes.numberOfRemovedNotes > 0) {
+    msg += `${changes.numberOfRemovedNotes} removed notes, `;
   }
   if (changes.numberOfUpdatedSources > 0) {
     msg += `${changes.numberOfUpdatedSources} updated sources, `;

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -211,9 +211,7 @@ export async function findNextUnTranslatedText(
     return;
   }
   if (!foundAnything) {
-    vscode.window.showInformationMessage(
-      `No more untranslated texts found. Update XLF files from g.xlf if this was unexpected.`
-    );
+    vscode.window.showInformationMessage(`No more untranslated texts found.`);
   }
   console.log("Done: FindNextUnTranslatedText");
 }

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -196,15 +196,17 @@ export async function findNextUnTranslatedText(
       );
     }
     // Run refresh from g.xlf then run again.
-    if (!foundAnything) {
-      await refreshXlfFilesFromGXlf();
-      foundAnything = await LanguageFunctions.findNextUnTranslatedText(
-        settings,
-        SettingsLoader.getAppManifest(),
-        false,
-        languageFunctionsSettings.replaceSelfClosingXlfTags,
-        lowerThanTargetState
-      );
+    if (languageFunctionsSettings.refreshXlfAfterFindNextUntranslated) {
+      if (!foundAnything) {
+        await refreshXlfFilesFromGXlf();
+        foundAnything = await LanguageFunctions.findNextUnTranslatedText(
+          settings,
+          SettingsLoader.getAppManifest(),
+          false,
+          languageFunctionsSettings.replaceSelfClosingXlfTags,
+          lowerThanTargetState
+        );
+      }
     }
   } catch (error) {
     showErrorAndLog(error);

--- a/extension/src/Settings/Settings.ts
+++ b/extension/src/Settings/Settings.ts
@@ -52,6 +52,7 @@ export class Settings {
   public xliffCSVExportPath = "";
   public xliffCSVImportTargetState = "translated";
   public loadSymbols = true;
+  public refreshXlfAfterFindNextUntranslated = false;
 
   constructor(workspaceFolderPath: string) {
     this.workspaceFolderPath = workspaceFolderPath;

--- a/extension/src/Settings/SettingsMap.ts
+++ b/extension/src/Settings/SettingsMap.ts
@@ -46,4 +46,8 @@ export const settingsMap = new Map<string, keyof Settings>([
   ["NAB.CreateUidForDocs", "createUidForDocs"],
   ["NAB.Xliff CSV Export Path", "xliffCSVExportPath"],
   ["NAB.CSV Import Target State", "xliffCSVImportTargetState"],
+  [
+    "NAB.RefreshXlfAfterFindNextUntranslated",
+    "refreshXlfAfterFindNextUntranslated",
+  ],
 ]);

--- a/extension/src/XliffEditor/XliffEditorPanel.ts
+++ b/extension/src/XliffEditor/XliffEditorPanel.ts
@@ -402,6 +402,16 @@ export class XliffEditorPanel {
         x.dispose();
       }
     }
+    vscode.window
+      .showInformationMessage(
+        "Do you want to refresh XLF files from g.xlf?",
+        ...["Yes", "No"]
+      )
+      .then((answer) => {
+        if (answer === "Yes") {
+          runRefreshXlfFilesFromGXlf();
+        }
+      });
   }
 
   private _recreateWebview(): void {
@@ -670,6 +680,21 @@ function dropdownMenu(
   <div class="dropdown-content"> ${dropdownContent}
   </div>
 </div> `;
+}
+
+function runRefreshXlfFilesFromGXlf(): void {
+  LanguageFunctions.refreshXlfFilesFromGXlf({
+    settings: SettingsLoader.getSettings(),
+    appManifest: SettingsLoader.getAppManifest(),
+    sortOnly: false,
+    matchXlfFileUri: undefined,
+    languageFunctionsSettings: new LanguageFunctions.LanguageFunctionsSettings(
+      SettingsLoader.getSettings()
+    ),
+  }).then((result) => {
+    vscode.window.showInformationMessage(result.getReport());
+  });
+  return;
 }
 
 interface EditorState {

--- a/extension/src/test/LanguageFunctions.test.ts
+++ b/extension/src/test/LanguageFunctions.test.ts
@@ -17,6 +17,7 @@ import * as ALParser from "../ALObject/ALParser";
 import { ALCodeLine } from "../ALObject/ALCodeLine";
 import { TranslationMode } from "../LanguageFunctions";
 import * as SettingsLoader from "../Settings/SettingsLoader";
+import { random } from "lodash";
 
 const xmlns = "urn:oasis:names:tc:xliff:document:1.2";
 const testResourcesPath = "../../src/test/resources/";
@@ -1171,6 +1172,33 @@ suite("ALObject TransUnit Tests", function () {
 });
 
 suite("Language Functions Tests", function () {
+  test("RefreshResult.isChanged()", function () {
+    let refreshResult = new LanguageFunctions.RefreshResult();
+    assert.strictEqual(
+      refreshResult.isChanged(),
+      false,
+      "Initialized RefreshResult should not be considered changed"
+    );
+    refreshResult.numberOfCheckedFiles = 2;
+    assert.strictEqual(
+      refreshResult.isChanged(),
+      false,
+      "RefreshResult with numberOfCheckedFiles > 0 should not be considered changed"
+    );
+    refreshResult.numberOfRemovedNotes = random(1, 1000, false);
+    assert.strictEqual(
+      refreshResult.isChanged(),
+      true,
+      "RefreshResult should be considered changed"
+    );
+    refreshResult = new LanguageFunctions.RefreshResult();
+    refreshResult.numberOfReviewsAdded = random(1, 1000, false);
+    assert.strictEqual(
+      refreshResult.isChanged(),
+      true,
+      "RefreshResult should be considered changed"
+    );
+  });
   test("LoadMatchXlfIntoMap()", function () {
     /*
      *   - Test with Xlf that has [NAB:* ] tokens

--- a/nab-al-tools.code-workspace
+++ b/nab-al-tools.code-workspace
@@ -1,62 +1,63 @@
 {
-	"folders": [
-		{
-			"path": "extension"
-		},
-		{
-			"path": "test-app"
-		},
-		{
-			"path": "dev-tools"
-		},
-		{
-			"path": ".github"
-		}
-	],
-	"settings": {
-		"files.exclude": {
-			"out": false // set this to true to hide the "out" folder with the compiled JS files
-		},
-		"search.exclude": {
-			"out": true // set this to false to include "out" folder in search results
-		},
-		// Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-		"typescript.tsc.autoDetect": "off",
-		"[typescript]": {
-			"editor.defaultFormatter": "esbenp.prettier-vscode"
-		},
-		"git.suggestSmartCommit": false,
-		"editor.formatOnSave": false,
-		"editor.codeActionsOnSave": {
-			"source.fixAll.eslint": true
-		},
-		"editor.formatOnPaste": true,
-		"editor.formatOnType": true,
-		"todohighlight.exclude": [
-			"**/.vscode-test/**",
-			"out/**",
-			"**/node_modules/**",
-			"**/bower_components/**",
-			"**/dist/**",
-			"**/build/**",
-			"**/.vscode/**",
-			"**/.github/**",
-			"**/_output/**",
-			"**/*.min.*",
-			"**/*.map",
-			"**/.next/**"
-		],
-		"cSpell.words": [
-			"Codeunits"
-		],
-		"eslint.lintTask.enable": true
-	},
-	"extensions": {
-		"recommendations": [
-			"dbaeumer.vscode-eslint",
-			"esbenp.prettier-vscode",
-			"davidanson.vscode-markdownlint",
-			"eamodio.tsl-problem-matcher"
-		]
-	}
+  "folders": [
+    {
+      "path": "extension"
+    },
+    {
+      "path": "test-app"
+    },
+    {
+      "path": "dev-tools"
+    },
+    {
+      "path": ".github"
+    }
+  ],
+  "settings": {
+    "files.exclude": {
+      "out": false // set this to true to hide the "out" folder with the compiled JS files
+    },
+    "search.exclude": {
+      "out": true // set this to false to include "out" folder in search results
+    },
+    // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
+    "typescript.tsc.autoDetect": "off",
+    "[typescript]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "git.suggestSmartCommit": false,
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": true
+    },
+    "editor.formatOnPaste": true,
+    "editor.formatOnType": true,
+    "[json]": {
+      "editor.defaultFormatter": "vscode.json-language-features"
+    },
+    "todohighlight.exclude": [
+      "**/.vscode-test/**",
+      "out/**",
+      "**/node_modules/**",
+      "**/bower_components/**",
+      "**/dist/**",
+      "**/build/**",
+      "**/.vscode/**",
+      "**/.github/**",
+      "**/_output/**",
+      "**/*.min.*",
+      "**/*.map",
+      "**/.next/**"
+    ],
+    "cSpell.words": ["Codeunits"],
+    "eslint.lintTask.enable": true
+  },
+  "extensions": {
+    "recommendations": [
+      "dbaeumer.vscode-eslint",
+      "esbenp.prettier-vscode",
+      "davidanson.vscode-markdownlint",
+      "eamodio.tsl-problem-matcher"
+    ]
+  }
 }


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
Fixes #175 

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- When running NAB: Set Translation Unit to "translated" / Ctrl+Alt+Q) if there's no targets left in need of action run Refresh XLF files from g.xlf.
- When running NAB: Find next untranslated text / Ctrl+Alt+U) if there's no targets left in need of action run Refresh XLF files from g.xlf.
- When closing Xliff Editor a prompt should ask the if the user want's to run Refresh XLF files from g.xlf

Additional comments

1. This behavior can be a bit confusing to the user. We might need to indicate that the refresh was intentional.
2.  It also might be annoying and hence an opt-out setting might be needed.
3. There no big code changes but point 1 and 2 might be very disrupting. I think we should be careful of merging this it might need a while in preview to get a good fel of it.
4. Bonus feature: `ctrl+alt+u` is now also a shortcut key for Refresh :sunglasses: 
5. No additional changes was made for `NAB: Set Translation Unit to "translated"` since this is depending on `findNextUntranslated`.