### PR TITLE
Validation of translation maps

### DIFF
--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -1005,18 +1005,25 @@ async function getBaseAppTranslationMap(
     await baseAppTranslationFiles.getBlobs([targetFilename]);
     localTransFiles = localBaseAppTranslationFiles();
   }
+
   const baseAppJsonPath = localTransFiles.get(targetFilename);
+  let parsedBaseApp = {};
   if (baseAppJsonPath !== undefined) {
     const baseAppJsonContent = readFileSync(baseAppJsonPath, "utf8");
     if (baseAppJsonContent.length === 0) {
       throw new Error(`No content in file: "${baseAppJsonPath}".`);
     }
-    const baseAppTranslationMap: Map<string, string[]> = new Map(
-      Object.entries(JSON.parse(baseAppJsonContent))
-    );
-    return baseAppTranslationMap;
+    try {
+      parsedBaseApp = JSON.parse(baseAppJsonContent);
+    } catch (err) {
+      throw new Error(
+        `Could not parse "${baseAppJsonPath}". Message: ${err.message}. If this persists, try disabling the setting "NAB: Match Base App Translation"`
+      );
+    }
   }
-  return;
+  return Object.keys(parsedBaseApp).length > 0
+    ? new Map(Object.entries(parsedBaseApp))
+    : undefined;
 }
 
 export function loadMatchXlfIntoMap(

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -1017,7 +1017,7 @@ async function getBaseAppTranslationMap(
       parsedBaseApp = JSON.parse(baseAppJsonContent);
     } catch (err) {
       throw new Error(
-        `Could not parse "${baseAppJsonPath}". Message: ${err.message}. If this persists, try disabling the setting "NAB: Match Base App Translation"`
+        `Could not parse match file for "${targetFilename}". Message: ${err.message}. If this persists, try disabling the setting "NAB: Match Base App Translation". File path: ${baseAppJsonPath}`
       );
     }
   }

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -562,7 +562,9 @@ export async function downloadBaseAppTranslationFiles(): Promise<void> {
     SettingsLoader.getAppManifest()
   );
   try {
-    const result = await baseAppTranslationFiles.getBlobs(targetLanguageCodes);
+    const result = await BaseAppTranslationFiles.baseAppTranslationFiles.getBlobs(
+      targetLanguageCodes
+    );
     vscode.window.showInformationMessage(
       `${result} Translation file(s) downloaded`
     );

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -5,11 +5,13 @@ import * as NABfunctions from "./NABfunctions"; //Our own functions
 import * as DebugTests from "./DebugTests";
 import * as SettingsLoader from "./Settings/SettingsLoader";
 import { XlfHighlighter } from "./XlfHighlighter";
+import * as BaseAppTranslationFiles from "./externalresources/BaseAppTranslationFiles";
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext): void {
   const xlfHighlighter = new XlfHighlighter(SettingsLoader.getSettings());
+  BaseAppTranslationFiles.validateLocalBaseAppTranslationFiles(true);
   console.log("Extension nab-al-tools activated.");
 
   // The command has been defined in the package.json file

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -5,13 +5,12 @@ import * as NABfunctions from "./NABfunctions"; //Our own functions
 import * as DebugTests from "./DebugTests";
 import * as SettingsLoader from "./Settings/SettingsLoader";
 import { XlfHighlighter } from "./XlfHighlighter";
-import * as BaseAppTranslationFiles from "./externalresources/BaseAppTranslationFiles";
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext): void {
   const xlfHighlighter = new XlfHighlighter(SettingsLoader.getSettings());
-  BaseAppTranslationFiles.validateLocalBaseAppTranslationFiles(true);
+  NABfunctions.validateLocalBaseAppTranslationFiles(true);
   console.log("Extension nab-al-tools activated.");
 
   // The command has been defined in the package.json file

--- a/extension/src/externalresources/BaseAppTranslationFiles.ts
+++ b/extension/src/externalresources/BaseAppTranslationFiles.ts
@@ -92,6 +92,5 @@ export async function validateLocalBaseAppTranslationFiles(
       console.log(`NAB AL Tools: Removed invalid translation map at: ${f}`);
     }
   });
-  console.log("length: ", invalidFiles.length);
   return invalidFiles.length;
 }

--- a/extension/src/test/BaseAppTranslationFiles.test.ts
+++ b/extension/src/test/BaseAppTranslationFiles.test.ts
@@ -1,5 +1,4 @@
 import * as assert from "assert";
-import { isNullOrUndefined } from "util";
 import * as BaseAppTranslationFiles from "../externalresources/BaseAppTranslationFiles";
 import * as path from "path";
 import * as fs from "fs";
