### PR TITLE
base app translation map validation

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -7,6 +7,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 -->
 
+## [1.7.0] -
+
+- Changes:
+  - To enable matching of translations with Base App we store map files in json format in a blob storage. The files are then downloaded when needed (if you have selected to match with Base App in the settings). At times the download would fail which could lead to empty or corrupted files which in turn could lead to errors with poor information. To mitigate the effects of this we have improved the information presented when certain functions fail. Translation maps corrupted by failed download are now also deleted which in turn will lead to a new download when triggered by either `NAB: Download Base App Translation Files`, `NAB: Refresh XLF Files from g.xlf` or `NAB: Update all XLF Files`. We haven't yet solved the problem within the download leaving corrupted files, we'll continue to investigate this. At the moment poor connection speeds seems to be the problem, we hope to find a way to work around it. Please continue to report any problems you run into regarding this by creating an [issue](https://github.com/jwikman/nab-al-tools/issues). Big thanks to [@RodrigoPuelma](https://github.com/RodrigoPuelma) for bringing this to our attention in [issue 190](https://github.com/jwikman/nab-al-tools/issues/190).
+
 ## [1.6.0] - 2021-08-23
 
 - New features:

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -1005,18 +1005,25 @@ async function getBaseAppTranslationMap(
     await baseAppTranslationFiles.getBlobs([targetFilename]);
     localTransFiles = localBaseAppTranslationFiles();
   }
+
   const baseAppJsonPath = localTransFiles.get(targetFilename);
+  let parsedBaseApp = {};
   if (baseAppJsonPath !== undefined) {
     const baseAppJsonContent = readFileSync(baseAppJsonPath, "utf8");
     if (baseAppJsonContent.length === 0) {
       throw new Error(`No content in file: "${baseAppJsonPath}".`);
     }
-    const baseAppTranslationMap: Map<string, string[]> = new Map(
-      Object.entries(JSON.parse(baseAppJsonContent))
-    );
-    return baseAppTranslationMap;
+    try {
+      parsedBaseApp = JSON.parse(baseAppJsonContent);
+    } catch (err) {
+      throw new Error(
+        `Could not parse "${baseAppJsonPath}". Message: ${err.message}. If this persists, try disabling the setting "NAB: Match Base App Translation"`
+      );
+    }
   }
-  return;
+  return Object.keys(parsedBaseApp).length > 0
+    ? new Map(Object.entries(parsedBaseApp))
+    : undefined;
 }
 
 export function loadMatchXlfIntoMap(

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -1017,7 +1017,9 @@ async function getBaseAppTranslationMap(
       parsedBaseApp = JSON.parse(baseAppJsonContent);
     } catch (err) {
       throw new Error(
-        `Could not parse match file for "${targetFilename}". Message: ${err.message}. If this persists, try disabling the setting "NAB: Match Base App Translation". File path: ${baseAppJsonPath}`
+        `Could not parse match file for "${targetFilename}". Message: ${
+          (err as Error).message
+        }. If this persists, try disabling the setting "NAB: Match Base App Translation". File path: ${baseAppJsonPath}`
       );
     }
   }

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -999,10 +999,18 @@ export async function matchTranslationsFromBaseApp(
 async function getBaseAppTranslationMap(
   targetLanguage: string
 ): Promise<Map<string, string[]> | undefined> {
+  const persistantMsg = `If this persists, try disabling the setting "NAB: Match Base App Translation" and log an issue at https://github.com/jwikman/nab-al-tools/issues`;
   const targetFilename = targetLanguage.toLocaleLowerCase().concat(".json");
   let localTransFiles = localBaseAppTranslationFiles();
   if (!localTransFiles.has(targetFilename)) {
-    await baseAppTranslationFiles.getBlobs([targetFilename]);
+    const downloadResult = await baseAppTranslationFiles.getBlobs([
+      targetFilename,
+    ]);
+    if (downloadResult.failed.length > 0) {
+      throw new Error(
+        `Failed to download translation map for ${targetLanguage}. ${persistantMsg}.`
+      );
+    }
     localTransFiles = localBaseAppTranslationFiles();
   }
 
@@ -1019,7 +1027,7 @@ async function getBaseAppTranslationMap(
       } catch (err) {
         fileErrorMsg = `Could not parse match file for "${targetFilename}". Message: ${
           (err as Error).message
-        }. If this persists, try disabling the setting "NAB: Match Base App Translation" and log an issue at https://github.com/jwikman/nab-al-tools/issues. Deleted corrupt file at: "${baseAppJsonPath}".`;
+        }. ${persistantMsg}. Deleted corrupt file at: "${baseAppJsonPath}".`;
       }
     }
     if (fileErrorMsg !== "") {

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -950,7 +950,7 @@ export function matchTranslationsFromTranslationMap(
         });
       } else {
         const match = matchMap.get(transUnit.source);
-        if (!isNullOrUndefined(match)) {
+        if (!(match === undefined)) {
           const newTarget = new Target(match[0], TargetState.translated);
           newTarget.stateQualifier = StateQualifier.exactMatch;
           transUnit.removeCustomNote(CustomNoteType.refreshXlfHint);
@@ -986,7 +986,7 @@ export async function matchTranslationsFromBaseApp(
   const targetLanguage = xlfDoc.targetLanguage;
   let numberOfMatches = 0;
   const baseAppTranslationMap = await getBaseAppTranslationMap(targetLanguage);
-  if (!isNullOrUndefined(baseAppTranslationMap)) {
+  if (!(baseAppTranslationMap === undefined)) {
     numberOfMatches = matchTranslationsFromTranslationMap(
       xlfDoc,
       baseAppTranslationMap,

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -1017,7 +1017,7 @@ async function getBaseAppTranslationMap(
       parsedBaseApp = JSON.parse(baseAppJsonContent);
     } catch (err) {
       throw new Error(
-        `Could not parse "${baseAppJsonPath}". Message: ${err.message}. If this persists, try disabling the setting "NAB: Match Base App Translation"`
+        `Could not parse match file for "${targetFilename}". Message: ${err.message}. If this persists, try disabling the setting "NAB: Match Base App Translation". File path: ${baseAppJsonPath}`
       );
     }
   }

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -950,7 +950,7 @@ export function matchTranslationsFromTranslationMap(
         });
       } else {
         const match = matchMap.get(transUnit.source);
-        if (!(match === undefined)) {
+        if (match !== undefined) {
           const newTarget = new Target(match[0], TargetState.translated);
           newTarget.stateQualifier = StateQualifier.exactMatch;
           transUnit.removeCustomNote(CustomNoteType.refreshXlfHint);
@@ -986,7 +986,7 @@ export async function matchTranslationsFromBaseApp(
   const targetLanguage = xlfDoc.targetLanguage;
   let numberOfMatches = 0;
   const baseAppTranslationMap = await getBaseAppTranslationMap(targetLanguage);
-  if (!(baseAppTranslationMap === undefined)) {
+  if (baseAppTranslationMap !== undefined) {
     numberOfMatches = matchTranslationsFromTranslationMap(
       xlfDoc,
       baseAppTranslationMap,

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -1009,18 +1009,22 @@ async function getBaseAppTranslationMap(
   const baseAppJsonPath = localTransFiles.get(targetFilename);
   let parsedBaseApp = {};
   if (baseAppJsonPath !== undefined) {
+    let fileErrorMsg = "";
     const baseAppJsonContent = readFileSync(baseAppJsonPath, "utf8");
     if (baseAppJsonContent.length === 0) {
-      throw new Error(`No content in file: "${baseAppJsonPath}".`);
-    }
-    try {
-      parsedBaseApp = JSON.parse(baseAppJsonContent);
-    } catch (err) {
-      throw new Error(
-        `Could not parse match file for "${targetFilename}". Message: ${
+      fileErrorMsg = `No content in file, file was deleted: "${baseAppJsonPath}".`;
+    } else {
+      try {
+        parsedBaseApp = JSON.parse(baseAppJsonContent);
+      } catch (err) {
+        fileErrorMsg = `Could not parse match file for "${targetFilename}". Message: ${
           (err as Error).message
-        }. If this persists, try disabling the setting "NAB: Match Base App Translation". File path: ${baseAppJsonPath}`
-      );
+        }. If this persists, try disabling the setting "NAB: Match Base App Translation" and log an issue at https://github.com/jwikman/nab-al-tools/issues. Deleted corrupt file at: "${baseAppJsonPath}".`;
+      }
+    }
+    if (fileErrorMsg !== "") {
+      fs.unlinkSync(baseAppJsonPath);
+      throw new Error(fileErrorMsg);
     }
   }
   return Object.keys(parsedBaseApp).length > 0

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -996,7 +996,7 @@ export async function matchTranslationsFromBaseApp(
   return numberOfMatches;
 }
 
