### PR TITLE
Refactor return typed result from search functions

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -133,7 +133,7 @@
                 "title": "NAB: Import DTS Translations"
             },
             {
-                "command": "nab.FindNextUnTranslatedText",
+                "command": "nab.FindNextUntranslatedText",
                 "title": "NAB: Find next untranslated text"
             },
             {
@@ -153,7 +153,7 @@
                 "title": "NAB: Match translations from external XLF file"
             },
             {
-                "command": "nab.FindAllUnTranslatedText",
+                "command": "nab.FindAllUntranslatedText",
                 "title": "NAB: Find untranslated texts"
             },
             {
@@ -258,7 +258,7 @@
                 "when": "editorLangId == xml && resourceExtname == .xlf"
             },
             {
-                "command": "nab.FindNextUnTranslatedText",
+                "command": "nab.FindNextUntranslatedText",
                 "key": "Ctrl+Alt+U"
             },
             {

--- a/extension/src/DocumentFunctions.ts
+++ b/extension/src/DocumentFunctions.ts
@@ -44,13 +44,6 @@ export async function openTextFileWithSelectionOnLineNo(
   return new vscode.Location(document.uri, selection);
 }
 
-export function eolToLineEnding(eol: vscode.EndOfLine): string {
-  if (eol === vscode.EndOfLine.CRLF) {
-    return "\r\n";
-  }
-  return "\n";
-}
-
 export async function openAlFileFromXliffTokens(
   settings: Settings,
   appManifest: AppManifest,

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -3,7 +3,6 @@ import * as vscode from "vscode";
 import * as fs from "fs";
 import * as path from "path";
 import * as WorkspaceFunctions from "./WorkspaceFunctions";
-import * as DocumentFunctions from "./DocumentFunctions";
 import * as escapeStringRegexp from "escape-string-regexp";
 import {
   CustomNoteType,
@@ -13,7 +12,6 @@ import {
   TransUnit,
   Xliff,
 } from "./Xliff/XLIFFDocument";
-
 import { createFolderIfNotExist } from "./Common";
 import { AppManifest, Settings } from "./Settings/Settings";
 import { TranslationMode, TransUnitElementType } from "./Enums";
@@ -174,9 +172,11 @@ export async function copySourceToTarget(): Promise<boolean> {
       // in a xlf file
       await vscode.window.activeTextEditor.document.save();
       const docText = vscode.window.activeTextEditor.document.getText();
-      const lineEnding = DocumentFunctions.eolToLineEnding(
-        vscode.window.activeTextEditor.document.eol
-      );
+      const lineEnding =
+        vscode.window.activeTextEditor.document.eol === vscode.EndOfLine.CRLF
+          ? "\r\n"
+          : "\n";
+
       const docArray = docText.split(lineEnding);
       if (
         docArray[vscode.window.activeTextEditor.selection.active.line].match(

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -20,7 +20,7 @@ import * as XliffFunctions from "./XliffFunctions";
 import { XliffIdToken } from "./ALObject/XliffIdToken";
 import { TextDocumentMatch } from "./Types";
 
-export async function findNextUnTranslatedText(
+export async function findNextUntranslatedText(
   settings: Settings,
   appManifest: AppManifest,
   searchCurrentDocument: boolean,

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -425,30 +425,26 @@ export function getTransUnitID(
 }
 
 export async function revealTransUnitTarget(
-  settings: Settings,
-  appManifest: AppManifest,
-  transUnitId: string
+  transUnitId: string,
+  langFilePath: string
 ): Promise<TextDocumentMatch | undefined> {
   if (!vscode.window.activeTextEditor) {
     return;
   }
-  const langFiles = WorkspaceFunctions.getLangXlfFiles(settings, appManifest);
-  if (langFiles.length === 1) {
-    const langContent = fs.readFileSync(langFiles[0], "utf8");
-    const transUnitIdRegExp = new RegExp(`"${transUnitId}"`);
-    const result = transUnitIdRegExp.exec(langContent);
-    if (result !== null) {
-      const matchIndex = result.index;
-      const targetRegExp = new RegExp(`(<target[^>]*>)([^>]*)(</target>)`);
-      const restString = langContent.substring(matchIndex);
-      const targetResult = targetRegExp.exec(restString);
-      if (targetResult !== null) {
-        return {
-          filePath: langFiles[0],
-          position: targetResult.index + matchIndex + targetResult[1].length,
-          length: targetResult[2].length,
-        };
-      }
+  const langContent = fs.readFileSync(langFilePath, "utf8");
+  const transUnitIdRegExp = new RegExp(`"${transUnitId}"`);
+  const result = transUnitIdRegExp.exec(langContent);
+  if (result !== null) {
+    const matchIndex = result.index;
+    const targetRegExp = new RegExp(`(<target[^>]*>)([^>]*)(</target>)`);
+    const restString = langContent.substring(matchIndex);
+    const targetResult = targetRegExp.exec(restString);
+    if (targetResult !== null) {
+      return {
+        filePath: langFilePath,
+        position: targetResult.index + matchIndex + targetResult[1].length,
+        length: targetResult[2].length,
+      };
     }
   }
   return;

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -428,9 +428,9 @@ export async function revealTransUnitTarget(
   settings: Settings,
   appManifest: AppManifest,
   transUnitId: string
-): Promise<boolean> {
+): Promise<TextDocumentMatch | undefined> {
   if (!vscode.window.activeTextEditor) {
-    return false;
+    return;
   }
   const langFiles = WorkspaceFunctions.getLangXlfFiles(settings, appManifest);
   if (langFiles.length === 1) {
@@ -443,16 +443,15 @@ export async function revealTransUnitTarget(
       const restString = langContent.substring(matchIndex);
       const targetResult = targetRegExp.exec(restString);
       if (targetResult !== null) {
-        await DocumentFunctions.openTextFileWithSelection(
-          langFiles[0],
-          targetResult.index + matchIndex + targetResult[1].length,
-          targetResult[2].length
-        );
-        return true;
+        return {
+          filePath: langFiles[0],
+          position: targetResult.index + matchIndex + targetResult[1].length,
+          length: targetResult[2].length,
+        };
       }
     }
   }
-  return false;
+  return;
 }
 
 interface FileSearchParameters {

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -174,10 +174,10 @@ export async function setTranslationUnitToFinal(): Promise<void> {
   console.log("Done: SetTranslationUnitToFinal");
 }
 
-export async function findNextUnTranslatedText(
+export async function findNextUntranslatedText(
   lowerThanTargetState?: TargetState
 ): Promise<void> {
-  console.log("Running: FindNextUnTranslatedText");
+  console.log("Running: FindNextUntranslatedText");
 
   let nextUntranslated: TextDocumentMatch | undefined;
   try {
@@ -186,7 +186,7 @@ export async function findNextUnTranslatedText(
     // Search active text editor first
     if (vscode.window.activeTextEditor) {
       if (vscode.window.activeTextEditor.document.uri.fsPath.endsWith(".xlf")) {
-        nextUntranslated = await LanguageFunctions.findNextUnTranslatedText(
+        nextUntranslated = await LanguageFunctions.findNextUntranslatedText(
           settings,
           SettingsLoader.getAppManifest(),
           true,
@@ -197,7 +197,7 @@ export async function findNextUnTranslatedText(
     }
     // Search any xlf file
     if (!nextUntranslated) {
-      nextUntranslated = await LanguageFunctions.findNextUnTranslatedText(
+      nextUntranslated = await LanguageFunctions.findNextUntranslatedText(
         settings,
         SettingsLoader.getAppManifest(),
         false,
@@ -211,7 +211,7 @@ export async function findNextUnTranslatedText(
       languageFunctionsSettings.refreshXlfAfterFindNextUntranslated
     ) {
       await refreshXlfFilesFromGXlf(true);
-      nextUntranslated = await LanguageFunctions.findNextUnTranslatedText(
+      nextUntranslated = await LanguageFunctions.findNextUntranslatedText(
         settings,
         SettingsLoader.getAppManifest(),
         false,
@@ -233,11 +233,11 @@ export async function findNextUnTranslatedText(
   if (!nextUntranslated) {
     vscode.window.showInformationMessage(`No more untranslated texts found.`);
   }
-  console.log("Done: FindNextUnTranslatedText");
+  console.log("Done: FindNextUntranslatedText");
 }
 
-export async function findAllUnTranslatedText(): Promise<void> {
-  console.log("Running: FindAllUnTranslatedText");
+export async function findAllUntranslatedText(): Promise<void> {
+  console.log("Running: FindAllUntranslatedText");
   try {
     const searchParams = LanguageFunctions.allUntranslatedSearchParameters(
       new LanguageFunctionsSettings(SettingsLoader.getSettings())
@@ -252,7 +252,7 @@ export async function findAllUnTranslatedText(): Promise<void> {
     return;
   }
 
-  console.log("Done: FindAllUnTranslatedText");
+  console.log("Done: FindAllUntranslatedText");
 }
 
 export async function findMultipleTargets(): Promise<void> {
@@ -1030,7 +1030,7 @@ async function setTranslationUnitState(
         );
         editBuilder.replace(fullDocumentRange, xlfContent); // A bit choppy in UI since it's the full file. Can later be refactored to only update the TransUnit
       });
-      findNextUnTranslatedText(newTargetState);
+      findNextUntranslatedText(newTargetState);
     }
   } catch (error) {
     showErrorAndLog("Set translation unit state", error as Error);

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -206,17 +206,18 @@ export async function findNextUnTranslatedText(
       );
     }
     // Run refresh from g.xlf then search again.
-    if (languageFunctionsSettings.refreshXlfAfterFindNextUntranslated) {
-      if (!nextUntranslated) {
-        await refreshXlfFilesFromGXlf(true);
-        nextUntranslated = await LanguageFunctions.findNextUnTranslatedText(
-          settings,
-          SettingsLoader.getAppManifest(),
-          false,
-          languageFunctionsSettings.replaceSelfClosingXlfTags,
-          lowerThanTargetState
-        );
-      }
+    if (
+      nextUntranslated === undefined &&
+      languageFunctionsSettings.refreshXlfAfterFindNextUntranslated
+    ) {
+      await refreshXlfFilesFromGXlf(true);
+      nextUntranslated = await LanguageFunctions.findNextUnTranslatedText(
+        settings,
+        SettingsLoader.getAppManifest(),
+        false,
+        languageFunctionsSettings.replaceSelfClosingXlfTags,
+        lowerThanTargetState
+      );
     }
     if (nextUntranslated) {
       DocumentFunctions.openTextFileWithSelection(

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -310,17 +310,22 @@ export async function findTranslatedTexts(): Promise<void> {
 
       let foundTarget: TextDocumentMatch | undefined;
       try {
-        foundTarget = await LanguageFunctions.revealTransUnitTarget(
+        const langFiles = WorkspaceFunctions.getLangXlfFiles(
           SettingsLoader.getSettings(),
-          SettingsLoader.getAppManifest(),
-          transUnitId
+          SettingsLoader.getAppManifest()
         );
-        if (foundTarget) {
-          DocumentFunctions.openTextFileWithSelection(
-            foundTarget.filePath,
-            foundTarget.position,
-            foundTarget.length
+        if (langFiles.length === 1) {
+          foundTarget = await LanguageFunctions.revealTransUnitTarget(
+            transUnitId,
+            langFiles[0]
           );
+          if (foundTarget) {
+            DocumentFunctions.openTextFileWithSelection(
+              foundTarget.filePath,
+              foundTarget.position,
+              foundTarget.length
+            );
+          }
         }
       } catch (error) {
         // When target file is large (50MB+) then this error occurs:

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -328,10 +328,9 @@ export async function findTranslatedTexts(): Promise<void> {
       }
 
       if (!foundTarget) {
-        let fileFilter = "";
-        if (SettingsLoader.getSettings().searchOnlyXlfFiles) {
-          fileFilter = "*.xlf";
-        }
+        const fileFilter = SettingsLoader.getSettings().searchOnlyXlfFiles
+          ? "*.xlf"
+          : "";
         await VSCodeFunctions.findTextInFiles(transUnitId, false, fileFilter);
       }
     }

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -307,21 +307,27 @@ export async function findTranslatedTexts(): Promise<void> {
       }
       const transUnitId = selectedMlObject[0].xliffId();
 
-      let revealedTransUnitTarget = false;
+      let foundTarget: TextDocumentMatch | undefined;
       try {
-        revealedTransUnitTarget = await LanguageFunctions.revealTransUnitTarget(
+        foundTarget = await LanguageFunctions.revealTransUnitTarget(
           SettingsLoader.getSettings(),
           SettingsLoader.getAppManifest(),
           transUnitId
         );
+        if (foundTarget) {
+          DocumentFunctions.openTextFileWithSelection(
+            foundTarget.filePath,
+            foundTarget.position,
+            foundTarget.length
+          );
+        }
       } catch (error) {
         // When target file is large (50MB+) then this error occurs:
         // cannot open file:///.../BaseApp/Translations/Base%20Application.cs-CZ.xlf. Detail: Files above 50MB cannot be synchronized with extensions.
         vscode.window.showWarningMessage((error as Error).message);
-        revealedTransUnitTarget = false;
       }
 
-      if (!revealedTransUnitTarget) {
+      if (!foundTarget) {
         let fileFilter = "";
         if (SettingsLoader.getSettings().searchOnlyXlfFiles) {
           fileFilter = "*.xlf";

--- a/extension/src/Types.ts
+++ b/extension/src/Types.ts
@@ -1,0 +1,5 @@
+export type TextDocumentMatch = {
+  filePath: string;
+  position: number;
+  length: number;
+};

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -28,8 +28,8 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand("nab.ImportDtsTranslations", () => {
       NABfunctions.importDtsTranslations();
     }),
-    vscode.commands.registerCommand("nab.FindNextUnTranslatedText", () => {
-      NABfunctions.findNextUnTranslatedText();
+    vscode.commands.registerCommand("nab.FindNextUntranslatedText", () => {
+      NABfunctions.findNextUntranslatedText();
     }),
     vscode.commands.registerCommand(
       "nab.SetTranslationUnitToTranslated",
@@ -43,8 +43,8 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand("nab.SetTranslationUnitToFinal", () => {
       NABfunctions.setTranslationUnitToFinal();
     }),
-    vscode.commands.registerCommand("nab.FindAllUnTranslatedText", () => {
-      NABfunctions.findAllUnTranslatedText();
+    vscode.commands.registerCommand("nab.FindAllUntranslatedText", () => {
+      NABfunctions.findAllUntranslatedText();
     }),
     vscode.commands.registerCommand("nab.FindMultipleTargets", () => {
       NABfunctions.findMultipleTargets();

--- a/extension/src/test/DocumentFunctions.test.ts
+++ b/extension/src/test/DocumentFunctions.test.ts
@@ -15,18 +15,6 @@ suite("DocumentFunctions", function () {
     }, "Unexpected rejection of promise");
   });
 
-  test("eolToLineEnding", function () {
-    assert.strictEqual(
-      DocumentFunctions.eolToLineEnding(vscode.EndOfLine.CRLF),
-      "\r\n",
-      "Incorrect EOL returned."
-    );
-    assert.strictEqual(
-      DocumentFunctions.eolToLineEnding(vscode.EndOfLine.LF),
-      "\n",
-      "Incorrect EOL returned."
-    );
-  });
   test("find field definition if caption property is missing", async function () {
     const textToFind = "Table Empty - Field MyField - Property Caption";
     const document = await vscode.workspace.openTextDocument(

--- a/extension/src/test/LanguageFunctions.test.ts
+++ b/extension/src/test/LanguageFunctions.test.ts
@@ -45,6 +45,8 @@ testFiles.forEach((f) => {
   langFilesUri.push(toPath);
 });
 
+const WORKFLOW = process.env.GITHUB_ACTION; // Only run in GitHub Workflow
+
 suite("DTS Import Tests", function () {
   const sourceXliff = Xliff.fromString(`<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
@@ -1213,6 +1215,74 @@ suite("ALObject TransUnit Tests", function () {
 });
 
 suite("Language Functions Tests", function () {
+  const settings = SettingsLoader.getSettings();
+  const appManifest = SettingsLoader.getAppManifest();
+  test("findNextUntranslatedText()", async function () {
+    const foundMatch = await LanguageFunctions.findNextUntranslatedText(
+      settings,
+      appManifest,
+      false,
+      false
+    );
+    assert.ok(foundMatch, "Expected a match");
+    assert.ok(foundMatch.position > 0, "Expected position to be > 0");
+    assert.ok(foundMatch.length > 0, "Expected length to be > 0");
+  });
+
+  test("revealTransUnitTarget()", async function () {
+    const actualTransUnit = await LanguageFunctions.revealTransUnitTarget(
+      "Table 2328808854 - Field 1296262074 - Method 2126772001 - NamedType 1978266064",
+      langFilesUri[1]
+    );
+    const expected = {
+      position: 1000,
+      length: 28,
+    };
+    assert.ok(actualTransUnit, "Expected trans-unit to be found");
+    assert.ok(actualTransUnit.filePath.endsWith(testFiles[1]));
+    assert.strictEqual(
+      actualTransUnit.position,
+      expected.position,
+      "Unexpected position"
+    );
+    assert.strictEqual(
+      actualTransUnit.length,
+      expected.length,
+      "Unexpected length."
+    );
+  });
+
+  test("zipXlfFiles()", async function () {
+    if (!WORKFLOW) {
+      this.skip();
+    }
+    const dtsWorkFolderPath = path.join(__dirname, "temp/dts");
+    await LanguageFunctions.zipXlfFiles(
+      settings,
+      appManifest,
+      dtsWorkFolderPath
+    );
+    const zipFiles = fs.readdirSync(dtsWorkFolderPath, { withFileTypes: true });
+    assert.strictEqual(zipFiles.length, 3, "Unexpected number of zip-files");
+    const expectedFiles = [
+      {
+        name: "Al.da-dk.zip",
+      },
+      {
+        name: "Al.g.zip",
+      },
+      {
+        name: "Al.sv-se.zip",
+      },
+    ];
+    zipFiles.forEach((z) => {
+      assert.ok(
+        expectedFiles.find((zip) => zip.name === z.name),
+        `New file exported ${z.name}. Is this correct?`
+      );
+    });
+  });
+
   test("allUntranslatedSearchParameters()", function () {
     const settings = SettingsLoader.getSettings();
     const languageFunctionSettings = new LanguageFunctionsSettings(settings);

--- a/extension/src/test/LanguageFunctions.test.ts
+++ b/extension/src/test/LanguageFunctions.test.ts
@@ -1235,7 +1235,7 @@ suite("Language Functions Tests", function () {
       langFilesUri[1]
     );
     const expected = {
-      position: 1000,
+      position: process.platform === "linux" ? 1000 : 1012,
       length: 28,
     };
     assert.ok(actualTransUnit, "Expected trans-unit to be found");


### PR DESCRIPTION
<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- Add new type `TextDocumentMatch`.
- Have `LanguageFunctions.findNextUnTranslatedText` and `LanguageFunctions.revealTransUnitTarget` return undefined or result as `TextDocumentMatch`.
  - The functions are now somewhat testable.
- `revealTransUnitTarget` had a condition that it would only run if there only was one target translation. This has now been removed and the signature refactored to only take a single file path and a translation unit id as parameters.
- Move call to `DocumentFunctions.openTextFileWithSelection` up the hierarchy. I think this allows for better control, clearer purpose and definition of the functions involved.
- Break dependency on `DocumentFunctions.ts` by cloning `eolToLineEnding`. Mainly because I knew it was the last reference not really sure if it's justified. 

Additional comments
I couldn't decide if the functions should return `TextDocumentMatch | undefined` or `TextDocumentMatch | void`. Using void would allow for elimination a few `return` statements but maybe `undefined` makes the intent clearer? I'd love your opinion on this.