### PR TITLE
Improved parsing of object names

### DIFF
--- a/extension/src/ALObject/ALParser.ts
+++ b/extension/src/ALObject/ALParser.ts
@@ -647,18 +647,12 @@ function loadObjectDescriptor(
     case ALObjectType.table:
     case ALObjectType.xmlPort:
     case ALObjectType.enum: {
-      const objectDescriptorPattern = new RegExp(
-        `(?<objectType>\\w+) +(?<objectId>[0-9]+) +(?<objectName>${wordPattern})\\s*(?<implements>implements\\s*((${wordPattern})[,\\s]*)+)?(?<comment>\\s*\\/\\/.*)?$`
-      );
+      const regexString = `(?<objectType>\\w+) +(?<objectId>[0-9]+) +(?<objectName>${wordPattern})(?<implements>(\\s+implements\\s+(${wordPattern}))(?<implementsMore>\\s*,\\s*(${wordPattern}))*)?(?<comment>\\s*\\/\\/.*)?$`;
+      const objectDescriptorPattern = new RegExp(regexString);
       const currObject = objectDescriptorCode.match(objectDescriptorPattern);
-      if (currObject === null) {
+      if (currObject === null || currObject.groups === undefined) {
         throw new Error(
-          `File '${objectFileName}' does not have valid object name. Maybe it got double quotes (") in the object name? - ${objectDescriptorCode}`
-        );
-      }
-      if (currObject.groups === undefined) {
-        throw new Error(
-          `File '${objectFileName}' does not have valid object name, it cannot be parsed - ${objectDescriptorCode}`
+          `File '${objectFileName}' does not have valid object name and could not be parsed. - ${objectDescriptorCode}`
         );
       }
       objectId = getObjectIdFromText(currObject.groups["objectId"]);

--- a/extension/src/test/ALObjectTestLibrary.ts
+++ b/extension/src/test/ALObjectTestLibrary.ts
@@ -205,6 +205,9 @@ export function getInvalidObjectDescriptors(): string[] {
     'pageextension 70219910 "QWESP" Customer Card" extends "Customer Card" // 21',
     'pageextension 70219910 QWESP Customer Card extends "Customer Card" // 21',
     'pageextension 70219910 QWESP"CustomerCard extends "Customer Card" // 21',
+    "codeunit 50100 MyCodeunit implements",
+    "codeunit 50100 MyCodeunit implements MyInterface1 MyInterface2",
+    "codeunit 50100 MyCodeunit implements MyInterface1,,,,MyInterface2",
   ];
 }
 export function getEmptyGXlf(): string {

--- a/extension/src/test/ALObjectTestLibrary.ts
+++ b/extension/src/test/ALObjectTestLibrary.ts
@@ -118,6 +118,9 @@ page 70219909 "Time Sheet Activities"
 export function getValidObjectDescriptors(): {
   objectDescriptor: string;
   objectName: string;
+  extendedObjectId?: number | undefined;
+  extendedObjectName?: string | undefined;
+  extendedTableId?: number | undefined;
 }[] {
   return [
     {
@@ -135,28 +138,47 @@ export function getValidObjectDescriptors(): {
       objectName: "QWESR Communication Method Mgt",
     },
     {
+      objectDescriptor:
+        'codeunit 70314130 "QWESR Communication Method Mgt" //some "comment"',
+      objectName: "QWESR Communication Method Mgt",
+    },
+    {
       objectDescriptor: "codeunit 70314130 CommunicationMethodMgt",
+      objectName: "CommunicationMethodMgt",
+    },
+    {
+      objectDescriptor:
+        'codeunit 70314130 CommunicationMethodMgt //some "comment"',
       objectName: "CommunicationMethodMgt",
     },
     {
       objectDescriptor:
         'pageextension 70219910 "QWESP Customer Card" extends "Customer Card" // 21',
       objectName: "QWESP Customer Card",
+      extendedObjectId: 21,
+      extendedObjectName: "Customer Card",
     },
     {
       objectDescriptor:
         'pageextension 70219910 "QWESP Customer Card" extends CustomerCard // 21',
       objectName: "QWESP Customer Card",
+      extendedObjectId: 21,
+      extendedObjectName: "CustomerCard",
     },
     {
       objectDescriptor:
         'pageextension 70219910 QWESPCustomerCard extends "Customer Card" // 21',
       objectName: "QWESPCustomerCard",
+      extendedObjectId: 21,
+      extendedObjectName: "Customer Card",
     },
     {
       objectDescriptor:
-        "pageextension 70219910 QWESPCustomerCard extends CustomerCard // 21",
+        "pageextension 70219910 QWESPCustomerCard extends CustomerCard // 21 (18)",
       objectName: "QWESPCustomerCard",
+      extendedObjectId: 21,
+      extendedObjectName: "CustomerCard",
+      extendedTableId: 18,
     },
     {
       objectDescriptor: 'profile "QWESP Time Sheet Role Center"',

--- a/extension/src/test/ALParser.test.ts
+++ b/extension/src/test/ALParser.test.ts
@@ -713,7 +713,16 @@ suite("Classes.AL Functions Tests", function () {
       if (!obj) {
         assert.fail(`No descriptor found in ${item.objectDescriptor}`);
       }
-      assert.equal(obj.objectName, item.objectName);
+      assert.strictEqual(obj.objectName, item.objectName);
+      if (obj.extendedObjectId) {
+        assert.strictEqual(obj.extendedObjectId, item.extendedObjectId);
+      }
+      if (obj.extendedObjectName) {
+        assert.strictEqual(obj.extendedObjectName, item.extendedObjectName);
+      }
+      if (obj.extendedTableId) {
+        assert.strictEqual(obj.extendedTableId, item.extendedTableId);
+      }
     }
   });
 
@@ -728,7 +737,9 @@ suite("Classes.AL Functions Tests", function () {
         // console.log('Item: ', item,'\nError:', error);
       }
       if (obj !== null) {
-        assert.fail("Object should fail. Name:" + obj?.objectName);
+        assert.fail(
+          `Object should fail. Code: "${item}". Name: "${obj?.objectName}"`
+        );
       }
     }
   });


### PR DESCRIPTION
Retake of #210 

Using the word matching from AL Language extension to match object names. That made it possible to remove some error handling.
Tests improved to test the additions

Known limitations:
Does _not_ handle /* comments, only // comments