### PR TITLE
Change return type of function Xliff.xliffGeneratorNote()

### DIFF
--- a/extension/src/CSV/ExportXliffCSV.ts
+++ b/extension/src/CSV/ExportXliffCSV.ts
@@ -34,7 +34,7 @@ export function createXliffCSV(xlf: Xliff): CSV {
           ),
       isNullOrUndefined(tu.maxwidth) ? "" : tu.maxwidth.toString(),
       "", // comment
-      isNullOrUndefined(generatorNote?.textContent)
+      generatorNote?.textContent === undefined
         ? ""
         : checkNoInvalidCharacters(
             generatorNote.textContent,

--- a/extension/src/Xliff/XLIFFDocument.ts
+++ b/extension/src/Xliff/XLIFFDocument.ts
@@ -508,6 +508,11 @@ export class TransUnit implements TransUnitInterface {
 
   public getXliffIdTokenArray(): XliffIdToken[] {
     const note = this.xliffGeneratorNote();
+    if (note === undefined) {
+      throw new Error(
+        `Could not find a note from "Xliff Generator" in trans-unit "${this.id}"`
+      );
+    }
     return XliffIdToken.getXliffIdTokenArray(this.id, note.textContent);
   }
 
@@ -677,9 +682,11 @@ export class TransUnit implements TransUnitInterface {
     const note = this.developerNote();
     return note ? note.textContent : "";
   }
-  public xliffGeneratorNote(): Note {
+
+  public xliffGeneratorNote(): Note | undefined {
     return this.notes.filter((x) => x.from === "Xliff Generator")[0];
   }
+
   public xliffGeneratorNoteContent(): string {
     const note = this.xliffGeneratorNote();
     return note ? note.textContent : "";

--- a/extension/src/test/XLIFFTypes.test.ts
+++ b/extension/src/test/XLIFFTypes.test.ts
@@ -1,4 +1,5 @@
 import * as assert from "assert";
+import { XliffIdToken } from "../ALObject/XliffIdToken";
 import {
   Xliff,
   TransUnit,
@@ -516,6 +517,34 @@ suite("Xliff Types - Functions", function () {
       "Duplicate trans-units in result"
     );
   });
+
+  test("Xliff.getXliffIdTokenArray()", function () {
+    const langXlf = Xliff.fromString(getXliffMissingXliffGeneratorNote());
+    const unitMissingGeneratorNote = langXlf.getTransUnitById(
+      "Page 2931038265 - NamedType 12557645"
+    );
+    const normalUnit = langXlf.getTransUnitById(
+      "Table 2328808854 - NamedType 12557645"
+    );
+
+    assert.throws(
+      () => unitMissingGeneratorNote.getXliffIdTokenArray(),
+      /Could not find a note from "Xliff Generator" in trans-unit "Page 2931038265 - NamedType 12557645"/
+    );
+    assert.doesNotThrow(
+      () => normalUnit.getXliffIdTokenArray(),
+      /Could not find a note from "Xliff Generator" in trans-unit "Table 2328808854 - NamedType 12557645"/
+    );
+    assert.deepStrictEqual(
+      normalUnit.getXliffIdTokenArray(),
+      XliffIdToken.getXliffIdTokenArray(
+        normalUnit.id,
+        normalUnit.notes.filter((n) => n.from === "Xliff Generator")[0]
+          .textContent
+      ),
+      "XliffIdToken is not matching"
+    );
+  });
 });
 
 function getNoteXml(): string {
@@ -761,6 +790,29 @@ export function getXliffWithHeaderXml(): string {
           <source>This is a test ERROR</source>
           <target>This is a test ERROR</target>
           <note from="Xliff Generator" annotates="general" priority="3">Page MyPage - NamedType TestErr</note>
+        </trans-unit>
+      </group>
+    </body>
+  </file>
+</xliff>`;
+}
+
+function getXliffMissingXliffGeneratorNote(): string {
+  return `<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en-US" target-language="sv-SE" original="AlTestApp">
+    <body>
+      <group id="body">
+        <trans-unit id="Table 2328808854 - NamedType 12557645" size-unit="char" translate="yes" xml:space="preserve">
+          <source>This is a test ERROR in table</source>
+          <target>This is a test ERROR in table</target>
+          <note from="Developer" annotates="general" priority="2" />
+          <note from="Xliff Generator" annotates="general" priority="3">Table MyTable - NamedType TestErr</note>
+        </trans-unit>
+        <trans-unit id="Page 2931038265 - NamedType 12557645" size-unit="char" translate="yes" xml:space="preserve">
+          <source>This is a test ERROR</source>
+          <target>This is a test ERROR</target>
+          <note from="Developer" annotates="general" priority="2" />
         </trans-unit>
       </group>
     </body>

--- a/extension/src/test/XLIFFTypes.test.ts
+++ b/extension/src/test/XLIFFTypes.test.ts
@@ -484,25 +484,25 @@ suite("Xliff Types - Functions", function () {
     );
   });
 
-  test("getSameSourceDifferentTarget", function () {
+  test("Xliff.getSameSourceDifferentTarget", function () {
     const xlf = Xliff.fromString(xliffXmlWithDuplicateSources());
     const transUnits = xlf.getSameSourceDifferentTarget(xlf.transunit[1]);
-    assert.equal(
+    assert.deepStrictEqual(
       transUnits.length,
       1,
       "Unexpected number of trans-units returned."
     );
   });
 
-  test("differentlyTranslatedTransunits", function () {
+  test("Xliff.differentlyTranslatedTransunits", function () {
     const xlf = Xliff.fromString(xliffXmlWithDuplicateSources());
     const transUnits = xlf.differentlyTranslatedTransUnits();
-    assert.notEqual(
+    assert.notDeepStrictEqual(
       transUnits.length,
       xlf.transunit.length,
       "Same number of transunit as the total was returned. No bueno!"
     );
-    assert.equal(
+    assert.deepStrictEqual(
       transUnits.length,
       3,
       "Unexpected number of transunits returned."
@@ -510,7 +510,7 @@ suite("Xliff Types - Functions", function () {
     const id = transUnits.map((t) => {
       return t.id;
     });
-    assert.equal(
+    assert.deepStrictEqual(
       id.length,
       new Set(id).size,
       "Duplicate trans-units in result"


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
Fixes #181

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- Change return type of `Xliff.xliffGeneratorNote()` to `Note | undefined`. Since the function filters the notes array and returns the item at index 0 it could possibly turn up `undefined`. I'm a bit disappointed that the compiler isn't warning for this already(?!).
- Throw error `Could not find a note from "Xliff Generator" in trans-unit "xxx"` in `Xliff.getXliffIdTokenArray()` if the note is `undefined` 
- Cleaned up some bits and pieces as I passed by :)

Additional comments:
There's no bugs in this repository, only missing test cases ;)
