### PR TITLE
Xliff CSV export bonus features

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -243,6 +243,10 @@
                 "title": "NAB: Export Translations to .csv"
             },
             {
+                "command": "nab.exportTranslationsCSVColumnSelect",
+                "title": "NAB: Export Translations to .csv (Select columns and filter)"
+            },
+            {
                 "command": "nab.importTranslationCSV",
                 "title": "NAB: Import Translations from .csv"
             }

--- a/extension/src/CSV/CSV.ts
+++ b/extension/src/CSV/CSV.ts
@@ -4,14 +4,17 @@ import * as path from "path";
 export class CSV {
   public lines: string[][] = [];
   public path = "";
-  public headers: string[] = [];
   public encoding = "utf8";
 
   private ext = "";
   private eol = "\r\n";
   private bom = "";
+  private _headers: string[] = [];
 
-  constructor(public name: string = "", public separator = "\t") {}
+  constructor(public name: string = "", public separator = "\t") {
+    this.headers = ["Id", "Source", "Target"];
+  }
+
   public set extension(ext: string) {
     this.ext = ext;
   }
@@ -40,6 +43,17 @@ export class CSV {
       headerMap.set(header, index);
     }
     return headerMap;
+  }
+
+  public get headers(): string[] {
+    return this._headers;
+  }
+
+  public set headers(headers: string[]) {
+    this._headers = [
+      ...this._headers,
+      ...headers.filter((h) => this._headers.indexOf(h) === -1),
+    ];
   }
 
   public addLine(line: string[]): void {

--- a/extension/src/CSV/CSV.ts
+++ b/extension/src/CSV/CSV.ts
@@ -11,9 +11,7 @@ export class CSV {
   private bom = "";
   private _headers: string[] = [];
 
-  constructor(public name: string = "", public separator = "\t") {
-    this.headers = ["Id", "Source", "Target"];
-  }
+  constructor(public name: string = "", public separator = "\t") {}
 
   public set extension(ext: string) {
     this.ext = ext;

--- a/extension/src/CSV/ExportXliffCSV.ts
+++ b/extension/src/CSV/ExportXliffCSV.ts
@@ -24,14 +24,14 @@ export function createXliffCSV(xlf: Xliff): CSV {
       tu.id,
       checkNoInvalidCharacters(tu.source, csv.headers[1], tu.id),
       checkNoInvalidCharacters(tu.target.textContent, csv.headers[2], tu.id),
-      developerNote.textContent === undefined
+      developerNote?.textContent === undefined
         ? ""
         : checkNoInvalidCharacters(
             developerNote.textContent,
             csv.headers[3],
             tu.id
           ),
-      tu.maxwidth === undefined ? "" : tu.maxwidth.toString(),
+      tu?.maxwidth === undefined ? "" : tu.maxwidth.toString(),
       "", // comment
       generatorNote?.textContent === undefined
         ? ""
@@ -40,7 +40,7 @@ export function createXliffCSV(xlf: Xliff): CSV {
             csv.headers[6],
             tu.id
           ),
-      customNote.textContent === undefined
+      customNote?.textContent === undefined
         ? ""
         : checkNoInvalidCharacters(
             customNote.textContent,

--- a/extension/src/CSV/ExportXliffCSV.ts
+++ b/extension/src/CSV/ExportXliffCSV.ts
@@ -1,7 +1,10 @@
 import { CustomNoteType, Xliff } from "../Xliff/XLIFFDocument";
 import { CSV } from "./CSV";
 
-export function createXliffCSV(xlf: Xliff): CSV {
+export function createXliffCSV(
+  xlf: Xliff,
+  options?: { columns: string[]; filter: string }
+): CSV {
   const csv = new CSV();
   csv.headers = [
     "Id",
@@ -73,7 +76,8 @@ export function createXliffCSV(xlf: Xliff): CSV {
 export function exportXliffCSV(
   exportPath: string,
   name: string,
-  xlf: Xliff
+  xlf: Xliff,
+  options?: { columns: string[]; filter: string }
 ): CSV {
   const csv = createXliffCSV(xlf);
   csv.path = exportPath;

--- a/extension/src/CSV/ExportXliffCSV.ts
+++ b/extension/src/CSV/ExportXliffCSV.ts
@@ -1,4 +1,3 @@
-import { isNullOrUndefined } from "util";
 import { CustomNoteType, Xliff } from "../Xliff/XLIFFDocument";
 import { CSV } from "./CSV";
 
@@ -25,14 +24,14 @@ export function createXliffCSV(xlf: Xliff): CSV {
       tu.id,
       checkNoInvalidCharacters(tu.source, csv.headers[1], tu.id),
       checkNoInvalidCharacters(tu.target.textContent, csv.headers[2], tu.id),
-      isNullOrUndefined(developerNote?.textContent)
+      developerNote.textContent === undefined
         ? ""
         : checkNoInvalidCharacters(
             developerNote.textContent,
             csv.headers[3],
             tu.id
           ),
-      isNullOrUndefined(tu.maxwidth) ? "" : tu.maxwidth.toString(),
+      tu.maxwidth === undefined ? "" : tu.maxwidth.toString(),
       "", // comment
       generatorNote?.textContent === undefined
         ? ""
@@ -41,7 +40,7 @@ export function createXliffCSV(xlf: Xliff): CSV {
             csv.headers[6],
             tu.id
           ),
-      isNullOrUndefined(customNote?.textContent)
+      customNote.textContent === undefined
         ? ""
         : checkNoInvalidCharacters(
             customNote.textContent,

--- a/extension/src/CSV/ImportXliffCSV.ts
+++ b/extension/src/CSV/ImportXliffCSV.ts
@@ -112,5 +112,5 @@ function testRequiredHeaders(
 }
 
 function isHeader(line: string[]): boolean {
-  return line.slice(0, 3).toString() === new CSV().headers.toString();
+  return line.slice(0, 3).toString() === ["Id", "Source", "Target"].toString();
 }

--- a/extension/src/CSV/ImportXliffCSV.ts
+++ b/extension/src/CSV/ImportXliffCSV.ts
@@ -24,10 +24,12 @@ export function importXliffCSV(
   }
   const headerIndexMap = csv.headerIndexMap;
   testRequiredHeaders(headerIndexMap, requiredHeaders);
-
   csv.lines
     .filter((l) => l.length > 1)
     .forEach((line) => {
+      if (isHeader(line)) {
+        return;
+      }
       const values = {
         id: line[<number>headerIndexMap.get("Id")],
         source: line[<number>headerIndexMap.get("Source")],
@@ -108,4 +110,9 @@ function testRequiredHeaders(
       throw new Error(`Missing required header "${requiredHeaders[i]}"`);
     }
   }
+}
+
+function isHeader(line: string[]): boolean {
+  console.log(new CSV().headers);
+  return line.slice(0, 3).toString() === new CSV().headers.toString();
 }

--- a/extension/src/CSV/ImportXliffCSV.ts
+++ b/extension/src/CSV/ImportXliffCSV.ts
@@ -1,4 +1,3 @@
-import { isNullOrUndefined } from "util";
 import { CustomNoteType, TargetState, Xliff } from "../Xliff/XLIFFDocument";
 import { CSV } from "./CSV";
 
@@ -39,7 +38,7 @@ export function importXliffCSV(
       };
 
       const transUnit = updateXlf.getTransUnitById(values.id);
-      if (isNullOrUndefined(transUnit)) {
+      if (transUnit === undefined) {
         throw new Error(
           `Could not find any translation unit with id "${values.id}" in "${updateXlf._path}"`
         );

--- a/extension/src/CSV/ImportXliffCSV.ts
+++ b/extension/src/CSV/ImportXliffCSV.ts
@@ -112,6 +112,5 @@ function testRequiredHeaders(
 }
 
 function isHeader(line: string[]): boolean {
-  console.log(new CSV().headers);
   return line.slice(0, 3).toString() === new CSV().headers.toString();
 }

--- a/extension/src/CSV/ImportXliffCSV.ts
+++ b/extension/src/CSV/ImportXliffCSV.ts
@@ -7,10 +7,9 @@ export function importXliffCSV(
   useTargetStates: boolean,
   xliffCSVImportTargetState: string
 ): number {
-  const requiredHeaders: string[] = ["Id", "Source", "Target"];
-
   let updatedTargets = 0;
   const csv = new CSV();
+  const requiredHeaders = csv.headers;
   csv.encoding = "utf8bom";
   csv.readFileSync(csvPath);
 

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -771,6 +771,13 @@ export async function exportTranslationsCSV(
     canPickMany: true,
     placeHolder: "Select translation files to export...",
   });
+  if (exportFiles === undefined || exportFiles.length === 0) {
+    showErrorAndLog(
+      "Export translations csv",
+      new Error("No files were selected for export")
+    );
+    return;
+  }
   const selectableFilters = { all: "All", review: "In need of review" };
   const exportOptions: IExportOptions = {
     columns: [],
@@ -820,9 +827,6 @@ export async function exportTranslationsCSV(
   }
 
   try {
-    if (exportFiles === undefined || exportFiles.length === 0) {
-      throw new Error("No files were selected for export");
-    }
     let exportPath = SettingsLoader.getSettings().xliffCSVExportPath;
     if (exportPath.length === 0) {
       exportPath = WorkspaceFunctions.getTranslationFolderPath(settings);

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -121,6 +121,15 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand("nab.exportTranslationsCSV", () => {
       NABfunctions.exportTranslationsCSV();
     }),
+    vscode.commands.registerCommand(
+      "nab.exportTranslationsCSVColumnSelect",
+      () => {
+        NABfunctions.exportTranslationsCSV({
+          selectColumns: true,
+          selectFilter: true,
+        });
+      }
+    ),
     vscode.commands.registerCommand("nab.importTranslationCSV", () => {
       NABfunctions.importTranslationCSV();
     }),

--- a/extension/src/test/CSV.test.ts
+++ b/extension/src/test/CSV.test.ts
@@ -10,25 +10,29 @@ suite("CSV Import / Export Tests", function () {
   test("ExportXliffCSV.createXliffCSV()", async function () {
     const xlf = Xliff.fromString(smallXliffXml());
     const csv = createXliffCSV(xlf);
-    assert.equal(csv.headers.length, 10, "unexpected number of header columns");
-    assert.equal(csv.lines.length, 2, "Unexpected number of lines");
-    assert.equal(
+    assert.deepStrictEqual(
+      csv.headers.length,
+      10,
+      "unexpected number of header columns"
+    );
+    assert.deepStrictEqual(csv.lines.length, 2, "Unexpected number of lines");
+    assert.deepStrictEqual(
       csv.lines[0].length,
       10,
       "Unexpected number of columns on line 0"
     );
-    assert.equal(
+    assert.deepStrictEqual(
       csv.lines[0].filter((col) => col === "").length,
       1,
       "Expected only one empty column for line 0 (Comment)."
     );
-    assert.equal(
+    assert.deepStrictEqual(
       csv.lines[1].length,
       10,
       "Unexpected number of columns on line 1"
     );
     const csvAsText = csv.toString();
-    assert.equal(
+    assert.deepStrictEqual(
       csvAsText.split("\r\n").length,
       csv.lines.length + 1,
       "Unexpected number of exported lines."
@@ -47,14 +51,14 @@ suite("CSV Import / Export Tests", function () {
     const exportPath = path.resolve(__dirname, testResourcesPath, "temp");
     const importPath = path.resolve(exportPath, `${name}.csv`);
     const csv = exportXliffCSV(exportPath, name, xlf);
-    assert.equal(
+    assert.deepStrictEqual(
       importXliffCSV(xlf, importPath, false, "(leave)"),
       0,
       "Expected no changes in xlf"
     );
     csv.lines[1][2] = "Cool";
     csv.writeFileSync();
-    assert.equal(
+    assert.deepStrictEqual(
       importXliffCSV(xlf, importPath, false, "(leave)"),
       1,
       "Expected 1 change in xlf"


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
Fixes #140  .

It became a bit more messy than I originally had in mind but I think it's a decent solution that can be further extended in the future. I was running out of inspiration in the end so maybe I'm way off :dog: 

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- Adjust `NABFunctions.exportTranslationsCSV` to take optional object parameter `{ selectColumns: boolean, selectFilter: boolean }`
- Add new command `nab.exportTranslationsCSVColumnSelect` which calls `NABFunctions.exportTranslationsCSV`  with `{ selectColumns: true, selectFilter: true }`. Previous existing command `nab.exportTranslationsCSV` remains unchanged. 
- User is presented with two new quick picks, columns and filter.
  - If the user escapes column select we continue since Id, Source and target are default.
  - If the user escapes filter select an error is show and the function is exited.
- CSV file is exported with selected column and filter.

Additional comments
- ImportXliffCSV got a new function (`isHeader`) to determine if a line is considered a header. I was a bit surprised by the sudden need for this so that'll need some special attention and more testing on my part before merge.
- The `headers` property of `CSV` class is now set to private and I added get/set methods. Where the setter joins the passed array with the existing keeping only the unique values. This change was part of a mistake I made declaring the default headers of the XLIFF export in the CSV class (which is intended to be a generic CSV class). Maybe this should be restored or maybe it's a neat feature?

Before merge:
- [ ] Update CHANGELOG.md.
- [ ] Test ImportXliffCSV (`isHeader` change)
- [ ] Keep get/set change for header in `CSV` class?


