### PR TITLE
Refactor functions to getters on Settings

### DIFF
--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -680,16 +680,13 @@ export async function createNewTargetXlf(): Promise<void> {
 
     const appName = appManifest.name;
     const gXlfPath = WorkspaceFunctions.getGXlfFilePath(settings, appManifest);
-    const translationFolderPath = WorkspaceFunctions.getTranslationFolderPath(
-      settings
-    );
     const matchBaseAppTranslation =
       undefined === selectedMatchBaseApp
         ? false
         : selectedMatchBaseApp.join("").toLowerCase() === "yes";
     const targetXlfFilename = `${appName}.${targetLanguage}.xlf`;
     const targetXlfFilepath = path.join(
-      translationFolderPath,
+      settings.translationFolderPath,
       targetXlfFilename
     );
     const languageFunctionsSettings = new LanguageFunctionsSettings(
@@ -821,7 +818,7 @@ export async function exportTranslationsCSV(
   try {
     let exportPath = SettingsLoader.getSettings().xliffCSVExportPath;
     if (exportPath.length === 0) {
-      exportPath = WorkspaceFunctions.getTranslationFolderPath(settings);
+      exportPath = settings.translationFolderPath;
     }
     const alAppName = appManifest.name;
     exportFiles.forEach((f) => {
@@ -994,11 +991,10 @@ export function openDTS(): void {
     url = `https://support.lcs.dynamics.com/RegFTranslationRequestProject/Index/${dtsProjectId}`;
   }
   const settings = SettingsLoader.getSettings();
-  const dtsWorkFolderPath = WorkspaceFunctions.getDtsWorkFolderPath(settings);
   LanguageFunctions.zipXlfFiles(
     settings,
     SettingsLoader.getAppManifest(),
-    dtsWorkFolderPath
+    settings.dtsWorkFolderPath
   );
   vscode.env.openExternal(vscode.Uri.parse(url));
 }

--- a/extension/src/Settings/Settings.ts
+++ b/extension/src/Settings/Settings.ts
@@ -64,6 +64,10 @@ export class Settings {
   public get translationFolderPath(): string {
     return path.join(this.workspaceFolderPath, "Translations");
   }
+
+  public get dtsWorkFolderPath(): string {
+    return path.join(this.workspaceFolderPath, ".dts");
+  }
 }
 
 export interface IAppManifest {

--- a/extension/src/WorkspaceFunctions.ts
+++ b/extension/src/WorkspaceFunctions.ts
@@ -140,25 +140,15 @@ export async function getAlObjectsFromSymbols(
   return alObjects;
 }
 
-export function getTranslationFolderPath(settings: Settings): string {
-  const translationFolderPath = path.join(
-    settings.workspaceFolderPath,
-    "Translations"
-  );
-  return translationFolderPath;
-}
-
-export function getDtsWorkFolderPath(settings: Settings): string {
-  return path.join(settings.workspaceFolderPath, ".dts");
-}
 export function getDtsOutputFiles(settings: Settings): string[] {
-  const dtsFolderPath = getDtsWorkFolderPath(settings);
-
-  const filePaths = FileFunctions.findFiles("*_output.zip", dtsFolderPath);
+  const filePaths = FileFunctions.findFiles(
+    "*_output.zip",
+    settings.dtsWorkFolderPath
+  );
 
   if (filePaths.length === 0) {
     throw new Error(
-      `No DTS output zip files found in the folder "${dtsFolderPath}"\nDownload the zip files with translation files and save them in this folder. The filename should match the pattern *_output.zip.`
+      `No DTS output zip files found in the folder "${settings.dtsWorkFolderPath}"\nDownload the zip files with translation files and save them in this folder. The filename should match the pattern *_output.zip.`
     );
   }
   return filePaths;
@@ -168,16 +158,15 @@ export function getGXlfFilePath(
   settings: Settings,
   appManifest: AppManifest
 ): string {
-  const translationFolderPath = getTranslationFolderPath(settings);
   const expectedName = getgXlfFileName(appManifest);
   const fileUriArr = FileFunctions.findFiles(
     expectedName,
-    translationFolderPath
+    settings.translationFolderPath
   );
 
   if (fileUriArr.length === 0) {
     throw new Error(
-      `The file ${expectedName} was not found in the translation folder "${translationFolderPath}"`
+      `The file ${expectedName} was not found in the translation folder "${settings.translationFolderPath}"`
     );
   }
   return fileUriArr[0];
@@ -195,16 +184,15 @@ export function getLangXlfFiles(
   settings: Settings,
   appManifest: AppManifest
 ): string[] {
-  const translationFolderPath = getTranslationFolderPath(settings);
   const gXlfName = getgXlfFileName(appManifest);
 
   const xlfFilePaths = FileFunctions.findFiles(
     "*.xlf",
-    translationFolderPath
+    settings.translationFolderPath
   ).filter((filePath) => !filePath.endsWith(gXlfName));
   if (xlfFilePaths.length === 0) {
     throw new Error(
-      `No language files found in the translation folder "${translationFolderPath}"\nTo get started: Copy the file ${gXlfName} to a new file and change target-language`
+      `No language files found in the translation folder "${settings.translationFolderPath}"\nTo get started: Copy the file ${gXlfName} to a new file and change target-language`
     );
   }
   return xlfFilePaths;


### PR DESCRIPTION
<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- Delete `WorkspaceFunctions.getTranslationFolderPath`
   - Replace with `Settings.translationFolderPath`
- Delete `WorkspaceFunctions.getDtsWorkFolderPath`
   - Replace with `Settings.dtsWorkFolderPath`



