### PR TITLE
Support Report Extension modification

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -7,6 +7,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 -->
 
+## [1.7.3] - 2021-12-07
+
+- Fixes:
+  - Report Extensions with modified columns was not supported, see [issue 221](https://github.com/jwikman/nab-al-tools/issues/221).
+
 ## [1.7.2] - 2021-11-30
 
 - Fixes:

--- a/extension/delivery.json
+++ b/extension/delivery.json
@@ -1,5 +1,5 @@
 {
     "previewPrefix": "",
     "nextLive": "1.7.3",
-    "nextPreview": "1"
+    "nextPreview": 3
 }

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "nab-al-tools",
-    "version": "1.7.2",
+    "version": "1.7.3-preview.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
     "name": "nab-al-tools",
     "displayName": "NAB AL Tools",
     "description": "Development and translation management tool for AL language and Microsoft Dynamics 365 Business Central extensions.",
-    "version": "1.7.2",
+    "version": "1.7.3-preview.2",
     "publisher": "nabsolutions",
     "repository": {
         "type": "git",

--- a/extension/src/ALObject/ALParser.ts
+++ b/extension/src/ALObject/ALParser.ts
@@ -231,6 +231,12 @@ function matchALControl(
             alControlResult[2]
           );
           break;
+        case ALObjectType.reportExtension:
+          control = new ALControl(
+            ALControlType.modifiedReportColumn,
+            alControlResult[2]
+          );
+          break;
         default:
           throw new Error(
             `modify not supported for Object type ${parent.getObjectType()}`

--- a/extension/src/ALObject/Enums.ts
+++ b/extension/src/ALObject/Enums.ts
@@ -73,6 +73,7 @@ export enum ALControlType {
   fieldAttribute = "FieldAttribute",
   modifiedPageField = "ModifiedPageField",
   modifiedTableField = "ModifiedTableField",
+  modifiedReportColumn = "ModifiedReportColumn",
 }
 
 export enum MultiLanguageType {

--- a/extension/src/test/ALObjectTestLibrary.ts
+++ b/extension/src/test/ALObjectTestLibrary.ts
@@ -1096,6 +1096,30 @@ export function getReport(): string {
     
     }`;
 }
+export function getReportExtension(): string {
+  return `reportextension 50000 "NAB Test Report Ext." extends "Customer - Top 10 List"
+{
+    dataset
+    {
+        add(Customer)
+        {
+            column(Address; Address)
+            {
+                Caption = 'Test 1';
+            }
+            column(Address2; "Address 2")
+            {
+                Caption = 'Test 2';
+            }
+        }
+        modify(BalanceLCY_Customer)
+        {
+            Description = 'Test 3';
+        }
+    }
+}
+`;
+}
 export function getTableExt(): string {
   return `tableextension 50000 "NAB Test Table Ext" extends Customer
     {

--- a/extension/src/test/ALParser.test.ts
+++ b/extension/src/test/ALParser.test.ts
@@ -284,6 +284,49 @@ suite("Classes.AL Functions Tests", function () {
     );
   });
 
+  test.only("Report Extension", function () {
+    const alObj = ALParser.getALObjectFromText(
+      ALObjectTestLibrary.getReportExtension(),
+      true
+    );
+    assert.ok(alObj, "Could not parse Report Extension");
+    assert.deepStrictEqual(
+      alObj.name,
+      "NAB Test Report Ext.",
+      "Unexpected Name"
+    );
+    assert.deepStrictEqual(
+      alObj.extendedObjectName,
+      "Customer - Top 10 List",
+      "Unexpected Extended Object Name"
+    );
+    assert.deepStrictEqual(
+      alObj.controls.length,
+      3,
+      "Unexpected control length"
+    );
+    assert.deepStrictEqual(
+      alObj.controls[0].name,
+      "Address",
+      "Unexpected Address (0)"
+    );
+    assert.deepStrictEqual(
+      alObj.controls[0].type,
+      ALControlType.column,
+      "Unexpected type (0)"
+    );
+    assert.deepStrictEqual(
+      alObj.controls[2].name,
+      "BalanceLCY_Customer",
+      "Unexpected BalanceLCY_Customer (2)"
+    );
+    assert.deepStrictEqual(
+      alObj.controls[2].type,
+      ALControlType.modifiedReportColumn,
+      "Unexpected type (2)"
+    );
+  });
+
   test("Remove group names from RegEx", function () {
     assert.equal(
       removeGroupNamesFromRegex("?<test>asdf"),

--- a/test-app/Xliff-test/Translations/Al.g.xlf
+++ b/test-app/Xliff-test/Translations/Al.g.xlf
@@ -533,6 +533,16 @@
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Enum NAB TestEnum - EnumValue MyValue - Property Caption</note>
         </trans-unit>
+        <trans-unit id="ReportExtension 1459638086 - ReportColumn 3168444338 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Report 919756715">
+          <source>Test 1</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">ReportExtension NAB Test Report Ext. - ReportColumn Address - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="ReportExtension 1459638086 - ReportColumn 179365352 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Report 919756715">
+          <source>Test 2</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">ReportExtension NAB Test Report Ext. - ReportColumn Address2 - Property Caption</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/test-app/Xliff-test/app.json
+++ b/test-app/Xliff-test/app.json
@@ -25,5 +25,5 @@
   "features": [
     "TranslationFile"
   ],
-  "runtime": "6.0"
+  "runtime": "7.0"
 }

--- a/test-app/Xliff-test/src/TestReportExt.ReportExt.al
+++ b/test-app/Xliff-test/src/TestReportExt.ReportExt.al
@@ -1,0 +1,22 @@
+reportextension 50000 "NAB Test Report Ext." extends "Customer - Top 10 List"
+{
+    dataset
+    {
+        add(Customer)
+        {
+            column(Address; Address)
+            {
+                Caption = 'Test 1';
+            }
+            column(Address2; "Address 2")
+            {
+                Caption = 'Test 2';
+            }
+        }
+        modify(Name_Customer)
+        {
+            Description = 'Test 3';
+
+        }
+    }
+}


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
Fixes #221 "Bug on ReportExtension Objects"

Adds support for modified report columns.