-async function getBaseAppTranslationMap(
+export async function getBaseAppTranslationMap(
   targetLanguage: string
 ): Promise<Map<string, string[]> | undefined> {
   const persistantMsg = `If this persists, try disabling the setting "NAB: Match Base App Translation" and log an issue at https://github.com/jwikman/nab-al-tools/issues`;

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -557,21 +557,26 @@ export async function editXliffDocument(
 }
 
 export async function downloadBaseAppTranslationFiles(): Promise<void> {
+  console.log("Running: downloadBaseAppTranslationFiles");
   const targetLanguageCodes = LanguageFunctions.existingTargetLanguageCodes(
     SettingsLoader.getSettings(),
     SettingsLoader.getAppManifest()
   );
   try {
     const result = await baseAppTranslationFiles.getBlobs(targetLanguageCodes);
-    vscode.window.showInformationMessage(
-      `${result} Translation file(s) downloaded`
-    );
+    let informationMessage = `Succesfully downloaded ${result.succeded.length} translation file(s).`;
+    informationMessage +=
+      result.failed.length > 0
+        ? ` Failed to download ${result.failed.length} file(s).`
+        : "";
+    vscode.window.showInformationMessage(informationMessage);
   } catch (error) {
     showErrorAndLog(
       "Download of Base Application translation files",
       error as Error
     );
   }
+  console.log("Done: downloadBaseAppTranslationFiles");
 }
 
 export async function matchTranslationsFromBaseApplication(): Promise<void> {

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -35,7 +35,7 @@ export async function refreshXlfFilesFromGXlf(
     }
     refreshResult = await refreshXlfFilesFromGXlfWithSettings();
   } catch (error) {
-    showErrorAndLog("Refresh files from g.xlf", error);
+    showErrorAndLog("Refresh files from g.xlf", error as Error);
     return;
   }
   const showMessage = suppressMessage ? refreshResult.isChanged() : true;
@@ -78,7 +78,7 @@ export async function formatCurrentXlfFileForDts(): Promise<void> {
       );
     }
   } catch (error) {
-    showErrorAndLog("Format current XLF file for DTS", error);
+    showErrorAndLog("Format current XLF file for DTS", error as Error);
     return;
   }
 
