### PR TITLE
Allow comments after object description

### DIFF
--- a/extension/src/ALObject/ALParser.ts
+++ b/extension/src/ALObject/ALParser.ts
@@ -650,7 +650,7 @@ function loadObjectDescriptor(
     case ALObjectType.xmlPort:
     case ALObjectType.enum: {
       let objectDescriptorPattern = new RegExp(
-        `(\\w+) +([0-9]+) +(${objectNamePattern}|${objectNameNoQuotesPattern})([^"\n]*"[^"\n]*)?`
+        `(\\w+) +([0-9]+) +(${objectNamePattern}|${objectNameNoQuotesPattern})([^"\n]*(?!(?://|/*))"[^"\n]*)?`
       );
       let currObject = objectDescriptorCode.match(objectDescriptorPattern);
       if (currObject === null) {

--- a/extension/src/ALObject/ALParser.ts
+++ b/extension/src/ALObject/ALParser.ts
@@ -650,7 +650,7 @@ function loadObjectDescriptor(
     case ALObjectType.xmlPort:
     case ALObjectType.enum: {
       let objectDescriptorPattern = new RegExp(
-        `(\\w+) +([0-9]+) +(${objectNamePattern}|${objectNameNoQuotesPattern})([^"\n]*(?!(?://|/*))"[^"\n]*)?`
+        `(\\w+) +([0-9]+) +(${objectNamePattern}|${objectNameNoQuotesPattern})([^"\n]*"[^"\n]*)?`
       );
       let currObject = objectDescriptorCode.match(objectDescriptorPattern);
       if (currObject === null) {
@@ -660,7 +660,7 @@ function loadObjectDescriptor(
       }
       if (currObject[4] !== undefined) {
         objectDescriptorPattern = new RegExp(
-          `(\\w+) +([0-9]+) +(${objectNamePattern}|${objectNameNoQuotesPattern}) implements ([^"\n]*"[^"\n]*)?`
+          `(\\w+) +([0-9]+) +(${objectNamePattern}|${objectNameNoQuotesPattern})( implements ([^"\n]*"[^"\n]*)?| *\\/\\/| *\\/\\*)`
         );
         currObject = objectDescriptorCode.match(objectDescriptorPattern);
         if (currObject === null) {

--- a/extension/src/test/ALObjectTestLibrary.ts
+++ b/extension/src/test/ALObjectTestLibrary.ts
@@ -135,7 +135,23 @@ export function getValidObjectDescriptors(): {
       objectName: "QWESR Communication Method Mgt",
     },
     {
+      objectDescriptor: 'codeunit 70314130 "QWESR Communication Method Mgt" //some \"comment\"',
+      objectName: "QWESR Communication Method Mgt",
+    },
+    {
+      objectDescriptor: 'codeunit 70314130 "QWESR Communication Method Mgt" /*some \"comment\" */',
+      objectName: "QWESR Communication Method Mgt",
+    },
+    {
       objectDescriptor: "codeunit 70314130 CommunicationMethodMgt",
+      objectName: "CommunicationMethodMgt",
+    },
+    {
+      objectDescriptor: "codeunit 70314130 CommunicationMethodMgt //some \"comment\"",
+      objectName: "CommunicationMethodMgt",
+    },
+    {
+      objectDescriptor: "codeunit 70314130 CommunicationMethodMgt /*some \"comment\" */",
       objectName: "CommunicationMethodMgt",
     },
     {

--- a/extension/src/test/ALObjectTestLibrary.ts
+++ b/extension/src/test/ALObjectTestLibrary.ts
@@ -123,68 +123,68 @@ export function getValidObjectDescriptors(): {
     {
       objectDescriptor:
         'codeunit 70314129 "QWESR IQCM S/Ftp Handler" implements "QWESR IQCM", "QWESR IQCM Import", "QWESR IQCM Export"',
-      objectName: "QWESR IQCM S/Ftp Handler",
+      objectName: 'QWESR IQCM S/Ftp Handler',
     },
     {
       objectDescriptor:
         'enum 70314080 "QWESR IQCM" implements "QWESR IQCM", "QWESR IQCM Import", "QWESR IQCM Export", "QWESR IQCM Function"',
-      objectName: "QWESR IQCM",
+      objectName: 'QWESR IQCM',
     },
     {
       objectDescriptor: 'codeunit 70314130 "QWESR Communication Method Mgt"',
-      objectName: "QWESR Communication Method Mgt",
+      objectName: 'QWESR Communication Method Mgt',
     },
     {
-      objectDescriptor: 'codeunit 70314130 "QWESR Communication Method Mgt" //some \"comment\"',
-      objectName: "QWESR Communication Method Mgt",
+      objectDescriptor: 'codeunit 70314130 "QWESR Communication Method Mgt" //some "comment"',
+      objectName: 'QWESR Communication Method Mgt',
     },
     {
-      objectDescriptor: 'codeunit 70314130 "QWESR Communication Method Mgt" /*some \"comment\" */',
-      objectName: "QWESR Communication Method Mgt",
+      objectDescriptor: 'codeunit 70314130 "QWESR Communication Method Mgt" /*some "comment" */',
+      objectName: 'QWESR Communication Method Mgt',
     },
     {
-      objectDescriptor: "codeunit 70314130 CommunicationMethodMgt",
-      objectName: "CommunicationMethodMgt",
+      objectDescriptor: 'codeunit 70314130 CommunicationMethodMgt',
+      objectName: 'CommunicationMethodMgt',
     },
     {
-      objectDescriptor: "codeunit 70314130 CommunicationMethodMgt //some \"comment\"",
-      objectName: "CommunicationMethodMgt",
+      objectDescriptor: 'codeunit 70314130 CommunicationMethodMgt //some "comment"',
+      objectName: 'CommunicationMethodMgt',
     },
     {
-      objectDescriptor: "codeunit 70314130 CommunicationMethodMgt /*some \"comment\" */",
-      objectName: "CommunicationMethodMgt",
+      objectDescriptor: 'codeunit 70314130 CommunicationMethodMgt /*some "comment" */',
+      objectName: 'CommunicationMethodMgt',
     },
     {
       objectDescriptor:
         'pageextension 70219910 "QWESP Customer Card" extends "Customer Card" // 21',
-      objectName: "QWESP Customer Card",
+      objectName: 'QWESP Customer Card',
     },
     {
       objectDescriptor:
         'pageextension 70219910 "QWESP Customer Card" extends CustomerCard // 21',
-      objectName: "QWESP Customer Card",
+      objectName: 'QWESP Customer Card',
     },
     {
       objectDescriptor:
         'pageextension 70219910 QWESPCustomerCard extends "Customer Card" // 21',
-      objectName: "QWESPCustomerCard",
+      objectName: 'QWESPCustomerCard',
     },
     {
       objectDescriptor:
-        "pageextension 70219910 QWESPCustomerCard extends CustomerCard // 21",
-      objectName: "QWESPCustomerCard",
+        'pageextension 70219910 QWESPCustomerCard extends CustomerCard // 21',
+      objectName: 'QWESPCustomerCard',
     },
     {
       objectDescriptor: 'profile "QWESP Time Sheet Role Center"',
-      objectName: "QWESP Time Sheet Role Center",
+      objectName: 'QWESP Time Sheet Role Center',
     },
     {
       objectDescriptor: 'interface "QWESR Integration Type"',
-      objectName: "QWESR Integration Type",
+      objectName: 'QWESR Integration Type',
     },
     {
       objectDescriptor: 'permissionset 123456789 "QWESR Admin"',
-      objectName: "QWESR Admin",
+      objectName: 'QWESR Admin',
     },
   ];
 }

--- a/extension/src/test/ALObjectTestLibrary.ts
+++ b/extension/src/test/ALObjectTestLibrary.ts
@@ -123,68 +123,72 @@ export function getValidObjectDescriptors(): {
     {
       objectDescriptor:
         'codeunit 70314129 "QWESR IQCM S/Ftp Handler" implements "QWESR IQCM", "QWESR IQCM Import", "QWESR IQCM Export"',
-      objectName: 'QWESR IQCM S/Ftp Handler',
+      objectName: "QWESR IQCM S/Ftp Handler",
     },
     {
       objectDescriptor:
         'enum 70314080 "QWESR IQCM" implements "QWESR IQCM", "QWESR IQCM Import", "QWESR IQCM Export", "QWESR IQCM Function"',
-      objectName: 'QWESR IQCM',
+      objectName: "QWESR IQCM",
     },
     {
       objectDescriptor: 'codeunit 70314130 "QWESR Communication Method Mgt"',
-      objectName: 'QWESR Communication Method Mgt',
+      objectName: "QWESR Communication Method Mgt",
     },
     {
-      objectDescriptor: 'codeunit 70314130 "QWESR Communication Method Mgt" //some "comment"',
-      objectName: 'QWESR Communication Method Mgt',
+      objectDescriptor:
+        'codeunit 70314130 "QWESR Communication Method Mgt" //some "comment"',
+      objectName: "QWESR Communication Method Mgt",
     },
     {
-      objectDescriptor: 'codeunit 70314130 "QWESR Communication Method Mgt" /*some "comment" */',
-      objectName: 'QWESR Communication Method Mgt',
+      objectDescriptor:
+        'codeunit 70314130 "QWESR Communication Method Mgt" /*some "comment" */',
+      objectName: "QWESR Communication Method Mgt",
     },
     {
-      objectDescriptor: 'codeunit 70314130 CommunicationMethodMgt',
-      objectName: 'CommunicationMethodMgt',
+      objectDescriptor: "codeunit 70314130 CommunicationMethodMgt",
+      objectName: "CommunicationMethodMgt",
     },
     {
-      objectDescriptor: 'codeunit 70314130 CommunicationMethodMgt //some "comment"',
-      objectName: 'CommunicationMethodMgt',
+      objectDescriptor:
+        'codeunit 70314130 CommunicationMethodMgt //some "comment"',
+      objectName: "CommunicationMethodMgt",
     },
     {
-      objectDescriptor: 'codeunit 70314130 CommunicationMethodMgt /*some "comment" */',
-      objectName: 'CommunicationMethodMgt',
+      objectDescriptor:
+        'codeunit 70314130 CommunicationMethodMgt /*some "comment" */',
+      objectName: "CommunicationMethodMgt",
     },
     {
       objectDescriptor:
         'pageextension 70219910 "QWESP Customer Card" extends "Customer Card" // 21',
-      objectName: 'QWESP Customer Card',
+      objectName: "QWESP Customer Card",
     },
     {
       objectDescriptor:
         'pageextension 70219910 "QWESP Customer Card" extends CustomerCard // 21',
-      objectName: 'QWESP Customer Card',
+      objectName: "QWESP Customer Card",
     },
     {
       objectDescriptor:
         'pageextension 70219910 QWESPCustomerCard extends "Customer Card" // 21',
-      objectName: 'QWESPCustomerCard',
+      objectName: "QWESPCustomerCard",
     },
     {
       objectDescriptor:
-        'pageextension 70219910 QWESPCustomerCard extends CustomerCard // 21',
-      objectName: 'QWESPCustomerCard',
+        "pageextension 70219910 QWESPCustomerCard extends CustomerCard // 21",
+      objectName: "QWESPCustomerCard",
     },
     {
       objectDescriptor: 'profile "QWESP Time Sheet Role Center"',
-      objectName: 'QWESP Time Sheet Role Center',
+      objectName: "QWESP Time Sheet Role Center",
     },
     {
       objectDescriptor: 'interface "QWESR Integration Type"',
-      objectName: 'QWESR Integration Type',
+      objectName: "QWESR Integration Type",
     },
     {
       objectDescriptor: 'permissionset 123456789 "QWESR Admin"',
-      objectName: 'QWESR Admin',
+      objectName: "QWESR Admin",
     },
   ];
 }


### PR DESCRIPTION
Hi Johannes,

we have some objects which have a comment at the end of the first line.
if *any* file has a comment with a quote at the end of "object description", then the command "NAB: Find code source of current line" crashes.
![image](https://user-images.githubusercontent.com/53570297/143038920-2c88f4ff-5fe7-4407-8296-3de8b3ce9fcd.png)

In this PR I'm just changing the regex slightly, so that the 4th group is only found if a quote is **before** a `//` or `/*`

If that works, then I'm very glad to work with this command further :) Thanks for that!

Best regards
David