### PR TITLE
Replace Axios with https

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -740,14 +740,6 @@
             "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
             "dev": true
         },
-        "axios": {
-            "version": "0.21.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.2.tgz",
-            "integrity": "sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==",
-            "requires": {
-                "follow-redirects": "^1.14.0"
-            }
-        },
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -1750,11 +1742,6 @@
             "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.3.tgz",
             "integrity": "sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==",
             "dev": true
-        },
-        "follow-redirects": {
-            "version": "1.14.4",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-            "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
         },
         "format-duration": {
             "version": "1.3.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -588,8 +588,8 @@
         "test": "node ./out/test/runTest.js"
     },
     "dependencies": {
+        "@xmldom/xmldom": "^0.7.5",
         "adm-zip": "^0.5.5",
-        "axios": "^0.21.2",
         "compare-versions": "^3.6.0",
         "escape-string-regexp": "^1.0.5",
         "format-duration": "^1.3.1",
@@ -601,8 +601,7 @@
         "semver": "^7.3.5",
         "strip-json-comments": "^3.1.1",
         "time-stamp": "^1.1.0",
-        "txml": "^4.0.1",
-        "@xmldom/xmldom": "^0.7.5"
+        "txml": "^4.0.1"
     },
     "devDependencies": {
         "@types/adm-zip": "^0.4.34",

--- a/extension/src/test/CliSettingsLoader.test.ts
+++ b/extension/src/test/CliSettingsLoader.test.ts
@@ -90,7 +90,7 @@ suite("CLI Settings Loader Tests", function () {
 
 function getENOENT(): string {
   // This condition will hopefully be removed some day
-  if (process.platform === "linux" && process.env.GITHUB_ACTION) {
+  if (process.platform === "linux") {
     return "";
   }
 

--- a/extension/src/test/ExternalResources.test.ts
+++ b/extension/src/test/ExternalResources.test.ts
@@ -177,7 +177,11 @@ suite("External Resources Tests", function () {
         await blobContainer.getBlobs();
       },
       (err) => {
-        assert.strictEqual(err.name, "Error");
+        assert.strictEqual(
+          err.name,
+          "Error",
+          `Unexpected error name in ${err}`
+        );
         assert.strictEqual(
           err.message,
           "Blob storage authentication failed. Please report this as an issue on GitHub (https://github.com/jwikman/nab-al-tools)."


### PR DESCRIPTION
<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:
- Replacing `Axios` with `https`. 
  The code doesn't really look that much different but there's some value in stripping away the "magic" of Axios. I think working with `https` will prove to be more natural and better suited for our use case. 

[HTTPS | Node.js v17.2.0 documentation](https://nodejs.org/api/https.html#httpsgeturl-options-callback)

Additional comments:
Apparently `follow-redirects` was also removed when uninstalling `Axios` :+1: 