@@ -99,7 +99,7 @@ export async function sortXlfFiles(): Promise<void> {
       }`
     );
   } catch (error) {
-    showErrorAndLog("Sort XLF files", error);
+    showErrorAndLog("Sort XLF files", error as Error);
     return;
   }
 
@@ -128,7 +128,7 @@ export async function matchFromXlfFile(): Promise<void> {
       showMessage = true;
     }
   } catch (error) {
-    showErrorAndLog("Match from XLF file", error);
+    showErrorAndLog("Match from XLF file", error as Error);
     return;
   }
   if (showMessage && refreshResult) {
@@ -145,7 +145,7 @@ export async function copySourceToTarget(): Promise<void> {
       vscode.window.showErrorMessage("Not in a xlf file on a <target> line.");
     }
   } catch (error) {
-    showErrorAndLog("Copy source to target", error);
+    showErrorAndLog("Copy source to target", error as Error);
     return;
   }
   console.log("Done: CopySourceToTarget");
@@ -212,7 +212,7 @@ export async function findNextUnTranslatedText(
       }
     }
   } catch (error) {
-    showErrorAndLog("Find next untranslated", error);
+    showErrorAndLog("Find next untranslated", error as Error);
     return;
   }
   if (!foundAnything) {
@@ -228,7 +228,7 @@ export async function findAllUnTranslatedText(): Promise<void> {
       new LanguageFunctionsSettings(SettingsLoader.getSettings())
     );
   } catch (error) {
-    showErrorAndLog("Find all untranslated", error);
+    showErrorAndLog("Find all untranslated", error as Error);
     return;
   }
 
@@ -242,7 +242,7 @@ export async function findMultipleTargets(): Promise<void> {
       new LanguageFunctionsSettings(SettingsLoader.getSettings())
     );
   } catch (error) {
-    showErrorAndLog("Find multiple targets", error);
+    showErrorAndLog("Find multiple targets", error as Error);
     return;
   }
   console.log("Done: FindMultipleTargets");
@@ -293,7 +293,7 @@ export async function findTranslatedTexts(): Promise<void> {
       } catch (error) {
         // When target file is large (50MB+) then this error occurs:
         // cannot open file:///.../BaseApp/Translations/Base%20Application.cs-CZ.xlf. Detail: Files above 50MB cannot be synchronized with extensions.
-        vscode.window.showWarningMessage(error.message);
+        vscode.window.showWarningMessage((error as Error).message);
         revealedTransUnitTarget = false;
       }
 
@@ -306,7 +306,7 @@ export async function findTranslatedTexts(): Promise<void> {
       }
     }
   } catch (error) {
-    showErrorAndLog("Find translated texts", error);
+    showErrorAndLog("Find translated texts", error as Error);
     return;
   }
   console.log("Done: FindTranslatedTexts");
@@ -330,7 +330,7 @@ export async function findSourceOfTranslatedTexts(): Promise<void> {
       );
     }
   } catch (error) {
-    showErrorAndLog("Find source of translated texts", error);
+    showErrorAndLog("Find source of translated texts", error as Error);
     return;
   }
   console.log("Done: FindSourceOfTranslatedTexts");
@@ -345,7 +345,7 @@ export async function uninstallDependencies(): Promise<void> {
       SettingsLoader.getLaunchSettings()
     );
   } catch (error) {
-    showErrorAndLog("Uninstall dependencies", error);
+    showErrorAndLog("Uninstall dependencies", error as Error);
     return;
   }
   vscode.window.showInformationMessage(
@@ -363,7 +363,7 @@ export async function signAppFile(): Promise<void> {
       SettingsLoader.getAppManifest()
     );
   } catch (error) {
-    showErrorAndLog("Sign app file", error);
+    showErrorAndLog("Sign app file", error as Error);
     return;
   }
   vscode.window.showInformationMessage(
@@ -382,7 +382,7 @@ export async function deployAndRunTestTool(noDebug: boolean): Promise<void> {
       noDebug
     );
   } catch (error) {
-    showErrorAndLog("Deploy and run test tool", error);
+    showErrorAndLog("Deploy and run test tool", error as Error);
     return;
   }
   console.log("Done: DeployAndRunTestTool");
@@ -438,7 +438,7 @@ export async function suggestToolTips(): Promise<void> {
       SettingsLoader.getAppManifest()
     );
   } catch (error) {
-    showErrorAndLog("Suggest ToolTips", error);
+    showErrorAndLog("Suggest ToolTips", error as Error);
     return;
   }
 
@@ -450,7 +450,7 @@ export async function showSuggestedToolTip(): Promise<void> {
   try {
     await ToolTipsFunctions.showSuggestedToolTip(false);
   } catch (error) {
-    showErrorAndLog("Show suggested ToolTips", error);
+    showErrorAndLog("Show suggested ToolTips", error as Error);
     return;
   }
 
@@ -468,7 +468,7 @@ export async function generateToolTipDocumentation(): Promise<void> {
       `ToolTip documentation (re)created from al files.`
     );
   } catch (error) {
-    showErrorAndLog("Generate ToolTip documentation", error);
+    showErrorAndLog("Generate ToolTip documentation", error as Error);
     return;
   }
 
@@ -485,7 +485,7 @@ export async function generateExternalDocumentation(): Promise<void> {
       `Documentation (re)created from al files.`
     );
   } catch (error) {
-    showErrorAndLog("Generate external documentation", error);
+    showErrorAndLog("Generate external documentation", error as Error);
     return;
   }
 
@@ -529,7 +529,7 @@ export async function matchTranslations(): Promise<void> {
       );
     });
   } catch (error) {
-    vscode.window.showErrorMessage(error.message);
+    vscode.window.showErrorMessage((error as Error).message);
     return;
   }
   console.log("Done: MatchTranslations");
@@ -551,7 +551,7 @@ export async function editXliffDocument(
     xlfDoc._path = xlfUri.fsPath;
     await XliffEditorPanel.createOrShow(extensionUri, xlfDoc);
   } catch (error) {
-    vscode.window.showErrorMessage(error.message);
+    vscode.window.showErrorMessage((error as Error).message);
     return;
   }
 }
@@ -567,7 +567,10 @@ export async function downloadBaseAppTranslationFiles(): Promise<void> {
       `${result} Translation file(s) downloaded`
     );
   } catch (error) {
-    showErrorAndLog("Download of Base Application translation files", error);
+    showErrorAndLog(
+      "Download of Base Application translation files",
+      error as Error
+    );
   }
 }
 
@@ -606,7 +609,7 @@ export async function matchTranslationsFromBaseApplication(): Promise<void> {
       );
     });
   } catch (error) {
-    vscode.window.showErrorMessage(error.message);
+    vscode.window.showErrorMessage((error as Error).message);
     return;
   }
   console.log("Done: matchTranslationsFromBaseApplication");
@@ -622,7 +625,7 @@ export async function updateGXlf(): Promise<void> {
     const msg1 = getRefreshXlfMessage(refreshResult);
     vscode.window.showInformationMessage(msg1);
   } catch (error) {
-    showErrorAndLog("Update g.xlf", error);
+    showErrorAndLog("Update g.xlf", error as Error);
     return;
   }
 
@@ -643,7 +646,7 @@ export async function updateAllXlfFiles(): Promise<void> {
     const msg2 = getRefreshXlfMessage(refreshResult);
     vscode.window.showInformationMessage(msg2);
   } catch (error) {
-    showErrorAndLog("Update all XLF files", error);
+    showErrorAndLog("Update all XLF files", error as Error);
     return;
   }
 
@@ -714,7 +717,7 @@ export async function createNewTargetXlf(): Promise<void> {
     });
     vscode.window.showTextDocument(vscode.Uri.file(targetXlfFilepath));
   } catch (error) {
-    vscode.window.showErrorMessage(error.message);
+    vscode.window.showErrorMessage((error as Error).message);
   }
   console.log("Done: createNewTargetXlf");
 }
@@ -773,7 +776,7 @@ export async function exportTranslationsCSV(): Promise<void> {
     });
     vscode.window.showInformationMessage(`CSV file(s) exported.`);
   } catch (error) {
-    showErrorAndLog("Export translations csv", error);
+    showErrorAndLog("Export translations csv", error as Error);
   }
   console.log("Done: exportTranslationsCSV");
 }
@@ -831,7 +834,7 @@ export async function importTranslationCSV(): Promise<void> {
       }`
     );
   } catch (error) {
-    showErrorAndLog("Import translations csv", error);
+    showErrorAndLog("Import translations csv", error as Error);
   }
 
   console.log("Done: importTranslationCSV");
