### PR TITLE
Try to find parent (field/table/..) if property is missing

### DIFF
--- a/extension/src/DocumentFunctions.ts
+++ b/extension/src/DocumentFunctions.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { ALObject } from "./ALObject/ALElementTypes";
 import * as ALParser from "./ALObject/ALParser";
 import { XliffIdToken } from "./ALObject/XliffIdToken";
 import { AppManifest, Settings } from "./Settings/Settings";
@@ -25,23 +26,22 @@ export async function openTextFileWithSelection(
 export async function openTextFileWithSelectionOnLineNo(
   path: string,
   lineNo: number
-): Promise<void> {
-  const textEditor = await vscode.window.showTextDocument(
-    await vscode.workspace.openTextDocument(path)
-  );
-  const lineText = textEditor.document.getText(
-    new vscode.Range(lineNo, 0, lineNo, 1000)
-  );
-  textEditor.selection = new vscode.Selection(
+): Promise<vscode.Location> {
+  const document = await vscode.workspace.openTextDocument(path);
+  const lineText = document.getText(new vscode.Range(lineNo, 0, lineNo, 1000));
+  const selection = new vscode.Selection(
     lineNo,
     lineText.length - lineText.trimLeft().length,
     lineNo,
     1000
   );
+  const textEditor = await vscode.window.showTextDocument(document);
+  textEditor.selection = selection;
   textEditor.revealRange(
     textEditor.selection,
     vscode.TextEditorRevealType.InCenter
   );
+  return new vscode.Location(document.uri, selection);
 }
 
 export function eolToLineEnding(eol: vscode.EndOfLine): string {
@@ -55,7 +55,7 @@ export async function openAlFileFromXliffTokens(
   settings: Settings,
   appManifest: AppManifest,
   tokens: XliffIdToken[]
-): Promise<void> {
+): Promise<vscode.Location> {
   const alObjects = await getAlObjectsFromCurrentWorkspace(
     settings,
     appManifest,
@@ -83,15 +83,50 @@ export async function openAlFileFromXliffTokens(
   const mlObject = mlObjects.filter(
     (x) => x.xliffId().toLowerCase() === xliffToSearchFor
   );
-  if (mlObject.length !== 1) {
+  let startLineIndex: number | undefined;
+  switch (mlObject.length) {
+    case 1:
+      startLineIndex = mlObject[0].startLineIndex;
+      break;
+    case 0:
+      startLineIndex = findControlOfMissingProperty(xliffToSearchFor, obj);
+      break;
+  }
+  if (startLineIndex !== undefined) {
+    return openTextFileWithSelectionOnLineNo(
+      obj.objectFileName,
+      startLineIndex
+    );
+  } else {
     throw new Error(
       `No code line found in file '${
         obj.objectFileName
       }' matching '${XliffIdToken.getXliffIdWithNames(tokens)}'`
     );
   }
-  openTextFileWithSelectionOnLineNo(
-    obj.objectFileName,
-    mlObject[0].startLineIndex
+}
+function findControlOfMissingProperty(
+  xliffToSearchFor: string,
+  obj: ALObject
+): number | undefined {
+  const xliffToSearchForWithoutPropertyPart = xliffToSearchFor.substring(
+    0,
+    xliffToSearchFor.lastIndexOf(" - property")
   );
+  if (
+    XliffIdToken.getXliffId(obj.xliffIdTokenArray()).toLowerCase() ===
+    xliffToSearchForWithoutPropertyPart
+  ) {
+    return obj.startLineIndex;
+  } else {
+    const control = obj.controls.filter(
+      (control) =>
+        XliffIdToken.getXliffId(control.xliffIdTokenArray()).toLowerCase() ===
+        xliffToSearchForWithoutPropertyPart
+    );
+    if (control.length === 1) {
+      return control[0].startLineIndex;
+    }
+  }
+  return undefined;
 }

--- a/extension/src/DocumentFunctions.ts
+++ b/extension/src/DocumentFunctions.ts
@@ -109,9 +109,13 @@ function findControlOfMissingProperty(
   xliffToSearchFor: string,
   obj: ALObject
 ): number | undefined {
+  const lastIndex = xliffToSearchFor.lastIndexOf(" - property");
+  if (lastIndex < 0) {
+    return undefined;
+  }
   const xliffToSearchForWithoutPropertyPart = xliffToSearchFor.substring(
     0,
-    xliffToSearchFor.lastIndexOf(" - property")
+    lastIndex
   );
   if (
     XliffIdToken.getXliffId(obj.xliffIdTokenArray()).toLowerCase() ===

--- a/extension/src/test/DocumentFunctions.test.ts
+++ b/extension/src/test/DocumentFunctions.test.ts
@@ -1,6 +1,9 @@
 import * as assert from "assert";
+import { resolve } from "path";
 import * as vscode from "vscode";
 import * as DocumentFunctions from "../DocumentFunctions";
+import * as LanguageFunctions from "../LanguageFunctions";
+import * as SettingsLoader from "../Settings/SettingsLoader";
 
 suite("DocumentFunctions", function () {
   test("openTextFileWithSelectionOnLineNo", async function () {
@@ -24,4 +27,40 @@ suite("DocumentFunctions", function () {
       "Incorrect EOL returned."
     );
   });
+  test("find field definition if caption property is missing", async function () {
+    const textToFind: string = "Table Empty - Field MyField - Property Caption";
+    const document = await vscode.workspace.openTextDocument(
+      resolve(__dirname, "../../../test-app/Xliff-test/Translations/Al.g.xlf")
+    );
+    const textEditor = await vscode.window.showTextDocument(document);
+    const docText = document.getText();
+    const foundAtCharInSingleString = docText.search(textToFind);
+    const docTextSubstring = docText.substring(0, foundAtCharInSingleString);
+    const foundAtLineNo =
+      docTextSubstring.length - docTextSubstring.replace(/\n/g, "").length;
+    let pos = new vscode.Position(foundAtLineNo, 0);
+    textEditor.selection = new vscode.Selection(pos, pos);
+
+    const tokens = await LanguageFunctions.getCurrentXlfData();
+    const location = await DocumentFunctions.openAlFileFromXliffTokens(
+      SettingsLoader.getSettings(),
+      SettingsLoader.getAppManifest(),
+      tokens
+    );
+
+    assert.strictEqual(
+      true,
+      location.uri.path.endsWith("Empty.Table.al"),
+      "TransUnit should be found"
+    );
+    const selectedLine = (await vscode.workspace.openTextDocument(location.uri))
+      .lineAt(location.range.start.line)
+      .text.trim();
+
+    assert.strictEqual(
+      "field(1; MyField; Integer)",
+      selectedLine,
+      "Field should be selected as the caption property is missing"
+    );
+  }).timeout(0);
 });

--- a/extension/src/test/DocumentFunctions.test.ts
+++ b/extension/src/test/DocumentFunctions.test.ts
@@ -28,7 +28,7 @@ suite("DocumentFunctions", function () {
     );
   });
   test("find field definition if caption property is missing", async function () {
-    const textToFind: string = "Table Empty - Field MyField - Property Caption";
+    const textToFind = "Table Empty - Field MyField - Property Caption";
     const document = await vscode.workspace.openTextDocument(
       resolve(__dirname, "../../../test-app/Xliff-test/Translations/Al.g.xlf")
     );

--- a/extension/src/test/DocumentFunctions.test.ts
+++ b/extension/src/test/DocumentFunctions.test.ts
@@ -38,7 +38,7 @@ suite("DocumentFunctions", function () {
     const docTextSubstring = docText.substring(0, foundAtCharInSingleString);
     const foundAtLineNo =
       docTextSubstring.length - docTextSubstring.replace(/\n/g, "").length;
-    let pos = new vscode.Position(foundAtLineNo, 0);
+    const pos = new vscode.Position(foundAtLineNo, 0);
     textEditor.selection = new vscode.Selection(pos, pos);
 
     const tokens = await LanguageFunctions.getCurrentXlfData();

--- a/test-app/Xliff-test/Translations/Al.g.xlf
+++ b/test-app/Xliff-test/Translations/Al.g.xlf
@@ -3,30 +3,15 @@
   <file datatype="xml" source-language="en-US" target-language="en-US" original="Al">
     <body>
       <group id="body">
+        <trans-unit id="Table 1365275863 - Field 1296262074 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>MyField</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Table Empty - Field MyField - Property Caption</note>
+        </trans-unit>
         <trans-unit id="Table 596208023 - Property 2879900210" maxwidth="23" size-unit="char" translate="yes" xml:space="preserve">
           <source>Table</source>
           <note from="Developer" annotates="general" priority="2">TableComment</note>
           <note from="Xliff Generator" annotates="general" priority="3">Table NAB Test Table - Property Caption</note>
-        </trans-unit>
-        <trans-unit id="Table 596208023 - Field 440443472 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Field</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Table NAB Test Table - Field Test Field - Property Caption</note>
-        </trans-unit>
-        <trans-unit id="Table 596208023 - Field 440443472 - Method 1213635141 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Field End OnLookupLabel</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Table NAB Test Table - Field Test Field - Method OnLookup - NamedType LocalTestLabelTxt</note>
-        </trans-unit>
-        <trans-unit id="Table 596208023 - Field 1296262074 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
-          <source>MyField</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Table NAB Test Table - Field MyField - Property Caption</note>
-        </trans-unit>
-        <trans-unit id="Table 596208023 - Field 1942294334 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
-          <source>My &lt;&gt; &amp; Field</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Table NAB Test Table - Field My &lt;&gt; &amp; Field - Property Caption</note>
         </trans-unit>
         <trans-unit id="Table 596208023 - Method 2451657066 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve">
           <source>Local Test begin Label</source>
@@ -38,95 +23,30 @@
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Table NAB Test Table - Method TestMethod - NamedType LocalTestLabelTxt</note>
         </trans-unit>
-        <trans-unit id="Page 596208023 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Page Caption</source>
+        <trans-unit id="Table 596208023 - Field 1942294334 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>My &lt;&gt; &amp; Field</source>
           <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Property Caption</note>
+          <note from="Xliff Generator" annotates="general" priority="3">Table NAB Test Table - Field My &lt;&gt; &amp; Field - Property Caption</note>
         </trans-unit>
-        <trans-unit id="Page 596208023 - Property 1968111052" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Instructions</source>
+        <trans-unit id="Table 596208023 - Field 1296262074 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>MyField</source>
           <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Property InstructionalText</note>
+          <note from="Xliff Generator" annotates="general" priority="3">Table NAB Test Table - Field MyField - Property Caption</note>
         </trans-unit>
-        <trans-unit id="Page 596208023 - Property 2019332006" size-unit="char" translate="yes" xml:space="preserve">
-          <source>asdf,erewf</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Property PromotedActionCategories</note>
-        </trans-unit>
-        <trans-unit id="Page 596208023 - Control 4105281732 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Grp</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Control GroupName - Property Caption</note>
-        </trans-unit>
-        <trans-unit id="Page 596208023 - Control 4105281732 - Property 1968111052" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Instruction</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Control GroupName - Property InstructionalText</note>
-        </trans-unit>
-        <trans-unit id="Page 596208023 - Control 2961552353 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+        <trans-unit id="Table 596208023 - Field 440443472 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
           <source>Field</source>
           <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Control Name - Property Caption</note>
+          <note from="Xliff Generator" annotates="general" priority="3">Table NAB Test Table - Field Test Field - Property Caption</note>
         </trans-unit>
-        <trans-unit id="Page 596208023 - Control 2961552353 - Property 62802879" size-unit="char" translate="yes" xml:space="preserve">
-          <source>asdf,sadf,____ASADF</source>
+        <trans-unit id="Table 596208023 - Field 440443472 - Method 1213635141 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Field End OnLookupLabel</source>
           <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Control Name - Property OptionCaption</note>
-        </trans-unit>
-        <trans-unit id="Page 596208023 - Control 2961552353 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Tooltup 3</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Control Name - Property ToolTip</note>
-        </trans-unit>
-        <trans-unit id="Page 596208023 - Control 2961552353 - Method 2699620902 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Local Test Label</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Control Name - Method OnAssistEdit - NamedType LocalTestLabelTxt</note>
-        </trans-unit>
-        <trans-unit id="Page 596208023 - Control 1296262074 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
-          <source></source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Control MyField - Property Caption</note>
-        </trans-unit>
-        <trans-unit id="Page 596208023 - Action 3862845261 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
-          <source>AreaTooltip</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Action Processing - Property ToolTip</note>
-        </trans-unit>
-        <trans-unit id="Page 596208023 - Action 1692444235 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Action</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Action ActionName - Property Caption</note>
-        </trans-unit>
-        <trans-unit id="Page 596208023 - Action 1692444235 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Tooltip 4</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Action ActionName - Property ToolTip</note>
-        </trans-unit>
-        <trans-unit id="Page 596208023 - Action 1692444235 - Method 1377591017 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Local Test Label</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Action ActionName - Method OnAction - NamedType LocalTestLabelTxt</note>
-        </trans-unit>
-        <trans-unit id="Page 596208023 - Method 1306612702 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Local Test Label</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Method TestMethodPage - NamedType LocalTestLabelTxt</note>
-        </trans-unit>
-        <trans-unit id="Page 596208023 - NamedType 2688233357" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Global Test Label</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - NamedType GlobalTestLabelTxt</note>
+          <note from="Xliff Generator" annotates="general" priority="3">Table NAB Test Table - Field Test Field - Method OnLookup - NamedType LocalTestLabelTxt</note>
         </trans-unit>
         <trans-unit id="Table 2794708188 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
           <source>NAB ToolTip</source>
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Table NAB ToolTip - Property Caption</note>
-        </trans-unit>
-        <trans-unit id="Table 2794708188 - Field 970416965 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
-          <source>PK</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Table NAB ToolTip - Field PK - Property Caption</note>
         </trans-unit>
         <trans-unit id="Table 2794708188 - Field 157186525 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
           <source>Field 1</source>
@@ -143,30 +63,25 @@
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Table NAB ToolTip - Field Field No Caption - Property Caption</note>
         </trans-unit>
-        <trans-unit id="TableExtension 2794708188 - Field 157186525 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Table 3276313895">
-          <source>Field 1</source>
+        <trans-unit id="Table 2794708188 - Field 970416965 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>PK</source>
           <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">TableExtension NAB ToolTip - Field Field 1 - Property Caption</note>
+          <note from="Xliff Generator" annotates="general" priority="3">Table NAB ToolTip - Field PK - Property Caption</note>
         </trans-unit>
-        <trans-unit id="TableExtension 2794708188 - Field 3814457204 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Table 3276313895">
-          <source>Field 2</source>
+        <trans-unit id="Codeunit 456387620 - NamedType 2732361835" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Global Test Label</source>
           <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">TableExtension NAB ToolTip - Field Field 2 - Property Caption</note>
+          <note from="Xliff Generator" annotates="general" priority="3">Codeunit NAB Test Codeunit - NamedType GlobalTestLabel2Txt</note>
         </trans-unit>
-        <trans-unit id="TableExtension 2794708188 - Field 3176760587 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Table 3276313895">
-          <source>Field 3</source>
+        <trans-unit id="Codeunit 456387620 - NamedType 1347986220" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Global Test Label</source>
           <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">TableExtension NAB ToolTip - Field Field 3 - Property Caption</note>
+          <note from="Xliff Generator" annotates="general" priority="3">Codeunit NAB Test Codeunit - NamedType GlobalTestLabel3Txt</note>
         </trans-unit>
-        <trans-unit id="TableExtension 2794708188 - Field 2539063970 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Table 3276313895">
-          <source>Field 4</source>
+        <trans-unit id="Codeunit 456387620 - NamedType 2688233357" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Global Test Label</source>
           <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">TableExtension NAB ToolTip - Field Field 4 - Property Caption</note>
-        </trans-unit>
-        <trans-unit id="TableExtension 2794708188 - Field 2539063970 - Property 62802879" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Table 3276313895">
-          <source>One,Two</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">TableExtension NAB ToolTip - Field Field 4 - Property OptionCaption</note>
+          <note from="Xliff Generator" annotates="general" priority="3">Codeunit NAB Test Codeunit - NamedType GlobalTestLabelTxt</note>
         </trans-unit>
         <trans-unit id="Codeunit 456387620 - Method 1665861916 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve">
           <source>Local Test Label</source>
@@ -178,20 +93,85 @@
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Codeunit NAB Test Codeunit - Method TestMethod - NamedType LocalTestLabelTxt</note>
         </trans-unit>
-        <trans-unit id="Codeunit 456387620 - NamedType 2688233357" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Global Test Label</source>
+        <trans-unit id="Page 596208023 - Property 1968111052" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Instructions</source>
           <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Codeunit NAB Test Codeunit - NamedType GlobalTestLabelTxt</note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Property InstructionalText</note>
         </trans-unit>
-        <trans-unit id="Codeunit 456387620 - NamedType 2732361835" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Global Test Label</source>
+        <trans-unit id="Page 596208023 - Property 2019332006" size-unit="char" translate="yes" xml:space="preserve">
+          <source>asdf,erewf</source>
           <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Codeunit NAB Test Codeunit - NamedType GlobalTestLabel2Txt</note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Property PromotedActionCategories</note>
         </trans-unit>
-        <trans-unit id="Codeunit 456387620 - NamedType 1347986220" size-unit="char" translate="yes" xml:space="preserve">
+        <trans-unit id="Page 596208023 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Page Caption</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="Page 596208023 - NamedType 2688233357" size-unit="char" translate="yes" xml:space="preserve">
           <source>Global Test Label</source>
           <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Codeunit NAB Test Codeunit - NamedType GlobalTestLabel3Txt</note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - NamedType GlobalTestLabelTxt</note>
+        </trans-unit>
+        <trans-unit id="Page 596208023 - Method 1306612702 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Local Test Label</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Method TestMethodPage - NamedType LocalTestLabelTxt</note>
+        </trans-unit>
+        <trans-unit id="Page 596208023 - Control 4105281732 - Property 1968111052" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Instruction</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Control GroupName - Property InstructionalText</note>
+        </trans-unit>
+        <trans-unit id="Page 596208023 - Control 4105281732 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Grp</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Control GroupName - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="Page 596208023 - Control 1296262074 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source></source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Control MyField - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="Page 596208023 - Control 2961552353 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Tooltup 3</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Control Name - Property ToolTip</note>
+        </trans-unit>
+        <trans-unit id="Page 596208023 - Control 2961552353 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Field</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Control Name - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="Page 596208023 - Control 2961552353 - Property 62802879" size-unit="char" translate="yes" xml:space="preserve">
+          <source>asdf,sadf,____ASADF</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Control Name - Property OptionCaption</note>
+        </trans-unit>
+        <trans-unit id="Page 596208023 - Control 2961552353 - Method 2699620902 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Local Test Label</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Control Name - Method OnAssistEdit - NamedType LocalTestLabelTxt</note>
+        </trans-unit>
+        <trans-unit id="Page 596208023 - Action 3862845261 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
+          <source>AreaTooltip</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Action Processing - Property ToolTip</note>
+        </trans-unit>
+        <trans-unit id="Page 596208023 - Action 1692444235 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Tooltip 4</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Action ActionName - Property ToolTip</note>
+        </trans-unit>
+        <trans-unit id="Page 596208023 - Action 1692444235 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Action</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Action ActionName - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="Page 596208023 - Action 1692444235 - Method 1377591017 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Local Test Label</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Action ActionName - Method OnAction - NamedType LocalTestLabelTxt</note>
         </trans-unit>
         <trans-unit id="Page 883204498 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
           <source>NAB ToolTip Part 1</source>
@@ -258,11 +238,6 @@
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Page NAB ToolTips - Property Caption</note>
         </trans-unit>
-        <trans-unit id="Page 1462529885 - Control 970416965 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Specifies the value of the PK field</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Page NAB ToolTips - Control PK - Property ToolTip</note>
-        </trans-unit>
         <trans-unit id="Page 1462529885 - Control 157186525 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
           <source>Specifies the value of the Field 1 field</source>
           <note from="Developer" annotates="general" priority="2"></note>
@@ -283,6 +258,11 @@
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Page NAB ToolTips - Control Field 4 - Property ToolTip</note>
         </trans-unit>
+        <trans-unit id="Page 1462529885 - Control 970416965 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Specifies the value of the PK field</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB ToolTips - Control PK - Property ToolTip</note>
+        </trans-unit>
         <trans-unit id="Page 1462529885 - Control 1367528460 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
           <source>Specifies the value of the SystemId field</source>
           <note from="Developer" annotates="general" priority="2"></note>
@@ -292,6 +272,16 @@
           <source>Report</source>
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="Report 529985455 - NamedType 2688233357" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Global Test Label</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - NamedType GlobalTestLabelTxt</note>
+        </trans-unit>
+        <trans-unit id="Report 529985455 - Method 1968185403 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Local Test Label</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - Method TestMethod - NamedType LocalTestLabelTxt</note>
         </trans-unit>
         <trans-unit id="Report 529985455 - ReportDataItem 205381422 - Property 1806354803" size-unit="char" translate="yes" xml:space="preserve">
           <source>sdfa</source>
@@ -308,15 +298,25 @@
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - ReportColumn ColumnName - Property OptionCaption</note>
         </trans-unit>
-        <trans-unit id="Report 529985455 - Control 4105281732 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Grp</source>
+        <trans-unit id="Report 529985455 - RequestPage 2516438534 - Method 4177352842 - NamedType 1126472184" size-unit="char" translate="yes" xml:space="preserve">
+          <source>This report cannot be scheduled</source>
           <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - Control GroupName - Property Caption</note>
+          <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - RequestPage RequestOptionsPage - Method OnQueryClosePage - NamedType ReportCannotBeScheduledErr</note>
         </trans-unit>
         <trans-unit id="Report 529985455 - Control 4105281732 - Property 1968111052" size-unit="char" translate="yes" xml:space="preserve">
           <source>Instructions</source>
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - Control GroupName - Property InstructionalText</note>
+        </trans-unit>
+        <trans-unit id="Report 529985455 - Control 4105281732 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Grp</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - Control GroupName - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="Report 529985455 - Control 3731481282 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Tooltip</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - Control Fld - Property ToolTip</note>
         </trans-unit>
         <trans-unit id="Report 529985455 - Control 3731481282 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
           <source>Fld</source>
@@ -327,11 +327,6 @@
           <source>1234,34,43</source>
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - Control Fld - Property OptionCaption</note>
-        </trans-unit>
-        <trans-unit id="Report 529985455 - Control 3731481282 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Tooltip</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - Control Fld - Property ToolTip</note>
         </trans-unit>
         <trans-unit id="Report 529985455 - Control 3731481282 - Method 2699620902 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve">
           <source>Local Test Label</source>
@@ -348,30 +343,15 @@
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - Action ActionName - Method OnAction - NamedType LocalTestLabelTxt</note>
         </trans-unit>
-        <trans-unit id="Report 529985455 - RequestPage 2516438534 - Method 4177352842 - NamedType 1126472184" size-unit="char" translate="yes" xml:space="preserve">
-          <source>This report cannot be scheduled</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - RequestPage RequestOptionsPage - Method OnQueryClosePage - NamedType ReportCannotBeScheduledErr</note>
-        </trans-unit>
-        <trans-unit id="Report 529985455 - Method 1968185403 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Local Test Label</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - Method TestMethod - NamedType LocalTestLabelTxt</note>
-        </trans-unit>
-        <trans-unit id="Report 529985455 - NamedType 2688233357" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Global Test Label</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - NamedType GlobalTestLabelTxt</note>
-        </trans-unit>
         <trans-unit id="Query 3258925707 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
           <source>Query</source>
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Query NAB Test Query - Property Caption</note>
         </trans-unit>
-        <trans-unit id="Query 3258925707 - QueryColumn 967337907 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Column</source>
+        <trans-unit id="Query 3258925707 - NamedType 2688233357" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Global Test Label</source>
           <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Query NAB Test Query - QueryColumn ColumnName - Property Caption</note>
+          <note from="Xliff Generator" annotates="general" priority="3">Query NAB Test Query - NamedType GlobalTestLabelTxt</note>
         </trans-unit>
         <trans-unit id="Query 3258925707 - Method 1336600528 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve">
           <source>Local Test Label</source>
@@ -383,20 +363,25 @@
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Query NAB Test Query - Method TestMethod - NamedType LocalTestLabelTxt</note>
         </trans-unit>
-        <trans-unit id="Query 3258925707 - NamedType 2688233357" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Global Test Label</source>
+        <trans-unit id="Query 3258925707 - QueryColumn 967337907 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Column</source>
           <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">Query NAB Test Query - NamedType GlobalTestLabelTxt</note>
+          <note from="Xliff Generator" annotates="general" priority="3">Query NAB Test Query - QueryColumn ColumnName - Property Caption</note>
         </trans-unit>
         <trans-unit id="XmlPort 3951249077 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
-          <source>The Caption</source>
+          <source>The XmlPort Caption</source>
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">XmlPort NAB Test XmlPort - Property Caption</note>
         </trans-unit>
-        <trans-unit id="XmlPort 3951249077 - XmlPortNode 3374928249 - Method 828199545 - NamedType 1704108872" size-unit="char" translate="yes" xml:space="preserve">
-          <source>ChangeLog.Type %1 not supported</source>
-          <note from="Developer" annotates="general" priority="2">%1 = Type (Inserted, Modified, Deleted)</note>
-          <note from="Xliff Generator" annotates="general" priority="3">XmlPort NAB Test XmlPort - XmlPortNode TypeOfChange - Method OnBeforePassVariable - NamedType ChangeLogTypeNotSupportedErr</note>
+        <trans-unit id="XmlPort 3951249077 - RequestPage 2516438534 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>The request page</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">XmlPort NAB Test XmlPort - RequestPage RequestOptionsPage - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="XmlPort 3951249077 - Control 1296262074 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>The XmlPort Field Caption</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">XmlPort NAB Test XmlPort - Control MyField - Property Caption</note>
         </trans-unit>
         <trans-unit id="XmlPort 3951249077 - XmlPortNode 2961552353 - Method 257022829 - NamedType 1704108872" size-unit="char" translate="yes" xml:space="preserve">
           <source>ChangeLog.Type %1 not supported</source>
@@ -408,55 +393,100 @@
           <note from="Developer" annotates="general" priority="2">%1 = Type (Inserted, Modified, Deleted)</note>
           <note from="Xliff Generator" annotates="general" priority="3">XmlPort NAB Test XmlPort - XmlPortNode TypeOfChange2 - Method OnBeforePassVariable - NamedType ChangeLogTypeNotSupportedErr</note>
         </trans-unit>
-        <trans-unit id="PageExtension 3795862579 - Control 3146432722 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
-          <source>Capt</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - Control NAB Blocked3 - Property Caption</note>
+        <trans-unit id="XmlPort 3951249077 - XmlPortNode 3374928249 - Method 828199545 - NamedType 1704108872" size-unit="char" translate="yes" xml:space="preserve">
+          <source>ChangeLog.Type %1 not supported</source>
+          <note from="Developer" annotates="general" priority="2">%1 = Type (Inserted, Modified, Deleted)</note>
+          <note from="Xliff Generator" annotates="general" priority="3">XmlPort NAB Test XmlPort - XmlPortNode TypeOfChange - Method OnBeforePassVariable - NamedType ChangeLogTypeNotSupportedErr</note>
         </trans-unit>
-        <trans-unit id="PageExtension 3795862579 - Control 3146432722 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
-          <source>Tooltip 1</source>
+        <trans-unit id="PageExtension 3795862579 - NamedType 2688233357" size-unit="char" translate="yes" xml:space="preserve" al-object-target="PageExtension 3795862579">
+          <source>Global Test Label</source>
           <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - Control NAB Blocked3 - Property ToolTip</note>
+          <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - NamedType GlobalTestLabelTxt</note>
         </trans-unit>
-        <trans-unit id="PageExtension 3795862579 - Control 3146432722 - Property 62802879" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
-          <source>asdf,ef</source>
+        <trans-unit id="PageExtension 3795862579 - Method 3244334789 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve" al-object-target="PageExtension 3795862579">
+          <source>Local Test Label</source>
           <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - Control NAB Blocked3 - Property OptionCaption</note>
-        </trans-unit>
-        <trans-unit id="PageExtension 3795862579 - Action 3144175164 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
-          <source>Group</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - Action NAB Grp - Property Caption</note>
+          <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - Method TestMethodPageExt - NamedType LocalTestLabelTxt</note>
         </trans-unit>
         <trans-unit id="PageExtension 3795862579 - Action 3144175164 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
           <source>ToolTup</source>
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - Action NAB Grp - Property ToolTip</note>
         </trans-unit>
-        <trans-unit id="PageExtension 3795862579 - Action 1483499693 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
-          <source>Action</source>
+        <trans-unit id="PageExtension 3795862579 - Action 3144175164 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
+          <source>Group</source>
           <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - Action NAB Act - Property Caption</note>
+          <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - Action NAB Grp - Property Caption</note>
         </trans-unit>
         <trans-unit id="PageExtension 3795862579 - Action 1483499693 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
           <source>Tooltip 2</source>
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - Action NAB Act - Property ToolTip</note>
         </trans-unit>
-        <trans-unit id="PageExtension 3795862579 - Action 1483499693 - Method 1377591017 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
+        <trans-unit id="PageExtension 3795862579 - Action 1483499693 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
+          <source>Action</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - Action NAB Act - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="PageExtension 3795862579 - Action 1483499693 - Method 1377591017 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve" al-object-target="PageExtension 3795862579">
           <source>Local Test Label</source>
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - Action NAB Act - Method OnAction - NamedType LocalTestLabelTxt</note>
         </trans-unit>
-        <trans-unit id="PageExtension 3795862579 - Method 3244334789 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
+        <trans-unit id="PageExtension 3795862579 - Change 2039693239 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
+          <source>Specifies ...</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - Change Application Method - Property ToolTip</note>
+        </trans-unit>
+        <trans-unit id="PageExtension 3795862579 - Change 2039693239 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
+          <source>dsfe</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - Change Application Method - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="PageExtension 3795862579 - Change 2039693239 - Property 62802879" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
+          <source>dfee</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - Change Application Method - Property OptionCaption</note>
+        </trans-unit>
+        <trans-unit id="PageExtension 3795862579 - Control 3146432722 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
+          <source>Tooltip 1</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - Control NAB Blocked3 - Property ToolTip</note>
+        </trans-unit>
+        <trans-unit id="PageExtension 3795862579 - Control 3146432722 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
+          <source>Capt</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - Control NAB Blocked3 - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="PageExtension 3795862579 - Control 3146432722 - Property 62802879" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
+          <source>asdf,ef</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - Control NAB Blocked3 - Property OptionCaption</note>
+        </trans-unit>
+        <trans-unit id="TableExtension 3999646232 - NamedType 1399329827" size-unit="char" translate="yes" xml:space="preserve" al-object-target="TableExtension 3999646232">
+          <source>TableExt Label</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">TableExtension NAB Test Table Ext - NamedType TableExtLabel</note>
+        </trans-unit>
+        <trans-unit id="TableExtension 3999646232 - Method 1968185403 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve" al-object-target="TableExtension 3999646232">
           <source>Local Test Label</source>
           <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - Method TestMethodPageExt - NamedType LocalTestLabelTxt</note>
+          <note from="Xliff Generator" annotates="general" priority="3">TableExtension NAB Test Table Ext - Method TestMethod - NamedType LocalTestLabelTxt</note>
         </trans-unit>
-        <trans-unit id="PageExtension 3795862579 - NamedType 2688233357" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
-          <source>Global Test Label</source>
+        <trans-unit id="TableExtension 3999646232 - Field 4159685971 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Table 1994964448">
+          <source>Field</source>
           <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - NamedType GlobalTestLabelTxt</note>
+          <note from="Xliff Generator" annotates="general" priority="3">TableExtension NAB Test Table Ext - Field NAB Test Field - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="TableExtension 3999646232 - Field 4159685971 - Property 62802879" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Table 1994964448">
+          <source>asdf,er</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">TableExtension NAB Test Table Ext - Field NAB Test Field - Property OptionCaption</note>
+        </trans-unit>
+        <trans-unit id="TableExtension 3999646232 - Field 4159685971 - Method 1213635141 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve" al-object-target="TableExtension 3999646232">
+          <source>Local Test Label</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">TableExtension NAB Test Table Ext - Field NAB Test Field - Method OnLookup - NamedType LocalTestLabelTxt</note>
         </trans-unit>
         <trans-unit id="TableExtension 3999646232 - Change 3168444338 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Table 1994964448">
           <source>asdf</source>
@@ -473,50 +503,35 @@
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">TableExtension NAB Test Table Ext - Change Application Method - Property OptionCaption</note>
         </trans-unit>
-        <trans-unit id="TableExtension 3999646232 - Field 4159685971 - Property 62802879" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Table 1994964448">
-          <source>asdf,er</source>
+        <trans-unit id="TableExtension 2794708188 - Field 157186525 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Table 3276313895">
+          <source>Field 1</source>
           <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">TableExtension NAB Test Table Ext - Field NAB Test Field - Property OptionCaption</note>
+          <note from="Xliff Generator" annotates="general" priority="3">TableExtension NAB ToolTip - Field Field 1 - Property Caption</note>
         </trans-unit>
-        <trans-unit id="TableExtension 3999646232 - Field 4159685971 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Table 1994964448">
-          <source>Field</source>
+        <trans-unit id="TableExtension 2794708188 - Field 3814457204 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Table 3276313895">
+          <source>Field 2</source>
           <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">TableExtension NAB Test Table Ext - Field NAB Test Field - Property Caption</note>
+          <note from="Xliff Generator" annotates="general" priority="3">TableExtension NAB ToolTip - Field Field 2 - Property Caption</note>
         </trans-unit>
-        <trans-unit id="TableExtension 3999646232 - Field 4159685971 - Method 1213635141 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Table 1994964448">
-          <source>Local Test Label</source>
+        <trans-unit id="TableExtension 2794708188 - Field 3176760587 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Table 3276313895">
+          <source>Field 3</source>
           <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">TableExtension NAB Test Table Ext - Field NAB Test Field - Method OnLookup - NamedType LocalTestLabelTxt</note>
+          <note from="Xliff Generator" annotates="general" priority="3">TableExtension NAB ToolTip - Field Field 3 - Property Caption</note>
         </trans-unit>
-        <trans-unit id="TableExtension 3999646232 - Method 1968185403 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Table 1994964448">
-          <source>Local Test Label</source>
+        <trans-unit id="TableExtension 2794708188 - Field 2539063970 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Table 3276313895">
+          <source>Field 4</source>
           <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">TableExtension NAB Test Table Ext - Method TestMethod - NamedType LocalTestLabelTxt</note>
+          <note from="Xliff Generator" annotates="general" priority="3">TableExtension NAB ToolTip - Field Field 4 - Property Caption</note>
         </trans-unit>
-        <trans-unit id="TableExtension 3999646232 - NamedType 1399329827" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Table 1994964448">
-          <source>TableExt Label</source>
+        <trans-unit id="TableExtension 2794708188 - Field 2539063970 - Property 62802879" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Table 3276313895">
+          <source>One,Two</source>
           <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">TableExtension NAB Test Table Ext - NamedType TableExtLabel</note>
+          <note from="Xliff Generator" annotates="general" priority="3">TableExtension NAB ToolTip - Field Field 4 - Property OptionCaption</note>
         </trans-unit>
         <trans-unit id="Enum 3133857684 - EnumValue 1445202145 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
           <source>Enum1</source>
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Enum NAB TestEnum - EnumValue MyValue - Property Caption</note>
-        </trans-unit>
-        <trans-unit id="PageExtension 3795862579 - Change 2039693239 - Property 62802879" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
-          <source>dfee</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - Change Application Method - Property OptionCaption</note>
-        </trans-unit>
-        <trans-unit id="PageExtension 3795862579 - Change 2039693239 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
-          <source>dsfe</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - Change Application Method - Property Caption</note>
-        </trans-unit>
-        <trans-unit id="PageExtension 3795862579 - Change 2039693239 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
-          <source>Specifies ...</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - Change Application Method - Property ToolTip</note>
         </trans-unit>
       </group>
     </body>

--- a/test-app/Xliff-test/src/Empty.Table.al
+++ b/test-app/Xliff-test/src/Empty.Table.al
@@ -1,0 +1,12 @@
+table 50002 Empty
+{
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            DataClassification = ToBeClassified;
+
+        }
+    }
+}


### PR DESCRIPTION
Fixes #218 .
Hi @jwikman, @theschitz . 
I hope this is my last time where I'm going to interrupt you, so sorry for all the PRs and for keeping you busy with all my wishes :)

My change as such is described in the issue linked above.

Let me explain a bit the changes I made:
- The change in the .xlf seems to be a big one, but actually I just added the Empty.Table.al and built the project, so that the Caption of the Field is showing up (see [here](https://github.com/jwikman/nab-al-tools/compare/master...DavidFeldhoff:master#diff-de075a73e2a36ead8f95fc7f94934122a914e02e922902f344a50772e77b7013R9))
- The real change is made [here](https://github.com/jwikman/nab-al-tools/compare/master...DavidFeldhoff:master#diff-98e93b82acc20d494754543d188a59cc931ea277759cc125abb2e08d2a572354R92) where I try to find the parent before throwing the error, if the property itself could not be found.
- The reason why I'm returning the location is just to make it more testable, so that I was able to pick it up in the tests.