### PR TITLE
Handle rejected promise in test

### DIFF
--- a/extension/src/test/BaseAppTranslationFiles.test.ts
+++ b/extension/src/test/BaseAppTranslationFiles.test.ts
@@ -123,7 +123,7 @@ suite("Base App Translation Files Tests", function () {
         assert.strictEqual(
           err.message.match(
             /Could not parse match file for "en-au_broken\.json"\. Message: Unexpected end of JSON input\..*/
-          ),
+          ).length,
           1,
           `Unexpected error message: ${err.message}`
         );

--- a/extension/src/test/BaseAppTranslationFiles.test.ts
+++ b/extension/src/test/BaseAppTranslationFiles.test.ts
@@ -97,8 +97,11 @@ suite("Base App Translation Files Tests", function () {
       (err) => {
         assert.strictEqual(err.name, "Error");
         assert.strictEqual(
-          err.message,
-          'No content in file, file was deleted: "/home/theschitz/git/GitHub/nab-al-tools/extension/out/externalresources/en-au_broken.json".'
+          err.message.match(
+            /No content in file, file was deleted: ".*en-au_broken.json"\./
+          ).length,
+          1,
+          "Unexpected error message."
         );
         return true;
       }
@@ -118,8 +121,11 @@ suite("Base App Translation Files Tests", function () {
       (err) => {
         assert.strictEqual(err.name, "Error");
         assert.strictEqual(
-          err.message,
-          'Could not parse match file for "en-au_broken.json". Message: Unexpected end of JSON input. If this persists, try disabling the setting "NAB: Match Base App Translation" and log an issue at https://github.com/jwikman/nab-al-tools/issues. Deleted corrupt file at: "/home/theschitz/git/GitHub/nab-al-tools/extension/out/externalresources/en-au_broken.json".'
+          err.message.match(
+            /Could not parse match file for "en-au_broken\.json"\. Message: Unexpected end of JSON input\..*/
+          ),
+          1,
+          "Unexpected error message"
         );
         return true;
       }

--- a/extension/src/test/BaseAppTranslationFiles.test.ts
+++ b/extension/src/test/BaseAppTranslationFiles.test.ts
@@ -125,7 +125,7 @@ suite("Base App Translation Files Tests", function () {
             /Could not parse match file for "en-au_broken\.json"\. Message: Unexpected end of JSON input\..*/
           ),
           1,
-          "Unexpected error message"
+          `Unexpected error message: ${err.message}`
         );
         return true;
       }

--- a/extension/src/test/DocumentFunctions.test.ts
+++ b/extension/src/test/DocumentFunctions.test.ts
@@ -3,11 +3,13 @@ import * as vscode from "vscode";
 import * as DocumentFunctions from "../DocumentFunctions";
 
 suite("DocumentFunctions", function () {
-  test("openTextFileWithSelectionOnLineNo", function () {
-    assert.ok(
-      DocumentFunctions.openTextFileWithSelectionOnLineNo("", 0),
-      "Failed to open text file with selection"
-    );
+  test("openTextFileWithSelectionOnLineNo", async function () {
+    await assert.doesNotReject(async () => {
+      await DocumentFunctions.openTextFileWithSelectionOnLineNo(
+        `${__filename}`,
+        0
+      );
+    }, "Unexpected rejection of promise");
   });
 
   test("eolToLineEnding", function () {

--- a/extension/src/test/ExternalResources.test.ts
+++ b/extension/src/test/ExternalResources.test.ts
@@ -65,22 +65,27 @@ suite("External Resources Tests", function () {
     );
   });
 
-  test("Always - BlobContainer.getBlobs()", async function () {
+  test("BlobContainer.getBlobs() - Bad path", async function () {
     const blobContainer = new BlobContainer(
       "this/path/does/not/exist",
       baseUrl,
       sasToken
     );
-    let errorMsg = "";
-    try {
-      await blobContainer.getBlobs();
-    } catch (e) {
-      errorMsg = (e as Error).message;
-    }
-    assert.deepStrictEqual(
-      errorMsg,
-      "Directory does not exist: this/path/does/not/exist",
-      "Non existing path should throw error"
+    await assert.rejects(
+      async () => {
+        await blobContainer.getBlobs();
+      },
+      (err) => {
+        assert.strictEqual(err.name, "Error");
+        assert.strictEqual(
+          err.message.match(
+            /Directory does not exist: this[\\|/]path[\\|/]does[\\|/]not[\\|/]exist/
+          ).length,
+          1,
+          `Unexpected error message: ${err.message}`
+        );
+        return true;
+      }
     );
   });
 

--- a/extension/src/test/XlfHighlighter.test.ts
+++ b/extension/src/test/XlfHighlighter.test.ts
@@ -50,28 +50,29 @@ suite("Xlf Highlighter", function () {
 
   test("Refresh with Invalid Xml", async function () {
     const gXlfUri = path.resolve(__dirname, testResourcesPath, "invalid.g.xlf");
-    const langFilesUri: string[] = [];
-    langFilesUri.push(
-      path.resolve(__dirname, testResourcesPath, "invalid.xlf")
+    const langFilesUri: string[] = [
+      path.resolve(__dirname, testResourcesPath, "invalid.xlf"),
+    ];
+    const languageFunctionsSettings = new LanguageFunctions.LanguageFunctionsSettings(
+      SettingsLoader.getSettings()
     );
-    let failed = false;
-    try {
-      // Workaround that assert.throws does not handle async errors
-      const languageFunctionsSettings = new LanguageFunctions.LanguageFunctionsSettings(
-        SettingsLoader.getSettings()
-      );
-      languageFunctionsSettings.translationMode =
-        LanguageFunctions.TranslationMode.nabTags;
-      await LanguageFunctions._refreshXlfFilesFromGXlf({
-        gXlfFilePath: gXlfUri,
-        langFiles: langFilesUri,
-        languageFunctionsSettings,
-        sortOnly: false,
-      });
-    } catch (error) {
-      failed = true;
-      assert.equal(error.message, "The xml in invalid.xlf is invalid.");
-    }
-    assert.equal(failed, true, "Test didn't throw error");
+    languageFunctionsSettings.translationMode =
+      LanguageFunctions.TranslationMode.nabTags;
+
+    await assert.rejects(
+      async () => {
+        await LanguageFunctions._refreshXlfFilesFromGXlf({
+          gXlfFilePath: gXlfUri,
+          langFiles: langFilesUri,
+          languageFunctionsSettings,
+          sortOnly: false,
+        });
+      },
+      (err) => {
+        assert.strictEqual(err.name, "Error");
+        assert.strictEqual(err.message, "The xml in invalid.xlf is invalid.");
+        return true;
+      }
+    );
   });
 });


### PR DESCRIPTION
Asserting rejected promises in asynchronous functions is no longer a mystery!

I started out hunting that path/file error but soon realized there was more to find. I fixed the most obvious cases but there might be more. From the experiences I've had while learning how `assert.rejects` works. I would say that there's a high risk for false positives when testing asynchronous functions. 

There are still some unexplained crap lines being outputted in the workflow. We'll have to keep an eye out for those.

![image](https://user-images.githubusercontent.com/17023248/143687581-04d8487f-2342-4ec1-9813-c88031a009dc.png)

Additional comments:
Are we ready to activate squash merge again?