### PR TITLE
Refactor exported classes and enums of LanguageFunctions

### DIFF
--- a/extension/src/Enums.ts
+++ b/extension/src/Enums.ts
@@ -1,0 +1,23 @@
+export enum TranslationMode {
+  nabTags,
+  dts,
+  external,
+}
+
+export enum TransUnitElementType {
+  transUnit,
+  source,
+  target,
+  developerNote,
+  descriptionNote,
+  transUnitEnd,
+  customNote,
+}
+
+export enum RefreshXlfHint {
+  newCopiedSource = "New translation. Target copied from source.",
+  modifiedSource = "Source has been modified.",
+  emptySource = "Source contains only white-space, consider using 'Locked = true' to avoid translation of unnecessary texts",
+  new = "New translation.",
+  suggestion = "Suggested translation inserted.",
+}

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -30,6 +30,7 @@ import * as FileFunctions from "./FileFunctions";
 import { Dictionary } from "./Dictionary";
 import { RefreshXlfHint, TransUnitElementType, TranslationMode } from "./Enums";
 import { LanguageFunctionsSettings } from "./Settings/LanguageFunctionsSettings";
+import { RefreshResult } from "./RefreshResult";
 
 export async function getGXlfDocument(
   settings: Settings,
@@ -1238,66 +1239,6 @@ export async function revealTransUnitTarget(
     }
   }
   return false;