@@ -15,7 +14,7 @@ suite("Base App Translation Files Tests", function () {
     }
     this.timeout(TIMEOUT); // Takes some time to download all files synchronously on GitHubs Ubuntu servers...and windows!
     const result = await BaseAppTranslationFiles.baseAppTranslationFiles.getBlobs(); // Gets all the blobs, and I mean aaaall of them.
-    assert.equal(result, 25, "Unexpected number of files downloaded");
+    assert.deepStrictEqual(result, 25, "Unexpected number of files downloaded");
   });
 
   test("localTranslationFiles", async function () {
@@ -28,9 +27,9 @@ suite("Base App Translation Files Tests", function () {
       ["sv-se"]
     );
     const localTranslationFiles = BaseAppTranslationFiles.localBaseAppTranslationFiles();
-    assert.equal(result, 1, "Unexpected number of files downloaded");
-    assert.equal(
-      isNullOrUndefined(localTranslationFiles),
+    assert.deepStrictEqual(result, 1, "Unexpected number of files downloaded");
+    assert.deepStrictEqual(
+      localTranslationFiles === undefined || localTranslationFiles === null,
       false,
       "map should not be null or undefined"
     );

--- a/extension/src/test/BaseAppTranslationFiles.test.ts
+++ b/extension/src/test/BaseAppTranslationFiles.test.ts
@@ -1,6 +1,8 @@
 import * as assert from "assert";
 import { isNullOrUndefined } from "util";
 import * as BaseAppTranslationFiles from "../externalresources/BaseAppTranslationFiles";
+import * as path from "path";
+import * as fs from "fs";
 
 suite("Base App Translation Files Tests", function () {
   const TIMEOUT = 360000;
@@ -32,5 +34,34 @@ suite("Base App Translation Files Tests", function () {
       "map should not be null or undefined"
     );
     assert.notEqual(localTranslationFiles.size, 0, "Unexpected Map size");
+  });
+
+  test.only("validateLocalBaseAppTranslationFiles", async function () {
+    //TODO: remove only
+    this.timeout(TIMEOUT); // Just in case there's a lot of files in the folder
+    const filePath = path.resolve(__dirname, "../../out/externalresources/");
+    fs.writeFileSync(
+      path.resolve(filePath, "da-dk.json"),
+      `{ "invalid": "Jay's son`
+    );
+    fs.writeFileSync(path.resolve(filePath, "sv-se.json"), `{"valid": "JSON"}`);
+
+    assert.deepStrictEqual(
+      await BaseAppTranslationFiles.validateLocalBaseAppTranslationFiles(),
+      1,
+      "Unexpected number of files deleted in first run."
+    );
+
+    assert.deepStrictEqual(
+      await BaseAppTranslationFiles.validateLocalBaseAppTranslationFiles(),
+      0,
+      "No files should have been deleted in second run."
+    );
+
+    assert.deepStrictEqual(
+      fs.existsSync(path.resolve(filePath, "sv-se.json")),
+      true,
+      "Expected to find file. To many may have been delted."
+    );
   });
 });

--- a/extension/src/test/BaseAppTranslationFiles.test.ts
+++ b/extension/src/test/BaseAppTranslationFiles.test.ts
@@ -3,6 +3,7 @@ import { isNullOrUndefined } from "util";
 import * as BaseAppTranslationFiles from "../externalresources/BaseAppTranslationFiles";
 import * as path from "path";
 import * as fs from "fs";
+import { validateLocalBaseAppTranslationFiles } from "../NABfunctions";
 
 suite("Base App Translation Files Tests", function () {
   const TIMEOUT = 360000;
@@ -46,13 +47,13 @@ suite("Base App Translation Files Tests", function () {
     fs.writeFileSync(path.resolve(filePath, "sv-se.json"), `{"valid": "JSON"}`);
 
     assert.deepStrictEqual(
-      await BaseAppTranslationFiles.validateLocalBaseAppTranslationFiles(),
+      await validateLocalBaseAppTranslationFiles(),
       1,
       "Unexpected number of files deleted in first run."
     );
 
     assert.deepStrictEqual(
-      await BaseAppTranslationFiles.validateLocalBaseAppTranslationFiles(),
+      await validateLocalBaseAppTranslationFiles(),
       0,
       "No files should have been deleted in second run."
     );

--- a/extension/src/test/BaseAppTranslationFiles.test.ts
+++ b/extension/src/test/BaseAppTranslationFiles.test.ts
@@ -36,8 +36,7 @@ suite("Base App Translation Files Tests", function () {
     assert.notEqual(localTranslationFiles.size, 0, "Unexpected Map size");
   });
 
-  test.only("validateLocalBaseAppTranslationFiles", async function () {
-    //TODO: remove only
+  test("validateLocalBaseAppTranslationFiles", async function () {
     this.timeout(TIMEOUT); // Just in case there's a lot of files in the folder
     const filePath = path.resolve(__dirname, "../../out/externalresources/");
     fs.writeFileSync(


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
Mitigates parts of the problem in #190  .

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- More informative message when parsing of translation maps fail.
- On activation of the extension we ensure that the translation maps are able to be parsed as JSON or otherwise deleted. To make minimal impact on loading times and resource consumption only translation maps with language codes matching translations in the current workspace are validated.

This isn't the solution to the core problem with partial downloads but I think it will mitigate some of the issues and make for a less disruptive experience for the user. 


Additional comments
Tried another way of parsing the xliffs from Base App. I think this is as fast as it gets with Python at least. I'm not saying it's bad, the total runtime of the script is not really an issue. I'm just stating that I'm quite proud of  my self ;) I started building one in c++ during the summer witch might be blazing fast, we'll se if I ever finish it :) 