### PR TITLE
Refactor target state function

### DIFF
--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -4,7 +4,6 @@ import * as fs from "fs";
 import * as path from "path";
 import * as WorkspaceFunctions from "./WorkspaceFunctions";
 import * as DocumentFunctions from "./DocumentFunctions";
-import * as VSCodeFunctions from "./VSCodeFunctions";
 import * as escapeStringRegexp from "escape-string-regexp";
 import { XliffIdToken } from "./ALObject/XliffIdToken";
 import {
@@ -389,32 +388,30 @@ export async function copySourceToTarget(): Promise<boolean> {
   return false;
 }
 
-export async function findAllUnTranslatedText(
+export function allUntranslatedSearchParameters(
   languageFunctionsSettings: LanguageFunctionsSettings
-): Promise<void> {
-  const findText = languageFunctionsSettings.useExternalTranslationTool
-    ? targetStateActionNeededAttributes()
-    : [
-        escapeStringRegexp(TranslationToken.review),
-        escapeStringRegexp(TranslationToken.notTranslated),
-        escapeStringRegexp(TranslationToken.suggestion),
-      ];
-  let fileFilter = "";
-  if (languageFunctionsSettings.searchOnlyXlfFiles) {
-    fileFilter = "*.xlf";
-  }
-  await VSCodeFunctions.findTextInFiles(findText.join("|"), true, fileFilter);
+): FileSearchParameters {
+  return {
+    searchStrings: languageFunctionsSettings.useExternalTranslationTool
+      ? targetStateActionNeededAttributes()
+      : [
+          escapeStringRegexp(TranslationToken.review),
+          escapeStringRegexp(TranslationToken.notTranslated),
+          escapeStringRegexp(TranslationToken.suggestion),
+        ],
+    fileFilter: languageFunctionsSettings.searchOnlyXlfFiles ? "*.xlf" : "",
+  };
 }
 
-export async function findMultipleTargets(
+export function findMultipleTargetsSearchParameters(
   languageFunctionsSettings: LanguageFunctionsSettings
-): Promise<void> {
-  const findText = "^\\s*<target>.*\\r*\\n*(\\s*<target>.*)+";
-  let fileFilter = "";
-  if (languageFunctionsSettings.useExternalTranslationTool) {
-    fileFilter = "*.xlf";
-  }
-  await VSCodeFunctions.findTextInFiles(findText, true, fileFilter);
+): FileSearchParameters {
+  return {
+    searchStrings: ["^\\s*<target>.*\\r*\\n*(\\s*<target>.*)+"],
+    fileFilter: languageFunctionsSettings.useExternalTranslationTool
+      ? "*.xlf"
+      : "",
+  };
 }
 
 export async function refreshXlfFilesFromGXlf({
@@ -1712,4 +1709,9 @@ function getDictionary(
   return fs.existsSync(dictionaryPath)
     ? new Dictionary(dictionaryPath)
     : Dictionary.newDictionary(translationPath, languageCode, "dts");
+}
+
+interface FileSearchParameters {
+  searchStrings: string[];
+  fileFilter: string;
 }

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -332,11 +332,9 @@ export function allUntranslatedSearchParameters(
   return {
     searchStrings: languageFunctionsSettings.useExternalTranslationTool
       ? targetStateActionNeededAttributes()
-      : [
-          escapeStringRegexp(TranslationToken.review),
-          escapeStringRegexp(TranslationToken.notTranslated),
-          escapeStringRegexp(TranslationToken.suggestion),
-        ],
+      : Object.values(TranslationToken).map((t) => {
+          return escapeStringRegexp(t);
+        }),
     fileFilter: languageFunctionsSettings.searchOnlyXlfFiles ? "*.xlf" : "",
   };
 }

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -12,8 +12,7 @@ import {
   StateQualifier,
   Target,
   TargetState,
-  targetStateActionNeededKeywordList,
-  targetStateActionNeededToken,
+  targetStateActionNeededAttributes,
   TranslationToken,
   TransUnit,
   Xliff,
@@ -239,7 +238,7 @@ export async function findNextUnTranslatedText(
     let searchFor: Array<string> = [];
     searchFor = searchFor.concat(Object.values(TranslationToken)); // NAB: tokens
     searchFor = searchFor.concat(
-      targetStateActionNeededKeywordList(lowerThanTargetState)
+      targetStateActionNeededAttributes(lowerThanTargetState)
     ); // States
     searchFor = searchFor.concat("></target>"); // Empty target
 
@@ -389,25 +388,22 @@ export async function copySourceToTarget(): Promise<boolean> {
   }
   return false;
 }
+
 export async function findAllUnTranslatedText(
   languageFunctionsSettings: LanguageFunctionsSettings
 ): Promise<void> {
-  let findText = "";
-  if (languageFunctionsSettings.useExternalTranslationTool) {
-    findText = targetStateActionNeededToken();
-  } else {
-    findText =
-      escapeStringRegexp(TranslationToken.review) +
-      "|" +
-      escapeStringRegexp(TranslationToken.notTranslated) +
-      "|" +
-      escapeStringRegexp(TranslationToken.suggestion);
-  }
+  const findText = languageFunctionsSettings.useExternalTranslationTool
+    ? targetStateActionNeededAttributes()
+    : [
+        escapeStringRegexp(TranslationToken.review),
+        escapeStringRegexp(TranslationToken.notTranslated),
+        escapeStringRegexp(TranslationToken.suggestion),
+      ];
   let fileFilter = "";
   if (languageFunctionsSettings.searchOnlyXlfFiles) {
     fileFilter = "*.xlf";
   }
-  await VSCodeFunctions.findTextInFiles(findText, true, fileFilter);
+  await VSCodeFunctions.findTextInFiles(findText.join("|"), true, fileFilter);
 }
 
 export async function findMultipleTargets(

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -228,8 +228,13 @@ export async function findNextUnTranslatedText(
 export async function findAllUnTranslatedText(): Promise<void> {
   console.log("Running: FindAllUnTranslatedText");
   try {
-    await LanguageFunctions.findAllUnTranslatedText(
+    const searchParams = LanguageFunctions.allUntranslatedSearchParameters(
       new LanguageFunctionsSettings(SettingsLoader.getSettings())
+    );
+    await VSCodeFunctions.findTextInFiles(
+      searchParams.searchStrings.join("|"),
+      true,
+      searchParams.fileFilter
     );
   } catch (error) {
     showErrorAndLog("Find all untranslated", error as Error);
@@ -242,8 +247,13 @@ export async function findAllUnTranslatedText(): Promise<void> {
 export async function findMultipleTargets(): Promise<void> {
   console.log("Running: FindMultipleTargets");
   try {
-    await LanguageFunctions.findMultipleTargets(
+    const searchParams = LanguageFunctions.findMultipleTargetsSearchParameters(
       new LanguageFunctionsSettings(SettingsLoader.getSettings())
+    );
+    await VSCodeFunctions.findTextInFiles(
+      searchParams.searchStrings.join(""),
+      true,
+      searchParams.fileFilter
     );
   } catch (error) {
     showErrorAndLog("Find multiple targets", error as Error);

--- a/extension/src/Xliff/XLIFFDocument.ts
+++ b/extension/src/Xliff/XLIFFDocument.ts
@@ -3,7 +3,6 @@
  */
 import * as fs from "fs";
 import * as xmldom from "@xmldom/xmldom";
-import * as escapeStringRegexp from "escape-string-regexp";
 import {
   XmlFormattingOptionsFactory,
   ClassicXmlFormatter,
@@ -722,7 +721,7 @@ export class TransUnit implements TransUnitInterface {
       this.hasCustomNote(CustomNoteType.refreshXlfHint) ||
       (checkTargetState &&
         !(this.target.state === undefined || this.target.state === null) &&
-        targetStateActionNeededAsList().includes(this.target.state))
+        targetStateActionNeededValues().includes(this.target.state))
     );
   }
 }
@@ -971,18 +970,18 @@ export interface ToolInterface {
   toolCompany?: string;
 }
 
-function targetStateActionNeededAsList(
+function targetStateActionNeededValues(
   lowerThanTargetState?: TargetState
 ): string[] {
-  const stateActionNeeded = [
-    TargetState.needsAdaptation,
-    TargetState.needsL10n,
-    TargetState.needsReviewAdaptation,
-    TargetState.needsReviewL10n,
-    TargetState.needsReviewTranslation,
-    TargetState.needsTranslation,
-    TargetState.new,
-  ];
+  const stateActionNeeded = Object.values(TargetState).filter(
+    (state) =>
+      [
+        TargetState.final,
+        TargetState.signedOff,
+        TargetState.translated,
+      ].includes(state) === false
+  );
+
   if (lowerThanTargetState) {
     switch (lowerThanTargetState) {
       case TargetState.signedOff:
@@ -997,24 +996,15 @@ function targetStateActionNeededAsList(
   return stateActionNeeded;
 }
 
-export function targetStateActionNeededKeywordList(
+/**
+ * Returns a list of target states where the state indicates that action is needed formatted as attributes.
+ * @param lowerThanTargetState (optional) `signed-off` includes "translated". `final` includes "translated" and "signed-off".
+ * @returns string[]
+ */
+export function targetStateActionNeededAttributes(
   lowerThanTargetState?: TargetState
-): Array<string> {
-  const keywordList: Array<string> = [];
-  targetStateActionNeededAsList(lowerThanTargetState).forEach((s) => {
-    keywordList.push(`state="${s}"`);
+): string[] {
+  return targetStateActionNeededValues(lowerThanTargetState).map((state) => {
+    return `state="${state}"`;
   });
-  return keywordList;
-}
-
-export function targetStateActionNeededToken(): string {
-  return (
-    `state="${escapeStringRegexp(TargetState.needsAdaptation)}"|` +
-    `state="${escapeStringRegexp(TargetState.needsL10n)}"|` +
-    `state="${escapeStringRegexp(TargetState.needsReviewAdaptation)}"|` +
-    `state="${escapeStringRegexp(TargetState.needsReviewL10n)}"|` +
-    `state="${escapeStringRegexp(TargetState.needsReviewTranslation)}"|` +
-    `state="${escapeStringRegexp(TargetState.needsTranslation)}"|` +
-    `state="${escapeStringRegexp(TargetState.new)}"`
-  );
 }

--- a/extension/src/test/LanguageFunctions.test.ts
+++ b/extension/src/test/LanguageFunctions.test.ts
@@ -1217,9 +1217,9 @@ suite("Language Functions Tests", function () {
     const languageFunctionSettings = new LanguageFunctionsSettings(settings);
     const expectedDefault = {
       searchStrings: [
-        "\\[NAB: REVIEW\\]",
         "\\[NAB: NOT TRANSLATED\\]",
         "\\[NAB: SUGGESTION\\]",
+        "\\[NAB: REVIEW\\]",
       ],
       fileFilter: "",
     };

--- a/extension/src/test/LanguageFunctions.test.ts
+++ b/extension/src/test/LanguageFunctions.test.ts
@@ -1214,9 +1214,7 @@ suite("ALObject TransUnit Tests", function () {
 suite("Language Functions Tests", function () {
   test("allUntranslatedSearchParameters()", function () {
     const settings = SettingsLoader.getSettings();
-    const languageFunctionSettings = new LanguageFunctions.LanguageFunctionsSettings(
-      settings
-    );
+    const languageFunctionSettings = new LanguageFunctionsSettings(settings);
     const expectedDefault = {
       searchStrings: [
         "\\[NAB: REVIEW\\]",
@@ -1270,9 +1268,7 @@ suite("Language Functions Tests", function () {
 
   test("findMultipleTargetsSearchParameters", function () {
     const settings = SettingsLoader.getSettings();
-    const languageFunctionSettings = new LanguageFunctions.LanguageFunctionsSettings(
-      settings
-    );
+    const languageFunctionSettings = new LanguageFunctionsSettings(settings);
     const expected = {
       searchStrings: ["^\\s*<target>.*\\r*\\n*(\\s*<target>.*)+"],
       fileFilter: "",

--- a/extension/src/test/LanguageFunctions.test.ts
+++ b/extension/src/test/LanguageFunctions.test.ts
@@ -1212,6 +1212,91 @@ suite("ALObject TransUnit Tests", function () {
 });
 
 suite("Language Functions Tests", function () {
+  test("allUntranslatedSearchParameters()", function () {
+    const settings = SettingsLoader.getSettings();
+    const languageFunctionSettings = new LanguageFunctions.LanguageFunctionsSettings(
+      settings
+    );
+    const expectedDefault = {
+      searchStrings: [
+        "\\[NAB: REVIEW\\]",
+        "\\[NAB: NOT TRANSLATED\\]",
+        "\\[NAB: SUGGESTION\\]",
+      ],
+      fileFilter: "",
+    };
+    assert.deepStrictEqual(
+      LanguageFunctions.allUntranslatedSearchParameters(
+        languageFunctionSettings
+      ),
+      expectedDefault,
+      "Unexpected default result"
+    );
+
+    // Search only xlf files
+    expectedDefault.fileFilter = "*.xlf";
+    languageFunctionSettings.searchOnlyXlfFiles = true;
+    assert.deepStrictEqual(
+      LanguageFunctions.allUntranslatedSearchParameters(
+        languageFunctionSettings
+      ),
+      expectedDefault,
+      "Test of searchOnlyXlfFiles setting failed."
+    );
+
+    // External Translation Tool
+    languageFunctionSettings.searchOnlyXlfFiles = false;
+    languageFunctionSettings.useExternalTranslationTool = true;
+    const expectedExternal = {
+      searchStrings: [
+        'state="needs-adaptation"',
+        'state="needs-l10n"',
+        'state="needs-review-adaptation"',
+        'state="needs-review-l10n"',
+        'state="needs-review-translation"',
+        'state="needs-translation"',
+        'state="new"',
+      ],
+      fileFilter: "",
+    };
+    assert.deepStrictEqual(
+      LanguageFunctions.allUntranslatedSearchParameters(
+        languageFunctionSettings
+      ),
+      expectedExternal,
+      "Unexpected result when using external translation tool"
+    );
+  });
+
+  test("findMultipleTargetsSearchParameters", function () {
+    const settings = SettingsLoader.getSettings();
+    const languageFunctionSettings = new LanguageFunctions.LanguageFunctionsSettings(
+      settings
+    );
+    const expected = {
+      searchStrings: ["^\\s*<target>.*\\r*\\n*(\\s*<target>.*)+"],
+      fileFilter: "",
+    };
+    assert.deepStrictEqual(
+      LanguageFunctions.findMultipleTargetsSearchParameters(
+        languageFunctionSettings
+      ),
+      expected,
+      "Unexpected default result"
+    );
+
+    // External translation Tool
+    languageFunctionSettings.useExternalTranslationTool = true;
+    expected.fileFilter = "*.xlf";
+    assert.deepStrictEqual(
+      LanguageFunctions.findMultipleTargetsSearchParameters(
+        languageFunctionSettings
+      ),
+      expected,
+      "Unexpected result when using external translation tool"
+    );
+  });
+
   test("RefreshResult.isChanged()", function () {
     let refreshResult = new LanguageFunctions.RefreshResult();
     assert.strictEqual(
@@ -1239,6 +1324,7 @@ suite("Language Functions Tests", function () {
       "RefreshResult should be considered changed"
     );
   });
+
   test("LoadMatchXlfIntoMap()", function () {
     /*
      *   - Test with Xlf that has [NAB:* ] tokens

--- a/extension/src/test/VSCodeFunctions.test.ts
+++ b/extension/src/test/VSCodeFunctions.test.ts
@@ -1,7 +1,10 @@
+import * as assert from "assert";
 import * as VSCodeFunctions from "../VSCodeFunctions";
 
 suite("VSCodeFunctions", function () {
-  test("findTextFiles", function () {
-    VSCodeFunctions.findTextInFiles("table", false);
+  test("findTextFiles()", async function () {
+    await assert.doesNotReject(async () => {
+      VSCodeFunctions.findTextInFiles("table", false, ".md");
+    }, "Unexpected rejection of promise");
   });
 });

--- a/extension/src/test/XLIFFTypes.test.ts
+++ b/extension/src/test/XLIFFTypes.test.ts
@@ -9,6 +9,7 @@ import {
   SizeUnit,
   CustomNoteType,
   StateQualifier,
+  targetStateActionNeededAttributes,
 } from "../Xliff/XLIFFDocument";
 
 suite("Xliff Types - Deserialization", function () {
@@ -585,6 +586,22 @@ suite("Xliff Types - Functions", function () {
           .textContent
       ),
       "XliffIdToken is not matching"
+    );
+  });
+
+  test("targetStateActionNeededAttributes()", function () {
+    assert.deepStrictEqual(
+      targetStateActionNeededAttributes(),
+      [
+        'state="needs-adaptation"',
+        'state="needs-l10n"',
+        'state="needs-review-adaptation"',
+        'state="needs-review-l10n"',
+        'state="needs-review-translation"',
+        'state="needs-translation"',
+        'state="new"',
+      ],
+      "Unexpected contents of array"
     );
   });
 });


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
Maybe not as well motivated as the previous PR. This does however add test for previously untested functions and removes a bit of old code :)

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- Refactor functions `findAllUnTranslatedText` and `findMultipleTargets` of `NABFunctions.ts`
  - Refactor the called functions of `LanguageFunctions.ts` to return the search parameters. This makes for more testable code :+1: 
  - Move async call to `vscode` api up one step in hierarchy `NABFunctions.ts`
  - Add tests 
- Refactor generation of trans-unit target state search strings
  - Remove superfluous function `targetStateActionNeededToken`
  - apply skills learned since orginal creation
  - added tests

