### PR TITLE
Added "app-name" to info.json

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -11,6 +11,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - Changes:
   - To enable matching of translations with Base App we store map files in json format in a blob storage. The files are then downloaded when needed (if you have selected to match with Base App in the settings). At times the download would fail which could lead to empty or corrupted files which in turn could lead to errors with poor information. To mitigate the effects of this we have improved the information presented when certain functions fail. Translation maps corrupted by failed download are now also deleted which in turn will lead to a new download when triggered by either `NAB: Download Base App Translation Files`, `NAB: Refresh XLF Files from g.xlf` or `NAB: Update all XLF Files`. We haven't yet solved the problem within the download leaving corrupted files, we'll continue to investigate this. At the moment poor connection speeds seems to be the problem, we hope to find a way to work around it. Please continue to report any problems you run into regarding this by creating an [issue](https://github.com/jwikman/nab-al-tools/issues). Big thanks to [@RodrigoPuelma](https://github.com/RodrigoPuelma) for bringing this to our attention in [issue 190](https://github.com/jwikman/nab-al-tools/issues/190).
+  - Added "app-name" to the info.json created when external documentation is generated.
 
 ## [1.6.0] - 2021-08-23
 

--- a/extension/src/Documentation.ts
+++ b/extension/src/Documentation.ts
@@ -78,6 +78,7 @@ export async function generateExternalDocumentation(
     const info = {
       "generated-date": formatToday(),
       generator: `${extensionName} v${extensionVersion}`,
+      "app-name": appManifest.name,
       "app-version": appManifest.version,
     };
 


### PR DESCRIPTION
Changes proposed in this pull request:
Adds the app name to the info.json created when generating external documentation. This can be useful as metadata for DocFx or other engines that transforms the md files to html.