@@ -917,7 +920,7 @@ async function setTranslationUnitState(
       findNextUnTranslatedText(newTargetState);
     }
   } catch (error) {
-    showErrorAndLog("Set translation unit state", error);
+    showErrorAndLog("Set translation unit state", error as Error);
   }
 }
 
@@ -981,7 +984,7 @@ export async function importDtsTranslations(): Promise<void> {
       `${pickedFiles.length} xlf files updated.`
     );
   } catch (error) {
-    vscode.window.showErrorMessage(error.message);
+    vscode.window.showErrorMessage((error as Error).message);
   }
 
   console.log("Done: importDtsTranslations");

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -414,7 +414,7 @@ function getRefreshXlfMessage(changes: RefreshResult): string {
     }
   }
   if (changes.numberOfReviewsAdded > 0) {
-    msg += `${changes.numberOfReviewsAdded} targets in need of review, `;
+    msg += `${changes.numberOfReviewsAdded} targets marked as in need of review, `;
   }
   if (msg !== "") {
     msg = msg.substr(0, msg.length - 2); // Remove trailing ,

--- a/extension/src/externalresources/ExternalResources.ts
+++ b/extension/src/externalresources/ExternalResources.ts
@@ -14,8 +14,13 @@ interface BlobContainerInterface {
   blobs: ExternalResource[];
   exportPath: string;
   sasToken: string;
-  getBlobs(filter: string[] | undefined): void;
+  getBlobs(filter: string[] | undefined): Promise<BlobDownloadResult>;
   addBlob(name: string, uri: string): void;
+}
+
+interface BlobDownloadResult {
+  succeded: string[];
+  failed: string[];
 }
 
 export class ExternalResource implements ExternalResourceInterface {
@@ -75,7 +80,10 @@ export class BlobContainer implements BlobContainerInterface {
     this.sasToken = sasToken;
   }
 
-  public async getBlobs(languageCodeFilter?: string[]): Promise<number> {
+  public async getBlobs(
+    languageCodeFilter?: string[]
+  ): Promise<BlobDownloadResult> {
+    const downloadResult: BlobDownloadResult = { succeded: [], failed: [] };
     if (!fs.existsSync(this.exportPath)) {
       throw new Error(`Directory does not exist: ${this.exportPath}`);
     }
@@ -90,7 +98,6 @@ export class BlobContainer implements BlobContainerInterface {
         }
       });
     }
-    let result = 0;
     for (const blob of blobs) {
       const writeStream = fs.createWriteStream(
         path.resolve(this.exportPath, blob.name),
@@ -110,9 +117,19 @@ export class BlobContainer implements BlobContainerInterface {
           new Error(`${errorMessage} Error: ${err.message}`)
         );
       });
-      result++;
+      try {
+        JSON.parse(fs.readFileSync(writeStream.path.toString(), "utf8"));
+      } catch (e) {
+        console.log(
+          `Failed to parse: ${blob.name}. Error: ${(e as Error).message}`
+        );
+        downloadResult.failed.push(blob.name);
+        fs.unlinkSync(writeStream.path);
+        continue;
+      }
+      downloadResult.succeded.push(blob.name);
     }
