### PR TITLE
Detect whitespace sources

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -7,6 +7,13 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 -->
 
+## [1.6.0] -
+
+- New features:
+  - Trans-units with empty sources are now flagged. An empty source is often not supposed to be translated and the caption should be given the attribute `Locked = true`. When running `NAB: Refresh XLF files from g.xlf` a note is added to the trans-unit suggesting this: `Source contains only white-space, consider using 'Locked = true' to avoid translation of unnecessary texts`. Suggested in ([issue 179](https://github.com/jwikman/nab-al-tools/issues/179)).
+- Fixed:
+  - In the case of a trans-unit missing a "Xliff Generator"-note an error message (`Cannot read property 'textContent' of undefined`) would be shown when running `NAB: Refresh XLF files from g.xlf`. This has now been fixed and a better error message with the trans-unit id will now be shown. Big thanks to [@skyttedk](https://github.com/skyttedk) for reporting this in [issue 181](https://github.com/jwikman/nab-al-tools/issues/181).
+
 ## [1.5.0] - 2021-08-16
 
 - New features:

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -10,7 +10,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [1.6.0] -
 
 - New features:
-  - Trans-units with empty sources are now flagged. An empty source is often not supposed to be translated and the caption should be given the attribute `Locked = true`. When running `NAB: Refresh XLF files from g.xlf` a note is added to the trans-unit suggesting this: `Source contains only white-space, consider using 'Locked = true' to avoid translation of unnecessary texts`. Suggested in ([issue 179](https://github.com/jwikman/nab-al-tools/issues/179)).
+  - Trans-units with empty sources are now flagged. An empty source is often not supposed to be translated and the caption should be given the attribute `Locked = true`. When running `NAB: Refresh XLF files from g.xlf` a note is added to the trans-unit suggesting this: `Source contains only white-space, consider using 'Locked = true' to avoid translation of unnecessary texts`. Suggested in [issue 179](https://github.com/jwikman/nab-al-tools/issues/179).
 - Fixed:
   - In the case of a trans-unit missing a "Xliff Generator"-note an error message (`Cannot read property 'textContent' of undefined`) would be shown when running `NAB: Refresh XLF files from g.xlf`. This has now been fixed and a better error message with the trans-unit id will now be shown. Big thanks to [@skyttedk](https://github.com/skyttedk) for reporting this in [issue 181](https://github.com/jwikman/nab-al-tools/issues/181).
 

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -583,6 +583,13 @@ export function refreshSelectedXlfFileFromGXlf(
           }
           refreshResult.numberOfUpdatedNotes++;
         }
+        if (langTransUnit.sourceIsEmpty() && langTransUnit.targetIsEmpty()) {
+          langTransUnit.insertCustomNote(
+            CustomNoteType.refreshXlfHint,
+            RefreshXlfHint.emptySource
+          );
+          refreshResult.numberOfReviewsAdded++;
+        }
         formatTransUnitForTranslationMode(
           languageFunctionsSettings.translationMode,
           langTransUnit
@@ -615,6 +622,12 @@ export function refreshSelectedXlfFileFromGXlf(
           newTransUnit.insertCustomNote(
             CustomNoteType.refreshXlfHint,
             RefreshXlfHint.new
+          );
+        }
+        if (newTransUnit.sourceIsEmpty()) {
+          newTransUnit.insertCustomNote(
+            CustomNoteType.refreshXlfHint,
+            RefreshXlfHint.emptySource
           );
         }
         formatTransUnitForTranslationMode(
@@ -1270,6 +1283,7 @@ export async function revealTransUnitTarget(
 export enum RefreshXlfHint {
   newCopiedSource = "New translation. Target copied from source.",
   modifiedSource = "Source has been modified.",
+  emptySource = "Source contains only white-space, consider using 'Locked = true' to avoid translation of unnecessary texts",
   new = "New translation.",
   suggestion = "Suggested translation inserted.",
 }

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -537,8 +537,8 @@ export function refreshSelectedXlfFileFromGXlf(
         if (langTransUnit.source !== gTransUnit.source) {
           if (
             langIsSameAsGXlf &&
-            langTransUnit.targets.length === 1 &&
-            langTransUnit.target.textContent === langTransUnit.source
+            langTransUnit.hasTargets() &&
+            langTransUnit.targetMatchesSource()
           ) {
             langTransUnit.target.textContent = gTransUnit.source;
           }

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -142,7 +142,7 @@ export function updateGXlf(
   transUnits: TransUnit[] | null
 ): RefreshResult {
   const result = new RefreshResult();
-  if (isNullOrUndefined(gXlfDoc) || isNullOrUndefined(transUnits)) {
+  if (gXlfDoc === null || isNullOrUndefined(transUnits)) {
     return result;
   }
   transUnits.forEach((transUnit) => {
@@ -720,7 +720,7 @@ function formatTransUnitForTranslationMode(
       // transUnit.alObjectTarget = undefined;
       break;
     default:
-      if (isNullOrUndefined(transUnit.target.translationToken)) {
+      if (transUnit.target.translationToken === undefined) {
         switch (transUnit.target.state) {
           case TargetState.new:
           case TargetState.needsTranslation:
@@ -746,27 +746,28 @@ function formatTransUnitForTranslationMode(
 }
 
 function setTargetStateFromToken(transUnit: TransUnit): void {
-  if (isNullOrUndefined(transUnit.target.state)) {
-    switch (transUnit.target.translationToken) {
-      case TranslationToken.notTranslated:
-        transUnit.target.state = TargetState.needsTranslation;
-        transUnit.target.stateQualifier = undefined;
-        break;
-      case TranslationToken.review:
-        transUnit.target.state = TargetState.needsReviewTranslation;
-        transUnit.target.stateQualifier = undefined;
-        break;
-      case TranslationToken.suggestion:
-        transUnit.target.state = TargetState.translated;
-        transUnit.target.stateQualifier = StateQualifier.exactMatch;
-        break;
-      default:
-        transUnit.target.state = TargetState.translated;
-        transUnit.target.stateQualifier = undefined;
-        break;
-    }
-    transUnit.target.translationToken = undefined;
+  if (transUnit.target.state !== undefined || transUnit.target.state !== null) {
+    return;
   }
+  switch (transUnit.target.translationToken) {
+    case TranslationToken.notTranslated:
+      transUnit.target.state = TargetState.needsTranslation;
+      transUnit.target.stateQualifier = undefined;
+      break;
+    case TranslationToken.review:
+      transUnit.target.state = TargetState.needsReviewTranslation;
+      transUnit.target.stateQualifier = undefined;
+      break;
+    case TranslationToken.suggestion:
+      transUnit.target.state = TargetState.translated;
+      transUnit.target.stateQualifier = StateQualifier.exactMatch;
+      break;
+    default:
+      transUnit.target.state = TargetState.translated;
+      transUnit.target.stateQualifier = undefined;
+      break;
+  }
+  transUnit.target.translationToken = undefined;
 }
 
 export async function formatCurrentXlfFileForDts(
@@ -813,7 +814,7 @@ export async function createSuggestionMaps(
 ): Promise<Map<string, Map<string, string[]>[]>> {
   const languageCodes = existingTargetLanguageCodes(settings, appManifest);
   const suggestionMaps: Map<string, Map<string, string[]>[]> = new Map();
-  if (isNullOrUndefined(languageCodes)) {
+  if (languageCodes === undefined) {
     return suggestionMaps;
   }
   // Maps added in reverse priority, lowest priority first in
@@ -843,7 +844,7 @@ export async function createSuggestionMaps(
   );
 
   // Manually selected match file
-  if (!isNullOrUndefined(matchXlfFileUri)) {
+  if (matchXlfFileUri !== undefined) {
     const matchFilePath = matchXlfFileUri ? matchXlfFileUri.fsPath : "";
     if (matchFilePath === "") {
       throw new Error("No xlf selected for matching");
@@ -896,7 +897,7 @@ export function matchTranslationsFromTranslationMaps(
 ): number {
   let numberOfMatchedTranslations = 0;
   const maps = suggestionsMaps.get(xlfDocument.targetLanguage.toLowerCase());
-  if (isNullOrUndefined(maps)) {
+  if (maps === undefined) {
     return 0;
   }
   // Reverse order because of priority, latest added has highest priority

--- a/extension/src/Xliff/XLIFFDocument.ts
+++ b/extension/src/Xliff/XLIFFDocument.ts
@@ -656,6 +656,7 @@ export class TransUnit implements TransUnitInterface {
   ): void {
     this.notes.push(new Note(from, annotates, priority, textContent));
   }
+
   /**
    * Filters notes with matching from attribute value. If no matching notes is found an array of empty notes is returned.
    * @param from Attribute value to search for.
@@ -829,6 +830,7 @@ export class Note implements NoteInterface {
   annotates: string;
   priority: number;
   textContent: string;
+
   constructor(
     from: string,
     annotates: string,

--- a/extension/src/Xliff/XLIFFDocument.ts
+++ b/extension/src/Xliff/XLIFFDocument.ts
@@ -613,6 +613,14 @@ export class TransUnit implements TransUnitInterface {
     return this.targets.length > 0;
   }
 
+  /**
+   * @description Compares the first target textContent with source.
+   * @returns true if target textContent is exact match with source.
+   */
+  public targetMatchesSource(): boolean {
+    return this.target.textContent === this.source;
+  }
+
   public identicalTargetExists(target: Target): boolean {
     return (
       this.targets.filter((t) => t.textContent === target.textContent).length >

--- a/extension/src/Xliff/XLIFFDocument.ts
+++ b/extension/src/Xliff/XLIFFDocument.ts
@@ -656,10 +656,14 @@ export class TransUnit implements TransUnitInterface {
   ): void {
     this.notes.push(new Note(from, annotates, priority, textContent));
   }
-
-  public getNoteFrom(from: string): Note[] | null {
+  /**
+   * Filters notes with matching from attribute value. If no matching notes is found an array of empty notes is returned.
+   * @param from Attribute value to search for.
+   * @returns Array of Notes.
+   */
+  public getNoteFrom(from: string): Note[] {
     const note = this.notes.filter((n) => n.from === from);
-    return isNullOrUndefined(note) ? null : note;
+    return note !== undefined ? note : [new Note("", "", 0, "")];
   }
 
   private translateAttributeYesNo(): string {

--- a/extension/src/Xliff/XLIFFDocument.ts
+++ b/extension/src/Xliff/XLIFFDocument.ts
@@ -614,11 +614,27 @@ export class TransUnit implements TransUnitInterface {
   }
 
   /**
-   * @description Compares the first target textContent with source.
+   * Compares the first target textContent with source.
    * @returns true if target textContent is exact match with source.
    */
   public targetMatchesSource(): boolean {
     return this.target.textContent === this.source;
+  }
+
+  /**
+   * Removes the leading and trailing white space and line terminator characters from source and compares with an empty string.
+   * @returns true if source contains no other characters than whitespace.
+   */
+  public sourceIsEmpty(): boolean {
+    return this.source.trim() === "";
+  }
+
+  /**
+   * Removes the leading and trailing white space and line terminator characters from target textContent and compares with an empty string.
+   * @returns true if target textContent contains no other characters than whitespace.
+   */
+  public targetIsEmpty(): boolean {
+    return this.target.textContent.trim() === "";
   }
 
   public identicalTargetExists(target: Target): boolean {

--- a/extension/src/test/LanguageFunctions.test.ts
+++ b/extension/src/test/LanguageFunctions.test.ts
@@ -1841,7 +1841,6 @@ suite("Language Functions Tests", function () {
       LanguageFunctions.RefreshXlfHint.emptySource,
       "Unexpected note textContent"
     );
-    //TODO: Test all transunits
   });
 });
 

--- a/extension/src/test/XLIFFTypes.test.ts
+++ b/extension/src/test/XLIFFTypes.test.ts
@@ -484,7 +484,7 @@ suite("Xliff Types - Functions", function () {
     );
   });
 
-  test("getSameSourceDifferentTarget", function () {
+  test("Xliff.getSameSourceDifferentTarget", function () {
     const xlf = Xliff.fromString(xliffXmlWithDuplicateSources());
     const transUnits = xlf.getSameSourceDifferentTarget(xlf.transunit[1]);
     assert.equal(
@@ -494,7 +494,7 @@ suite("Xliff Types - Functions", function () {
     );
   });
 
-  test("differentlyTranslatedTransunits", function () {
+  test("Xliff.differentlyTranslatedTransunits", function () {
     const xlf = Xliff.fromString(xliffXmlWithDuplicateSources());
     const transUnits = xlf.differentlyTranslatedTransUnits();
     assert.notEqual(
@@ -514,6 +514,48 @@ suite("Xliff Types - Functions", function () {
       id.length,
       new Set(id).size,
       "Duplicate trans-units in result"
+    );
+  });
+  test("TransUnit.sourceIsEmpty", function () {
+    const transUnit = TransUnit.fromString(getTransUnitXml());
+    assert.strictEqual(
+      transUnit.sourceIsEmpty(),
+      false,
+      "Source should not be considered empty."
+    );
+    transUnit.source = "       ";
+    assert.strictEqual(
+      transUnit.sourceIsEmpty(),
+      true,
+      "Source should be considered empty."
+    );
+  });
+  test("TransUnit.targetIsEmpty", function () {
+    const transUnit = TransUnit.fromString(getTransUnitXml());
+    assert.strictEqual(
+      transUnit.targetIsEmpty(),
+      false,
+      "target should not be considered empty."
+    );
+    transUnit.target.textContent = "       ";
+    assert.strictEqual(
+      transUnit.targetIsEmpty(),
+      true,
+      "target should be considered empty."
+    );
+  });
+  test("TransUnit.targetMatchesSource", function () {
+    const transUnit = TransUnit.fromString(getTransUnitXml());
+    assert.strictEqual(
+      transUnit.targetMatchesSource(),
+      true,
+      "target text content should match source."
+    );
+    transUnit.target.textContent = "dlalmlsmlmadmlsla";
+    assert.strictEqual(
+      transUnit.targetMatchesSource(),
+      false,
+      "target text content should not match source."
     );
   });
 });


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
Fixes #179  .

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- Add a note if source only contains whitespaces in an untranslated trans-unit 
- Some clean up of deprecated functions

Additional comments
I had actually forgotten about this branch so it feels a bit like sleepwalking when making this PR. So hit me with your best shot, it might make me wake up :D