-}
-
-export class RefreshResult {
-  numberOfAddedTransUnitElements = 0;
-  numberOfUpdatedNotes = 0;
-  numberOfUpdatedMaxWidths = 0;
-  numberOfUpdatedSources = 0;
-  numberOfRemovedTransUnits = 0;
-  numberOfRemovedNotes = 0;
-  numberOfCheckedFiles = 0;
-  numberOfSuggestionsAdded = 0;
-  numberOfReviewsAdded = 0;
-  fileName?: string;
-
-  getReport(): string {
-    let msg = "";
-    if (this.numberOfAddedTransUnitElements > 0) {
-      msg += `${this.numberOfAddedTransUnitElements} inserted translations, `;
-    }
-    if (this.numberOfUpdatedMaxWidths > 0) {
-      msg += `${this.numberOfUpdatedMaxWidths} updated maxwidth, `;
-    }
-    if (this.numberOfUpdatedNotes > 0) {
-      msg += `${this.numberOfUpdatedNotes} updated notes, `;
-    }
-    if (this.numberOfRemovedNotes > 0) {
-      msg += `${this.numberOfRemovedNotes} removed notes, `;
-    }
-    if (this.numberOfUpdatedSources > 0) {
-      msg += `${this.numberOfUpdatedSources} updated sources, `;
-    }
-    if (this.numberOfRemovedTransUnits > 0) {
-      msg += `${this.numberOfRemovedTransUnits} removed translations, `;
-    }
-    if (this.numberOfSuggestionsAdded) {
-      if (this.numberOfSuggestionsAdded > 0) {
-        msg += `${this.numberOfSuggestionsAdded} added suggestions, `;
-      }
-    }
-    if (msg !== "") {
-      msg = msg.substr(0, msg.length - 2); // Remove trailing ,
-    } else {
-      msg = "Nothing changed";
-    }
-    if (this.numberOfCheckedFiles) {
-      msg += ` in ${this.numberOfCheckedFiles} XLF files`;
-    } else if (this.fileName) {
-      msg += ` in ${this.fileName}`;
-    }
-
-    return msg;
-  }
-
-  isChanged(): boolean {
-    return (
-      Object.entries(this)
-        .filter((e) => !["numberOfCheckedFiles"].includes(e[0]))
-        .filter((e) => e[1] > 0).length > 0
-    );
-  }
 }
 
 function removeCustomNotesFromFile(

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -29,64 +29,7 @@ import { AppManifest, Settings } from "./Settings/Settings";
 import * as FileFunctions from "./FileFunctions";
 import { Dictionary } from "./Dictionary";
 import { RefreshXlfHint, TransUnitElementType, TranslationMode } from "./Enums";
-export class LanguageFunctionsSettings {
-  translationMode: TranslationMode;
-  useExternalTranslationTool: boolean;
-  searchOnlyXlfFiles: boolean;
-  detectInvalidValuesEnabled: boolean;
-  translationSuggestionPaths: string[];
-  matchBaseAppTranslation: boolean;
-  useMatchingSetting: boolean;
-  replaceSelfClosingXlfTags: boolean;
-  exactMatchState?: TargetState;
-  formatXml = true;
-  refreshXlfAfterFindNextUntranslated: boolean;
-  useDictionaryInDTSImport: boolean;
-
-  constructor(settings: Settings) {
-    this.translationMode = this.getTranslationMode(settings);
-    this.useExternalTranslationTool = settings.useExternalTranslationTool;
-    this.searchOnlyXlfFiles = settings.searchOnlyXlfFiles;
-    this.detectInvalidValuesEnabled = settings.detectInvalidTargets;
-    this.translationSuggestionPaths = settings.translationSuggestionPaths;
-    this.matchBaseAppTranslation = settings.matchBaseAppTranslation;
-    this.useMatchingSetting = settings.matchTranslation;
-    this.replaceSelfClosingXlfTags = settings.replaceSelfClosingXlfTags;
-    this.exactMatchState = this.getDtsExactMatchToState(settings);
-    this.refreshXlfAfterFindNextUntranslated =
-      settings.refreshXlfAfterFindNextUntranslated;
-    this.useDictionaryInDTSImport = settings.useDictionaryInDTSImport;
-  }
-
-  private getDtsExactMatchToState(settings: Settings): TargetState | undefined {
-    const setDtsExactMatchToState: string = settings.setDtsExactMatchToState;
-    let exactMatchState: TargetState | undefined;
-    if (setDtsExactMatchToState.toLowerCase() !== "(keep)") {
-      exactMatchState = setDtsExactMatchToState as TargetState;
-    }
-    return exactMatchState;
-  }
-
-  private getTranslationMode(settings: Settings): TranslationMode {
-    const useDTS: boolean = settings.useDTS;
-    if (useDTS) {
-      return TranslationMode.dts;
-    }
-    const useExternalTranslationTool: boolean =
-      settings.useExternalTranslationTool;
-    if (useExternalTranslationTool) {
-      return TranslationMode.external;
-    }
-    return TranslationMode.nabTags;
-  }
-
-  public get useDTSDictionary(): boolean {
-    return (
-      this.translationMode === TranslationMode.dts &&
-      this.useDictionaryInDTSImport
-    );
-  }
-}
+import { LanguageFunctionsSettings } from "./Settings/LanguageFunctionsSettings";
 
 export async function getGXlfDocument(
   settings: Settings,

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -28,7 +28,7 @@ import { createFolderIfNotExist } from "./Common";
 import { AppManifest, Settings } from "./Settings/Settings";
 import * as FileFunctions from "./FileFunctions";
 import { Dictionary } from "./Dictionary";
-
+import { RefreshXlfHint, TransUnitElementType, TranslationMode } from "./Enums";
 export class LanguageFunctionsSettings {
   translationMode: TranslationMode;
   useExternalTranslationTool: boolean;
@@ -86,12 +86,6 @@ export class LanguageFunctionsSettings {
       this.useDictionaryInDTSImport
     );
   }
-}
-
-export enum TranslationMode {
-  nabTags,
-  dts,
-  external,
 }
 
 export async function getGXlfDocument(
@@ -1241,15 +1235,6 @@ function getTransUnitLineType(textLine: string): TransUnitElementType {
 function getTransUnitElementMaxLines(): number {
   return 6;
 }
-export enum TransUnitElementType {
-  transUnit,
-  source,
-  target,
-  developerNote,
-  descriptionNote,
-  transUnitEnd,
-  customNote,
-}
 
 /**
  * @description returns an array of existing target languages
@@ -1310,14 +1295,6 @@ export async function revealTransUnitTarget(
     }
   }
   return false;
-}
-
-export enum RefreshXlfHint {
-  newCopiedSource = "New translation. Target copied from source.",
-  modifiedSource = "Source has been modified.",
-  emptySource = "Source contains only white-space, consider using 'Locked = true' to avoid translation of unnecessary texts",
-  new = "New translation.",
-  suggestion = "Suggested translation inserted.",
 }
 
 export class RefreshResult {

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -23,7 +23,7 @@ import {
 import { importXliffCSV } from "./CSV/ImportXliffCSV";
 import { isArray } from "lodash";
 import * as SettingsLoader from "./Settings/SettingsLoader";
-
+import { TranslationMode } from "./Enums";
 // import { OutputLogger as out } from './Logging';
 
 export async function refreshXlfFilesFromGXlf(
@@ -56,10 +56,7 @@ export async function formatCurrentXlfFileForDts(): Promise<void> {
   );
 
   try {
-    if (
-      languageFunctionsSettings.translationMode !==
-      LanguageFunctions.TranslationMode.dts
-    ) {
+    if (languageFunctionsSettings.translationMode !== TranslationMode.dts) {
       throw new Error(
         "The setting NAB.UseDTS is not active, this function cannot be executed."
       );
@@ -811,10 +808,9 @@ export async function exportTranslationsCSV(
   const exportOptions: IExportOptions = {
     columns: [],
     filter: CSVExportFilter.all,
-    checkTargetState: [
-      LanguageFunctions.TranslationMode.external,
-      LanguageFunctions.TranslationMode.dts,
-    ].includes(languageFunctionsSettings.translationMode),
+    checkTargetState: [TranslationMode.external, TranslationMode.dts].includes(
+      languageFunctionsSettings.translationMode
+    ),
   };
 
   if (options.selectColumns) {
@@ -905,10 +901,9 @@ export async function importTranslationCSV(): Promise<void> {
     const updatedTransUnits = importXliffCSV(
       xlf,
       importCSV[0].fsPath,
-      [
-        LanguageFunctions.TranslationMode.external,
-        LanguageFunctions.TranslationMode.dts,
-      ].includes(languageFunctionsSettings.translationMode),
+      [TranslationMode.external, TranslationMode.dts].includes(
+        languageFunctionsSettings.translationMode
+      ),
       xliffCSVImportTargetState
     );
     if (updatedTransUnits > 0) {
@@ -1034,10 +1029,7 @@ export async function importDtsTranslations(): Promise<void> {
     const settings = SettingsLoader.getSettings();
     const languageFunctionsSettings = new LanguageFunctionsSettings(settings);
 
-    if (
-      languageFunctionsSettings.translationMode !==
-      LanguageFunctions.TranslationMode.dts
-    ) {
+    if (languageFunctionsSettings.translationMode !== TranslationMode.dts) {
       throw new Error(
         "The setting NAB.UseDTS is not active, this function cannot be executed."
       );

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -13,7 +13,6 @@ import * as DocumentFunctions from "./DocumentFunctions";
 import { TargetState, Xliff } from "./Xliff/XLIFFDocument";
 import { baseAppTranslationFiles } from "./externalresources/BaseAppTranslationFiles";
 import { XliffEditorPanel } from "./XliffEditor/XliffEditorPanel";
-import { RefreshResult } from "./LanguageFunctions";
 import * as fs from "fs";
 import {
   CSVExportFilter,
@@ -25,13 +24,14 @@ import { isArray } from "lodash";
 import * as SettingsLoader from "./Settings/SettingsLoader";
 import { TranslationMode } from "./Enums";
 import { LanguageFunctionsSettings } from "./Settings/LanguageFunctionsSettings";
+import { RefreshResult } from "./RefreshResult";
 // import { OutputLogger as out } from './Logging';
 
 export async function refreshXlfFilesFromGXlf(
   suppressMessage = false
 ): Promise<void> {
   console.log("Running: RefreshXlfFilesFromGXlf");
-  let refreshResult: LanguageFunctions.RefreshResult;
+  let refreshResult: RefreshResult;
   try {
     if (XliffEditorPanel.currentPanel?.isActiveTab()) {
       throw new Error(
@@ -43,7 +43,7 @@ export async function refreshXlfFilesFromGXlf(
     showErrorAndLog("Refresh files from g.xlf", error as Error);
     return;
   }
-  const showMessage = suppressMessage ? refreshResult.isChanged() : true;
+  const showMessage = suppressMessage ? refreshResult.isChanged : true;
   if (showMessage) {
     vscode.window.showInformationMessage(getRefreshXlfMessage(refreshResult));
   }
@@ -957,7 +957,7 @@ async function refreshXlfFilesFromGXlfWithSettings({
 }: {
   sortOnly?: boolean;
   matchXlfFileUri?: vscode.Uri;
-} = {}): Promise<LanguageFunctions.RefreshResult> {
+} = {}): Promise<RefreshResult> {
   return await LanguageFunctions.refreshXlfFilesFromGXlf({
     settings: SettingsLoader.getSettings(),
     appManifest: SettingsLoader.getAppManifest(),

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -13,7 +13,7 @@ import * as DocumentFunctions from "./DocumentFunctions";
 import { TargetState, Xliff } from "./Xliff/XLIFFDocument";
 import { baseAppTranslationFiles } from "./externalresources/BaseAppTranslationFiles";
 import { XliffEditorPanel } from "./XliffEditor/XliffEditorPanel";
-import { LanguageFunctionsSettings, RefreshResult } from "./LanguageFunctions";
+import { RefreshResult } from "./LanguageFunctions";
 import * as fs from "fs";
 import {
   CSVExportFilter,
@@ -24,6 +24,7 @@ import { importXliffCSV } from "./CSV/ImportXliffCSV";
 import { isArray } from "lodash";
 import * as SettingsLoader from "./Settings/SettingsLoader";
 import { TranslationMode } from "./Enums";
+import { LanguageFunctionsSettings } from "./Settings/LanguageFunctionsSettings";
 // import { OutputLogger as out } from './Logging';
 
 export async function refreshXlfFilesFromGXlf(
@@ -787,9 +788,7 @@ export async function exportTranslationsCSV(
   console.log("Running: exportTranslationsCSV");
   const settings = SettingsLoader.getSettings();
   const appManifest = SettingsLoader.getAppManifest();
-  const languageFunctionsSettings = new LanguageFunctions.LanguageFunctionsSettings(
-    settings
-  );
+  const languageFunctionsSettings = new LanguageFunctionsSettings(settings);
   const translationFilePaths = WorkspaceFunctions.getLangXlfFiles(
     settings,
     appManifest

--- a/extension/src/RefreshResult.ts
+++ b/extension/src/RefreshResult.ts
@@ -1,0 +1,59 @@
+export class RefreshResult {
+  numberOfAddedTransUnitElements = 0;
+  numberOfUpdatedNotes = 0;
+  numberOfUpdatedMaxWidths = 0;
+  numberOfUpdatedSources = 0;
+  numberOfRemovedTransUnits = 0;
+  numberOfRemovedNotes = 0;
+  numberOfCheckedFiles = 0;
+  numberOfSuggestionsAdded = 0;
+  numberOfReviewsAdded = 0;
+  fileName?: string;
+
+  getReport(): string {
+    let msg = "";
+    if (this.numberOfAddedTransUnitElements > 0) {
+      msg += `${this.numberOfAddedTransUnitElements} inserted translations, `;
+    }
+    if (this.numberOfUpdatedMaxWidths > 0) {
+      msg += `${this.numberOfUpdatedMaxWidths} updated maxwidth, `;
+    }
+    if (this.numberOfUpdatedNotes > 0) {
+      msg += `${this.numberOfUpdatedNotes} updated notes, `;
+    }
+    if (this.numberOfRemovedNotes > 0) {
+      msg += `${this.numberOfRemovedNotes} removed notes, `;
+    }
+    if (this.numberOfUpdatedSources > 0) {
+      msg += `${this.numberOfUpdatedSources} updated sources, `;
+    }
+    if (this.numberOfRemovedTransUnits > 0) {
+      msg += `${this.numberOfRemovedTransUnits} removed translations, `;
+    }
+    if (this.numberOfSuggestionsAdded) {
+      if (this.numberOfSuggestionsAdded > 0) {
+        msg += `${this.numberOfSuggestionsAdded} added suggestions, `;
+      }
+    }
+    if (msg !== "") {
+      msg = msg.substr(0, msg.length - 2); // Remove trailing ,
+    } else {
+      msg = "Nothing changed";
+    }
+    if (this.numberOfCheckedFiles) {
+      msg += ` in ${this.numberOfCheckedFiles} XLF files`;
+    } else if (this.fileName) {
+      msg += ` in ${this.fileName}`;
+    }
+
+    return msg;
+  }
+
+  public get isChanged(): boolean {
+    return (
+      Object.entries(this)
+        .filter((e) => !["numberOfCheckedFiles"].includes(e[0]))
+        .filter((e) => e[1] > 0).length > 0
+    );
+  }
+}

--- a/extension/src/Settings/LanguageFunctionsSettings.ts
+++ b/extension/src/Settings/LanguageFunctionsSettings.ts
@@ -1,0 +1,62 @@
+import { TranslationMode } from "../Enums";
+import { TargetState } from "../Xliff/XLIFFDocument";
+import { Settings } from "./Settings";
+
+export class LanguageFunctionsSettings {
+  translationMode: TranslationMode;
+  useExternalTranslationTool: boolean;
+  searchOnlyXlfFiles: boolean;
+  detectInvalidValuesEnabled: boolean;
+  translationSuggestionPaths: string[];
+  matchBaseAppTranslation: boolean;
+  useMatchingSetting: boolean;
+  replaceSelfClosingXlfTags: boolean;
+  exactMatchState?: TargetState;
+  formatXml = true;
+  refreshXlfAfterFindNextUntranslated: boolean;
+  useDictionaryInDTSImport: boolean;
+
+  constructor(settings: Settings) {
+    this.translationMode = this.getTranslationMode(settings);
+    this.useExternalTranslationTool = settings.useExternalTranslationTool;
+    this.searchOnlyXlfFiles = settings.searchOnlyXlfFiles;
+    this.detectInvalidValuesEnabled = settings.detectInvalidTargets;
+    this.translationSuggestionPaths = settings.translationSuggestionPaths;
+    this.matchBaseAppTranslation = settings.matchBaseAppTranslation;
+    this.useMatchingSetting = settings.matchTranslation;
+    this.replaceSelfClosingXlfTags = settings.replaceSelfClosingXlfTags;
+    this.exactMatchState = this.getDtsExactMatchToState(settings);
+    this.refreshXlfAfterFindNextUntranslated =
+      settings.refreshXlfAfterFindNextUntranslated;
+    this.useDictionaryInDTSImport = settings.useDictionaryInDTSImport;
+  }
+
+  private getDtsExactMatchToState(settings: Settings): TargetState | undefined {
+    const setDtsExactMatchToState: string = settings.setDtsExactMatchToState;
+    let exactMatchState: TargetState | undefined;
+    if (setDtsExactMatchToState.toLowerCase() !== "(keep)") {
+      exactMatchState = setDtsExactMatchToState as TargetState;
+    }
+    return exactMatchState;
+  }
+
+  private getTranslationMode(settings: Settings): TranslationMode {
+    const useDTS: boolean = settings.useDTS;
+    if (useDTS) {
+      return TranslationMode.dts;
+    }
+    const useExternalTranslationTool: boolean =
+      settings.useExternalTranslationTool;
+    if (useExternalTranslationTool) {
+      return TranslationMode.external;
+    }
+    return TranslationMode.nabTags;
+  }
+
+  public get useDTSDictionary(): boolean {
+    return (
+      this.translationMode === TranslationMode.dts &&
+      this.useDictionaryInDTSImport
+    );
+  }
+}

--- a/extension/src/XliffEditor/XliffEditorPanel.ts
+++ b/extension/src/XliffEditor/XliffEditorPanel.ts
@@ -11,6 +11,7 @@ import {
 } from "../Xliff/XLIFFDocument";
 import * as html from "./HTML";
 import * as SettingsLoader from "../Settings/SettingsLoader";
+import { TranslationMode } from "../Enums";
 
 /**
  * Manages XliffEditor webview panels
@@ -152,18 +153,18 @@ export class XliffEditorPanel {
   private handleCompleteChanged(
     transUnitId: string,
     checked: boolean,
-    translationMode: LanguageFunctions.TranslationMode
+    translationMode: TranslationMode
   ): void {
     const unit = this._xlfDocument.getTransUnitById(transUnitId);
     if (checked) {
       unit.target.translationToken = undefined;
       unit.removeCustomNote(CustomNoteType.refreshXlfHint);
       switch (translationMode) {
-        case LanguageFunctions.TranslationMode.external:
+        case TranslationMode.external:
           unit.target.state = TargetState.translated;
           unit.target.stateQualifier = undefined;
           break;
-        case LanguageFunctions.TranslationMode.dts:
+        case TranslationMode.dts:
           unit.target.stateQualifier = undefined;
           switch (this.state.filter) {
             case FilterType.all:
@@ -188,11 +189,11 @@ export class XliffEditorPanel {
     } else {
       if (unit.target.textContent === "") {
         switch (translationMode) {
-          case LanguageFunctions.TranslationMode.external:
+          case TranslationMode.external:
             unit.target.state = TargetState.needsTranslation;
             unit.target.stateQualifier = StateQualifier.rejectedInaccurate;
             break;
-          case LanguageFunctions.TranslationMode.dts:
+          case TranslationMode.dts:
             unit.target.state = TargetState.needsTranslation;
             unit.target.stateQualifier = StateQualifier.rejectedInaccurate;
             unit.target.translationToken = TranslationToken.notTranslated;
@@ -207,7 +208,7 @@ export class XliffEditorPanel {
         );
       } else {
         switch (translationMode) {
-          case LanguageFunctions.TranslationMode.external:
+          case TranslationMode.external:
             unit.target.state = TargetState.needsReviewTranslation;
             unit.target.stateQualifier = StateQualifier.rejectedInaccurate;
             unit.insertCustomNote(
@@ -215,7 +216,7 @@ export class XliffEditorPanel {
               "Manually set as review"
             );
             break;
-          case LanguageFunctions.TranslationMode.dts:
+          case TranslationMode.dts:
             unit.target.state = TargetState.needsReviewTranslation;
             unit.target.stateQualifier = StateQualifier.rejectedInaccurate;
             unit.insertCustomNote(
@@ -546,9 +547,9 @@ export class XliffEditorPanel {
 }
 function getCompleteHeader(
   filter: FilterType,
-  translationMode: LanguageFunctions.TranslationMode
+  translationMode: TranslationMode
 ): string {
-  if (translationMode !== LanguageFunctions.TranslationMode.dts) {
+  if (translationMode !== TranslationMode.dts) {
     return "Complete";
   }
   switch (filter) {
@@ -566,7 +567,7 @@ function getCheckedState(
   languageFunctionsSettings: LanguageFunctions.LanguageFunctionsSettings
 ): boolean {
   switch (languageFunctionsSettings.translationMode) {
-    case LanguageFunctions.TranslationMode.dts:
+    case TranslationMode.dts:
       switch (filter) {
         case FilterType.stateTranslated:
           return transunit.target.state === TargetState.signedOff;
@@ -586,10 +587,9 @@ function getCheckedState(
 function checkTargetState(
   languageFunctionsSettings: LanguageFunctions.LanguageFunctionsSettings
 ): boolean {
-  return [
-    LanguageFunctions.TranslationMode.external,
-    LanguageFunctions.TranslationMode.dts,
-  ].includes(languageFunctionsSettings.translationMode);
+  return [TranslationMode.external, TranslationMode.dts].includes(
+    languageFunctionsSettings.translationMode
+  );
 }
 
 function getNonce(): string {
@@ -604,12 +604,12 @@ function getNonce(): string {
 
 function getNotesHtml(
   transunit: TransUnit,
-  translationMode: LanguageFunctions.TranslationMode
+  translationMode: TranslationMode
 ): string {
   let content = "";
   switch (translationMode) {
-    case LanguageFunctions.TranslationMode.external:
-    case LanguageFunctions.TranslationMode.dts:
+    case TranslationMode.external:
+    case TranslationMode.dts:
       if (transunit.targetState !== TargetState.translated) {
         content += `${transunit.targetState}`;
         if (transunit.targetStateQualifier !== "") {
@@ -656,10 +656,7 @@ function dropdownMenu(
       { id: "btn-filter-differently-translated", class: "filter-btn" },
       "Show differently translated"
     )}</a>`;
-  if (
-    languageFunctionsSettings.translationMode !==
-    LanguageFunctions.TranslationMode.nabTags
-  ) {
+  if (languageFunctionsSettings.translationMode !== TranslationMode.nabTags) {
     dropdownContent += `
         <a href="#">${html.button(
           { id: "btn-filter-translated-state", class: "filter-btn" },

--- a/extension/src/XliffEditor/XliffEditorPanel.ts
+++ b/extension/src/XliffEditor/XliffEditorPanel.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import * as LanguageFunctions from "../LanguageFunctions";
+import { LanguageFunctionsSettings } from "../Settings/LanguageFunctionsSettings";
 import {
   CustomNoteType,
   StateQualifier,
@@ -29,7 +30,7 @@ export class XliffEditorPanel {
   private _currentXlfDocument: Xliff;
   private totalTransUnitCount: number;
   private state: EditorState;
-  private languageFunctionsSettings = new LanguageFunctions.LanguageFunctionsSettings(
+  private languageFunctionsSettings = new LanguageFunctionsSettings(
     SettingsLoader.getSettings()
   );
 
@@ -336,7 +337,7 @@ export class XliffEditorPanel {
   public static getFilteredXliff(
     xlfDocument: Xliff,
     filter: FilterType,
-    languageFunctionsSettings: LanguageFunctions.LanguageFunctionsSettings
+    languageFunctionsSettings: LanguageFunctionsSettings
   ): Xliff {
     if (
       xlfDocument.transunit.filter((u) => u.targets.length === 0).length !== 0
@@ -564,7 +565,7 @@ function getCompleteHeader(
 function getCheckedState(
   transunit: TransUnit,
   filter: FilterType,
-  languageFunctionsSettings: LanguageFunctions.LanguageFunctionsSettings
+  languageFunctionsSettings: LanguageFunctionsSettings
 ): boolean {
   switch (languageFunctionsSettings.translationMode) {
     case TranslationMode.dts:
@@ -585,7 +586,7 @@ function getCheckedState(
   }
 }
 function checkTargetState(
-  languageFunctionsSettings: LanguageFunctions.LanguageFunctionsSettings
+  languageFunctionsSettings: LanguageFunctionsSettings
 ): boolean {
   return [TranslationMode.external, TranslationMode.dts].includes(
     languageFunctionsSettings.translationMode
@@ -641,7 +642,7 @@ function getNotesHtml(
 }
 
 function dropdownMenu(
-  languageFunctionsSettings: LanguageFunctions.LanguageFunctionsSettings
+  languageFunctionsSettings: LanguageFunctionsSettings
 ): string {
   let dropdownContent = `
     <a href="#">${html.button(
@@ -685,7 +686,7 @@ function runRefreshXlfFilesFromGXlf(): void {
     appManifest: SettingsLoader.getAppManifest(),
     sortOnly: false,
     matchXlfFileUri: undefined,
-    languageFunctionsSettings: new LanguageFunctions.LanguageFunctionsSettings(
+    languageFunctionsSettings: new LanguageFunctionsSettings(
       SettingsLoader.getSettings()
     ),
   }).then((result) => {

--- a/extension/src/test/LanguageFunctions.test.ts
+++ b/extension/src/test/LanguageFunctions.test.ts
@@ -15,7 +15,7 @@ import {
 } from "../Xliff/XLIFFDocument";
 import * as ALParser from "../ALObject/ALParser";
 import { ALCodeLine } from "../ALObject/ALCodeLine";
-import { TranslationMode } from "../LanguageFunctions";
+import { RefreshXlfHint, TranslationMode } from "../Enums";
 import * as SettingsLoader from "../Settings/SettingsLoader";
 import { random } from "lodash";
 import { workspace } from "vscode";
@@ -1714,7 +1714,7 @@ suite("Language Functions Tests", function () {
 
       assert.strictEqual(
         transUnit.customNote(CustomNoteType.refreshXlfHint)?.textContent,
-        LanguageFunctions.RefreshXlfHint.modifiedSource,
+        RefreshXlfHint.modifiedSource,
         "Unexpected custom note"
       );
     });
@@ -1753,7 +1753,7 @@ suite("Language Functions Tests", function () {
 
       assert.strictEqual(
         transUnit.customNote(CustomNoteType.refreshXlfHint)?.textContent,
-        LanguageFunctions.RefreshXlfHint.new,
+        RefreshXlfHint.new,
         "Unexpected custom note"
       );
     });
@@ -1888,7 +1888,7 @@ suite("Language Functions Tests", function () {
       customNotes !== undefined ? customNotes : [new Note("", "", 0, "")];
     assert.strictEqual(
       customNotes[0].textContent,
-      LanguageFunctions.RefreshXlfHint.emptySource,
+      RefreshXlfHint.emptySource,
       "Unexpected note textContent"
     );
   });
@@ -1970,7 +1970,7 @@ suite("Language Functions Tests", function () {
 });
 
 function refreshXlfOptionCaptions(
-  translationMode: LanguageFunctions.TranslationMode,
+  translationMode: TranslationMode,
   sortOnly: boolean
 ): Xliff {
   const gXliff = Xliff.fromString(`<?xml version="1.0" encoding="utf-8"?>

--- a/extension/src/test/LanguageFunctions.test.ts
+++ b/extension/src/test/LanguageFunctions.test.ts
@@ -20,6 +20,7 @@ import { RefreshXlfHint, TranslationMode } from "../Enums";
 import * as SettingsLoader from "../Settings/SettingsLoader";
 import { random } from "lodash";
 import { workspace } from "vscode";
+import { RefreshResult } from "../RefreshResult";
 
 const xmlns = "urn:oasis:names:tc:xliff:document:1.2";
 const testResourcesPath = "../../src/test/resources/";
@@ -1212,32 +1213,33 @@ suite("ALObject TransUnit Tests", function () {
 
 suite("Language Functions Tests", function () {
   test("RefreshResult.isChanged()", function () {
-    let refreshResult = new LanguageFunctions.RefreshResult();
+    let refreshResult = new RefreshResult();
     assert.strictEqual(
-      refreshResult.isChanged(),
+      refreshResult.isChanged,
       false,
       "Initialized RefreshResult should not be considered changed"
     );
     refreshResult.numberOfCheckedFiles = 2;
     assert.strictEqual(
-      refreshResult.isChanged(),
+      refreshResult.isChanged,
       false,
       "RefreshResult with numberOfCheckedFiles > 0 should not be considered changed"
     );
     refreshResult.numberOfRemovedNotes = random(1, 1000, false);
     assert.strictEqual(
-      refreshResult.isChanged(),
+      refreshResult.isChanged,
       true,
       "RefreshResult should be considered changed"
     );
-    refreshResult = new LanguageFunctions.RefreshResult();
+    refreshResult = new RefreshResult();
     refreshResult.numberOfReviewsAdded = random(1, 1000, false);
     assert.strictEqual(
-      refreshResult.isChanged(),
+      refreshResult.isChanged,
       true,
       "RefreshResult should be considered changed"
     );
   });
+
   test("LoadMatchXlfIntoMap()", function () {
     /*
      *   - Test with Xlf that has [NAB:* ] tokens
@@ -1868,7 +1870,7 @@ suite("Language Functions Tests", function () {
     </body>
   </file>
 </xliff>`);
-    const refreshResult = new LanguageFunctions.RefreshResult();
+    const refreshResult = new RefreshResult();
     const languageFunctionsSettings = new LanguageFunctionsSettings(
       SettingsLoader.getSettings()
     );
@@ -1923,7 +1925,7 @@ suite("Language Functions Tests", function () {
   });
 
   test("RefreshResult.getReport", function () {
-    const refreshResult = new LanguageFunctions.RefreshResult();
+    const refreshResult = new RefreshResult();
     refreshResult.numberOfAddedTransUnitElements = 1;
     refreshResult.numberOfUpdatedNotes = 1;
     refreshResult.numberOfUpdatedMaxWidths = 1;
@@ -2078,7 +2080,7 @@ function refreshXlfOptionCaptions(
     </body>
   </file>
 </xliff>`);
-  const refreshResult = new LanguageFunctions.RefreshResult();
+  const refreshResult = new RefreshResult();
   const languageFunctionsSettings = new LanguageFunctionsSettings(
     SettingsLoader.getSettings()
   );

--- a/extension/src/test/LanguageFunctions.test.ts
+++ b/extension/src/test/LanguageFunctions.test.ts
@@ -4,6 +4,7 @@ import * as fs from "fs";
 import * as xmldom from "@xmldom/xmldom";
 import * as ALObjectTestLibrary from "./ALObjectTestLibrary";
 import * as LanguageFunctions from "../LanguageFunctions";
+import { LanguageFunctionsSettings } from "../Settings/LanguageFunctionsSettings";
 import {
   CustomNoteType,
   Note,
@@ -102,9 +103,7 @@ suite("DTS Import Tests", function () {
   </file>
 </xliff>`);
   const settings = SettingsLoader.getSettings();
-  const languageFunctionsSettings = new LanguageFunctions.LanguageFunctionsSettings(
-    settings
-  );
+  const languageFunctionsSettings = new LanguageFunctionsSettings(settings);
   languageFunctionsSettings.translationMode = TranslationMode.dts;
   test("Import Translation - Invalid translations", function () {
     LanguageFunctions.importTranslatedFileIntoTargetXliff(
@@ -1299,7 +1298,7 @@ suite("Language Functions Tests", function () {
      *   - Assert matched sources has [NAB: SUGGESTION] tokens
      *   - Assert non matching sources is unchanged.
      */
-    const languageFunctionsSettings = new LanguageFunctions.LanguageFunctionsSettings(
+    const languageFunctionsSettings = new LanguageFunctionsSettings(
       SettingsLoader.getSettings()
     );
     languageFunctionsSettings.translationMode = TranslationMode.nabTags;
@@ -1393,7 +1392,7 @@ suite("Language Functions Tests", function () {
      *   - Assert matched sources has [NAB: SUGGESTION] tokens
      *   - Assert non matching sources is unchanged.
      */
-    const languageFunctionsSettings = new LanguageFunctions.LanguageFunctionsSettings(
+    const languageFunctionsSettings = new LanguageFunctionsSettings(
       SettingsLoader.getSettings()
     );
     languageFunctionsSettings.translationMode = TranslationMode.nabTags;
@@ -1462,7 +1461,7 @@ suite("Language Functions Tests", function () {
      */
     const sortOnly = false;
 
-    const languageFunctionsSettings = new LanguageFunctions.LanguageFunctionsSettings(
+    const languageFunctionsSettings = new LanguageFunctionsSettings(
       SettingsLoader.getSettings()
     );
     languageFunctionsSettings.translationMode = TranslationMode.nabTags;
@@ -1870,7 +1869,7 @@ suite("Language Functions Tests", function () {
   </file>
 </xliff>`);
     const refreshResult = new LanguageFunctions.RefreshResult();
-    const languageFunctionsSettings = new LanguageFunctions.LanguageFunctionsSettings(
+    const languageFunctionsSettings = new LanguageFunctionsSettings(
       SettingsLoader.getSettings()
     );
     const updatedXliff = LanguageFunctions.refreshSelectedXlfFileFromGXlf(
@@ -1897,9 +1896,7 @@ suite("Language Functions Tests", function () {
     const settings = SettingsLoader.getSettings();
     settings.setDtsExactMatchToState = "test";
     settings.useDTS = true;
-    const langFuncSettings = new LanguageFunctions.LanguageFunctionsSettings(
-      settings
-    );
+    const langFuncSettings = new LanguageFunctionsSettings(settings);
     assert.strictEqual(
       langFuncSettings.exactMatchState,
       "test" as TargetState,
@@ -1916,9 +1913,7 @@ suite("Language Functions Tests", function () {
     const settings = SettingsLoader.getSettings();
     settings.useDTS = false;
     settings.useExternalTranslationTool = true;
-    const langFuncSettings = new LanguageFunctions.LanguageFunctionsSettings(
-      settings
-    );
+    const langFuncSettings = new LanguageFunctionsSettings(settings);
 
     assert.strictEqual(
       langFuncSettings.translationMode,
@@ -2084,7 +2079,7 @@ function refreshXlfOptionCaptions(
   </file>
 </xliff>`);
   const refreshResult = new LanguageFunctions.RefreshResult();
-  const languageFunctionsSettings = new LanguageFunctions.LanguageFunctionsSettings(
+  const languageFunctionsSettings = new LanguageFunctionsSettings(
     SettingsLoader.getSettings()
   );
   languageFunctionsSettings.translationMode = translationMode;

--- a/extension/src/test/XlfHighlighter.test.ts
+++ b/extension/src/test/XlfHighlighter.test.ts
@@ -8,6 +8,7 @@ import {
   translationTokenSearchExpression,
 } from "../constants";
 import * as SettingsLoader from "../Settings/SettingsLoader";
+import { TranslationMode } from "../Enums";
 
 const testResourcesPath = "../../src/test/resources/highlights/";
 const translationTokenXlfUri: vscode.Uri = vscode.Uri.file(
@@ -56,8 +57,7 @@ suite("Xlf Highlighter", function () {
     const languageFunctionsSettings = new LanguageFunctions.LanguageFunctionsSettings(
       SettingsLoader.getSettings()
     );
-    languageFunctionsSettings.translationMode =
-      LanguageFunctions.TranslationMode.nabTags;
+    languageFunctionsSettings.translationMode = TranslationMode.nabTags;
 
     await assert.rejects(
       async () => {

--- a/extension/src/test/XlfHighlighter.test.ts
+++ b/extension/src/test/XlfHighlighter.test.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import * as XlfHighlighter from "../XlfHighlighter";
 import * as assert from "assert";
 import * as LanguageFunctions from "../LanguageFunctions";
+import { LanguageFunctionsSettings } from "../Settings/LanguageFunctionsSettings";
 import {
   invalidXmlSearchExpression,
   translationTokenSearchExpression,
@@ -54,7 +55,7 @@ suite("Xlf Highlighter", function () {
     const langFilesUri: string[] = [
       path.resolve(__dirname, testResourcesPath, "invalid.xlf"),
     ];
-    const languageFunctionsSettings = new LanguageFunctions.LanguageFunctionsSettings(
+    const languageFunctionsSettings = new LanguageFunctionsSettings(
       SettingsLoader.getSettings()
     );
     languageFunctionsSettings.translationMode = TranslationMode.nabTags;


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
I was looking into #158  and realized that it would require some refactoring to avoid `vscode` and circular dependencies. It felt wiser to do the refactoring as a separate step.

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- Move exported enums to `src/Enums.ts`
  - I looked at the option of creating them as separate files but collecting them makes for a slimmer import statement. I did only move exported enums from `LanguageFunctions.ts` since it's a general purpose file and most other enums are already placed where they "belong".
- Move `LanguageFunctionsSettings` to own file.
- Move `RefreshResult` to own file.
  - refactored `isChanged` as a getter.
- Only references updated in tests.
