### PR TITLE
use theme colors for Xliff Editor

### DIFF
--- a/extension/frontend/XliffEditor/reset.css
+++ b/extension/frontend/XliffEditor/reset.css
@@ -29,8 +29,8 @@ img {
     height: auto;
 }
 
-tr:nth-child(even) td:nth-child(-n+2){background-color: #4b4b4b;} 
-tr:hover {background-color: rgb(95, 97, 100);}
+tr:nth-child(even) td:nth-child(-n+2){background-color:  var(--vscode-editor-inactiveSelectionBackground);} 
+tr:hover {background-color: var(--vscode-editor-selectionBackground);}
 
 .transunit-notes {
     padding-left: 10px;
@@ -63,7 +63,7 @@ th {
     top: 30px;
     z-index: 99;
     box-shadow: 0 2px 2px -1px rgba(0, 0, 0, 0.4);
-    background-color: #4b4b4b;
+    background-color: var(--vscode-editor-inactiveSelectionBackground);
 }
 th.complete {
     width: 2%;
@@ -84,7 +84,7 @@ div.sticky {
   position: sticky;
   top: 0;
   z-index: 100;
-  background-color: #4b4b4b;
+  background-color:  var(--vscode-editor-inactiveSelectionBackground);
 }
 input[type=checkbox] {
     width: 25px;


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
Fixes #176  .

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- Use colors from current theme in css. 

Additional comments
Looks good in all themes (4) that I've tried :)
![image](https://user-images.githubusercontent.com/17023248/123175679-7a711380-d482-11eb-9452-d4b66a2699da.png)
![image](https://user-images.githubusercontent.com/17023248/123175684-7d6c0400-d482-11eb-8dc5-acc49ef2924e.png)
![image](https://user-images.githubusercontent.com/17023248/123175695-7f35c780-d482-11eb-8132-3bf7c6352cf6.png)
![image](https://user-images.githubusercontent.com/17023248/123175827-bc01be80-d482-11eb-9d4d-f38e84a9428c.png)