-    return result;
+    return downloadResult;
   }
 
   public addBlob(name: string): void {

--- a/extension/src/test/BaseAppTranslationFiles.test.ts
+++ b/extension/src/test/BaseAppTranslationFiles.test.ts
@@ -3,20 +3,29 @@ import * as BaseAppTranslationFiles from "../externalresources/BaseAppTranslatio
 
 suite("Base App Translation Files Tests", function () {
   const TIMEOUT = 360000;
-
+  const WORKFLOW = process.env.GITHUB_ACTION; // Only run in GitHub Workflow
   test("BaseAppTranslationFiles.getBlobs()", async function () {
-    // Only run in GitHub Workflow
-    if (!process.env.GITHUB_ACTION) {
+    if (!WORKFLOW) {
       this.skip();
     }
     this.timeout(TIMEOUT); // Takes some time to download all files synchronously on GitHubs Ubuntu servers...and windows!
     const result = await BaseAppTranslationFiles.baseAppTranslationFiles.getBlobs(); // Gets all the blobs, and I mean aaaall of them.
-    assert.deepStrictEqual(result, 25, "Unexpected number of files downloaded");
+    console.log("result", result);
+    assert.deepStrictEqual(
+      result.succeded.length,
+      25,
+      "Unexpected number of files downloaded"
+    );
+    assert.deepStrictEqual(
+      result.failed.length,
+      0,
+      "Unexpected number of downloads failed"
+    );
   });
 
   test("localTranslationFiles", async function () {
     // Only run in GitHub Workflow
-    if (!process.env.GITHUB_ACTION) {
+    if (!WORKFLOW) {
       this.skip();
     }
     this.timeout(TIMEOUT); // Take some time to download blobs on Ubuntu... and windows!
@@ -24,12 +33,25 @@ suite("Base App Translation Files Tests", function () {
       ["sv-se"]
     );
     const localTranslationFiles = BaseAppTranslationFiles.localBaseAppTranslationFiles();
-    assert.deepStrictEqual(result, 1, "Unexpected number of files downloaded");
+    assert.deepStrictEqual(
+      result.succeded.length,
+      1,
+      "Unexpected number of files downloaded"
+    );
+    assert.deepStrictEqual(
+      result.failed.length,
+      1,
+      "Unexpected number of downloads failed"
+    );
     assert.deepStrictEqual(
       localTranslationFiles === undefined || localTranslationFiles === null,
       false,
       "map should not be null or undefined"
     );
-    assert.notEqual(localTranslationFiles.size, 0, "Unexpected Map size");
+    assert.notDeepStrictEqual(
+      localTranslationFiles.size,
+      0,
+      "Unexpected Map size"
+    );
   });
 });

--- a/extension/src/test/BaseAppTranslationFiles.test.ts
+++ b/extension/src/test/BaseAppTranslationFiles.test.ts
@@ -1,5 +1,4 @@
 import * as assert from "assert";
-import { isNullOrUndefined } from "util";
 import * as BaseAppTranslationFiles from "../externalresources/BaseAppTranslationFiles";
 
 suite("Base App Translation Files Tests", function () {
@@ -12,7 +11,7 @@ suite("Base App Translation Files Tests", function () {
     }
     this.timeout(TIMEOUT); // Takes some time to download all files synchronously on GitHubs Ubuntu servers...and windows!
     const result = await BaseAppTranslationFiles.baseAppTranslationFiles.getBlobs(); // Gets all the blobs, and I mean aaaall of them.
-    assert.equal(result, 25, "Unexpected number of files downloaded");
+    assert.deepStrictEqual(result, 25, "Unexpected number of files downloaded");
   });
 
   test("localTranslationFiles", async function () {
@@ -25,9 +24,9 @@ suite("Base App Translation Files Tests", function () {
       ["sv-se"]
     );
     const localTranslationFiles = BaseAppTranslationFiles.localBaseAppTranslationFiles();
-    assert.equal(result, 1, "Unexpected number of files downloaded");
-    assert.equal(
-      isNullOrUndefined(localTranslationFiles),
+    assert.deepStrictEqual(result, 1, "Unexpected number of files downloaded");
+    assert.deepStrictEqual(
+      localTranslationFiles === undefined || localTranslationFiles === null,
       false,
       "map should not be null or undefined"
     );

--- a/extension/src/test/BaseAppTranslationFiles.test.ts
+++ b/extension/src/test/BaseAppTranslationFiles.test.ts
@@ -1,5 +1,8 @@
 import * as assert from "assert";
+import { writeFileSync } from "fs";
+import * as path from "path";
 import * as BaseAppTranslationFiles from "../externalresources/BaseAppTranslationFiles";
+import * as LanguageFunctions from "../LanguageFunctions";
 
 suite("Base App Translation Files Tests", function () {
   const TIMEOUT = 360000; // Take some time to download blobs on Ubuntu... and windows!
@@ -53,6 +56,85 @@ suite("Base App Translation Files Tests", function () {
       localTranslationFiles.size,
       0,
       "Unexpected Map size"
+    );
+  });
+
+  test("Always - LanguageFunctions.getBaseAppTranslationMap()", async function () {
+    // Only test of getBaseAppTranslationMap that should always run.
+    const map = await LanguageFunctions.getBaseAppTranslationMap(
+      "not-a-lang-code"
+    );
+    assert.deepStrictEqual(map, undefined, "Expected map to be undefined");
+  });
+
+  test("Workflow - LanguageFunctions.getBaseAppTranslationMap()", async function () {
+    if (!WORKFLOW) {
+      this.skip();
+    }
+    this.timeout(TIMEOUT);
+
+    let map = await LanguageFunctions.getBaseAppTranslationMap("fr-ca");
+    assert.notDeepStrictEqual(
+      map,
+      undefined,
+      "Expected map should not be undefined"
+    );
+    if (map !== undefined) {
+      assert.deepStrictEqual(
+        map?.size > 0,
+        true,
+        "Expected map size to be >0."
+      );
+    }
+    // Non existing language code
+    map = await LanguageFunctions.getBaseAppTranslationMap("klingon");
+    assert.deepStrictEqual(map, undefined, "Expected map to be undefined");
+
+    // Empty file test
+    const reEmptyFileError = new RegExp(
+      /No content in file, file was deleted: .*/gm
+    );
+    writeFileSync(
+      path.resolve(__dirname, "../externalresources/en-au_broken.json"),
+      ""
+    );
+
+    map = undefined;
+    let emptyErrorMsg = "";
+    try {
+      map = await LanguageFunctions.getBaseAppTranslationMap("en-au_broken");
+    } catch (e) {
+      emptyErrorMsg = (e as Error).message;
+    }
+    assert.deepStrictEqual(map, undefined, "Expected map to be undefined");
+    assert.deepStrictEqual(
+      emptyErrorMsg.match(reEmptyFileError)?.length,
+      1,
+      "Unexpected error message for empty file."
+    );
+
+    // Corrupt file test
+    const reCorruptFile = new RegExp(
+      /Could not parse match file for "en-au_broken\.json"\. Message: Unexpected end of JSON input\..*/gm
+    );
+    writeFileSync(
+      path.resolve(__dirname, "../externalresources/en-au_broken.json"),
+      '{ "broken": "json"'
+    );
+
+    map = undefined;
+    let corruptErrorMsg = "";
+    try {
+      map = await LanguageFunctions.getBaseAppTranslationMap("en-au_broken");
+    } catch (e) {
+      corruptErrorMsg = (e as Error).message;
+    }
+    assert.deepStrictEqual(map, undefined, "Expected map to be undefined");
+
+    assert.deepStrictEqual(
+      corruptErrorMsg.match(reCorruptFile)?.length,
+      1,
+      "Unexpected error message for corrupt file."
     );
   });
 });

--- a/extension/src/test/BaseAppTranslationFiles.test.ts
+++ b/extension/src/test/BaseAppTranslationFiles.test.ts
@@ -24,7 +24,6 @@ suite("Base App Translation Files Tests", function () {
   });
 
   test("localTranslationFiles", async function () {
-    // Only run in GitHub Workflow
     if (!WORKFLOW) {
       this.skip();
     }

--- a/extension/src/test/BaseAppTranslationFiles.test.ts
+++ b/extension/src/test/BaseAppTranslationFiles.test.ts
@@ -2,13 +2,14 @@ import * as assert from "assert";
 import * as BaseAppTranslationFiles from "../externalresources/BaseAppTranslationFiles";
 
 suite("Base App Translation Files Tests", function () {
-  const TIMEOUT = 360000;
+  const TIMEOUT = 360000; // Take some time to download blobs on Ubuntu... and windows!
   const WORKFLOW = process.env.GITHUB_ACTION; // Only run in GitHub Workflow
+
   test("BaseAppTranslationFiles.getBlobs()", async function () {
     if (!WORKFLOW) {
       this.skip();
     }
-    this.timeout(TIMEOUT); // Takes some time to download all files synchronously on GitHubs Ubuntu servers...and windows!
+    this.timeout(TIMEOUT);
     const result = await BaseAppTranslationFiles.baseAppTranslationFiles.getBlobs(); // Gets all the blobs, and I mean aaaall of them.
     console.log("result", result);
     assert.deepStrictEqual(
@@ -27,7 +28,8 @@ suite("Base App Translation Files Tests", function () {
     if (!WORKFLOW) {
       this.skip();
     }
-    this.timeout(TIMEOUT); // Take some time to download blobs on Ubuntu... and windows!
+    this.timeout(TIMEOUT);
+
     const result = await BaseAppTranslationFiles.baseAppTranslationFiles.getBlobs(
       ["sv-se"]
     );

--- a/extension/src/test/BaseAppTranslationFiles.test.ts
+++ b/extension/src/test/BaseAppTranslationFiles.test.ts
@@ -40,7 +40,7 @@ suite("Base App Translation Files Tests", function () {
     );
     assert.deepStrictEqual(
       result.failed.length,
-      1,
+      0,
       "Unexpected number of downloads failed"
     );
     assert.deepStrictEqual(

--- a/extension/src/test/ExternalResources.test.ts
+++ b/extension/src/test/ExternalResources.test.ts
@@ -1,5 +1,5 @@
 import * as assert from "assert";
-import { createWriteStream } from "fs";
+import { createWriteStream, existsSync } from "fs";
 import * as path from "path";
 
 import {
@@ -20,10 +20,9 @@ suite("External Resources Tests", function () {
   const baseUrl =
     "https://nabaltools.file.core.windows.net/shared/base_app_lang_files/";
   const TIMEOUT = 30000;
-
+  const WORKFLOW = process.env.GITHUB_ACTION; // Only run in GitHub Workflow
   test("ExternalResource.get()", async function () {
-    // Only run in GitHub Workflow
-    if (!process.env.GITHUB_ACTION) {
+    if (!WORKFLOW) {
       this.skip();
     }
     this.timeout(TIMEOUT);
@@ -33,12 +32,12 @@ suite("External Resources Tests", function () {
       "utf8"
     );
     await extResource.get(writeStream);
-    assert.notEqual(
+    assert.notDeepStrictEqual(
       writeStream.bytesWritten,
       0,
       "Expected bytes to be written"
     );
-    assert.equal(
+    assert.deepStrictEqual(
       writeStream.bytesWritten,
       7384660,
       "unexpected byte number of bytes written"
@@ -47,16 +46,27 @@ suite("External Resources Tests", function () {
 
   test("ExternalResource.url()", function () {
     const extResource = new ExternalResource("sv-se.json", href);
-    assert.equal(href, fullUrl, "href is not correct");
-    assert.equal(extResource.url().href, href, "Unexpected url");
-    assert.equal(extResource.url().hostname, hostname, "Unexpected Hostname");
-    assert.equal(extResource.url().pathname, pathname, "Unexpected path");
-    assert.equal(extResource.url().search, search, "Unexpected search params");
+    assert.deepStrictEqual(href, fullUrl, "href is not correct");
+    assert.deepStrictEqual(extResource.url().href, href, "Unexpected url");
+    assert.deepStrictEqual(
+      extResource.url().hostname,
+      hostname,
+      "Unexpected Hostname"
+    );
+    assert.deepStrictEqual(
+      extResource.url().pathname,
+      pathname,
+      "Unexpected path"
+    );
+    assert.deepStrictEqual(
+      extResource.url().search,
+      search,
+      "Unexpected search params"
+    );
   });
 
   test("AzureBlobContainer.getBlobs()", async function () {
-    // Only run in GitHub Workflow
-    if (!process.env.GITHUB_ACTION) {
+    if (!WORKFLOW) {
       this.skip();
     }
     this.timeout(TIMEOUT);
@@ -64,6 +74,13 @@ suite("External Resources Tests", function () {
     const blobContainer = new BlobContainer(exportPath, baseUrl, sasToken);
     blobContainer.addBlob("sv-se.json");
     const result = await blobContainer.getBlobs();
+    assert.deepStrictEqual(
+      result.succeded.length,
+      1,
+      "Unexpected number of files downloaded"
+    );
+  });
+
     assert.equal(result, 1, "Unexpected number of files downloaded");
   });
 });

--- a/extension/src/test/ExternalResources.test.ts
+++ b/extension/src/test/ExternalResources.test.ts
@@ -81,6 +81,45 @@ suite("External Resources Tests", function () {
     );
   });
 
-    assert.equal(result, 1, "Unexpected number of files downloaded");
+  test("#190 - Unexpected end of JSON input", async function () {
+    // github.com/jwikman/nab-al-tools/issues/190
+
+    if (!WORKFLOW) {
+      this.skip();
+    }
+
+    this.timeout(TIMEOUT); // Take some time to download blobs on Ubuntu... and windows!
+    const langCode = {
+      corrupt: "en-au_broken",
+      pristine: "sv-se",
+    };
+    const exportPath = path.resolve(__dirname);
+    const blobContainer = new BlobContainer(exportPath, baseUrl, sasToken);
+    blobContainer.addBlob(`${langCode.corrupt}.json`);
+    blobContainer.addBlob(`${langCode.pristine}.json`);
+    const result = await blobContainer.getBlobs([
+      langCode.corrupt,
+      langCode.pristine,
+    ]);
+    assert.deepStrictEqual(
+      result.succeded.length,
+      1,
+      "Unexpected number of files downloaded"
+    );
+    assert.deepStrictEqual(
+      result.failed.length,
+      1,
+      "Unexpected number of failed downloads"
+    );
+    assert.deepStrictEqual(
+      existsSync(path.resolve(__dirname, `${langCode.corrupt}.json`)),
+      false,
+      `File "${langCode.corrupt}.json" should not exist`
+    );
+    assert.deepStrictEqual(
+      existsSync(path.resolve(__dirname, `${langCode.pristine}.json`)),
+      true,
+      `File "${langCode.pristine}.json" should not exist`
+    );
   });
 });

--- a/extension/src/test/ExternalResources.test.ts
+++ b/extension/src/test/ExternalResources.test.ts
@@ -19,13 +19,14 @@ suite("External Resources Tests", function () {
     "sv=2019-12-12&ss=f&srt=o&sp=r&se=2021-11-25T05:28:10Z&st=2020-11-24T21:28:10Z&spr=https&sig=JP3RwQVCZBo16vJCznojVIMvPOHgnDuH937ppzPmEqQ%3D";
   const baseUrl =
     "https://nabaltools.file.core.windows.net/shared/base_app_lang_files/";
-  const TIMEOUT = 30000;
+  const TIMEOUT = 30000; // Take some time to download blobs on Ubuntu... and windows!
   const WORKFLOW = process.env.GITHUB_ACTION; // Only run in GitHub Workflow
   test("ExternalResource.get()", async function () {
     if (!WORKFLOW) {
       this.skip();
     }
     this.timeout(TIMEOUT);
+
     const extResource = new ExternalResource("sv-se.json", href);
     const writeStream = createWriteStream(
       path.resolve(__dirname, "test.json"),
@@ -70,6 +71,7 @@ suite("External Resources Tests", function () {
       this.skip();
     }
     this.timeout(TIMEOUT);
+
     const exportPath = path.resolve(__dirname);
     const blobContainer = new BlobContainer(exportPath, baseUrl, sasToken);
     blobContainer.addBlob("sv-se.json");
@@ -87,8 +89,8 @@ suite("External Resources Tests", function () {
     if (!WORKFLOW) {
       this.skip();
     }
+    this.timeout(TIMEOUT);
 
-    this.timeout(TIMEOUT); // Take some time to download blobs on Ubuntu... and windows!
     const langCode = {
       corrupt: "en-au_broken",
       pristine: "sv-se",

--- a/extension/src/test/ExternalResources.test.ts
+++ b/extension/src/test/ExternalResources.test.ts
@@ -119,7 +119,7 @@ suite("External Resources Tests", function () {
     assert.deepStrictEqual(
       existsSync(path.resolve(__dirname, `${langCode.pristine}.json`)),
       true,
-      `File "${langCode.pristine}.json" should not exist`
+      `File "${langCode.pristine}.json" should exist`
     );
   });
 });


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
Mitigates parts of the problem in #190  .

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- More informative message when parsing of translation maps fail.
- `NAB: Download Base App Translation Files` now shows number of succeded / failed downloads
- Changed return signature of `BlobContainer.getBlobs` to return an object `{  succeded: 0, failed: 0 }` represented by new interface `BlobDownloadResult`.
- After translation maps are downloaded we try parsing them, if parsing fails the file is deleted.

This isn't the solution to the core problem with partial downloads but it will mitigate some of the issues and make for a less disruptive experience for the user. 


Additional comments:
Tried another way of parsing the xliffs from Base App without success. I think this is as fast as it gets with Python at least. I'm not saying it's bad, the total runtime of the script is not really an issue. I'm just stating that I'm quite proud of  my self ;) I started building one in c++ during the summer witch might be blazing fast, we'll se if I ever finish it :) 