### PR TITLE
refactor: zipXlfFiles becomes zipFiles in FileFunctions

### DIFF
--- a/extension/src/Common.ts
+++ b/extension/src/Common.ts
@@ -1,6 +1,3 @@
-import * as fs from "fs";
-import * as path from "path";
-
 export function replaceAll(
   text: string,
   searchFor: string | RegExp,
@@ -28,23 +25,6 @@ export function escapeRegex(text: string): string {
 
 export function convertLinefeedToBR(text: string): string {
   return text.replace(/\n/g, "<br>");
-}
-
-export function deleteFolderRecursive(directoryPath: string): void {
-  if (fs.existsSync(directoryPath)) {
-    fs.readdirSync(directoryPath).forEach((file) => {
-      const curPath = path.join(directoryPath, file);
-      if (fs.lstatSync(curPath).isDirectory()) {
-        // recurse
-        deleteFolderRecursive(curPath);
-      } else {
-        // delete file
-        fs.unlinkSync(curPath);
-      }
-    });
-
-    fs.rmdirSync(directoryPath);
-  }
 }
 
 /**

--- a/extension/src/Common.ts
+++ b/extension/src/Common.ts
@@ -47,37 +47,6 @@ export function deleteFolderRecursive(directoryPath: string): void {
   }
 }
 
-export function mkDirByPathSync(targetDir: string): string {
-  const sep = path.sep;
-  const initDir = path.isAbsolute(targetDir) ? sep : "";
-  const baseDir = ".";
-
-  return targetDir.split(sep).reduce((parentDir, childDir) => {
-    const curDir = path.resolve(baseDir, parentDir, childDir);
-    try {
-      fs.mkdirSync(curDir);
-    } catch (err) {
-      if (err.code === "EEXIST") {
-        // curDir already exists!
-        return curDir;
-      }
-
-      // To avoid `EISDIR` error on Mac and `EACCES`-->`ENOENT` and `EPERM` on Windows.
-      if (err.code === "ENOENT") {
-        // Throw the original parentDir error on curDir `ENOENT` failure.
-        throw new Error(`EACCES: permission denied, mkdir '${parentDir}'`);
-      }
-
-      const caughtErr = ["EACCES", "EPERM", "EISDIR"].indexOf(err.code) > -1;
-      if (!caughtErr || (caughtErr && curDir === path.resolve(targetDir))) {
-        throw err; // Throw if it's just the last created dir.
-      }
-    }
-
-    return curDir;
-  }, initDir);
-}
-
 /**
  *
  * @param date Default Today
@@ -92,10 +61,4 @@ export function formatDate(date = new Date()): string {
   day = day.length < 2 ? `0${day}` : day;
 
   return `${year}-${month}-${day}`;
-}
-
-export function createFolderIfNotExist(folderPath: string): void {
-  if (!fs.existsSync(folderPath)) {
-    mkDirByPathSync(folderPath);
-  }
 }

--- a/extension/src/Documentation.ts
+++ b/extension/src/Documentation.ts
@@ -11,8 +11,8 @@ import {
   DocsType,
 } from "./ALObject/Enums";
 import { ALProcedure } from "./ALObject/ALProcedure";
-import { deleteFolderRecursive, formatDate, replaceAll } from "./Common";
-import { createFolderIfNotExist } from "./FileFunctions";
+import { formatDate, replaceAll } from "./Common";
+import { deleteFolderRecursive, createFolderIfNotExist } from "./FileFunctions";
 import xmldom = require("@xmldom/xmldom");
 import { ALTenantWebService } from "./ALObject/ALTenantWebService";
 import { ALXmlComment } from "./ALObject/ALXmlComment";

--- a/extension/src/Documentation.ts
+++ b/extension/src/Documentation.ts
@@ -11,12 +11,8 @@ import {
   DocsType,
 } from "./ALObject/Enums";
 import { ALProcedure } from "./ALObject/ALProcedure";
-import {
-  createFolderIfNotExist,
-  deleteFolderRecursive,
-  formatDate,
-  replaceAll,
-} from "./Common";
+import { deleteFolderRecursive, formatDate, replaceAll } from "./Common";
+import { createFolderIfNotExist } from "./FileFunctions";
 import xmldom = require("@xmldom/xmldom");
 import { ALTenantWebService } from "./ALObject/ALTenantWebService";
 import { ALXmlComment } from "./ALObject/ALXmlComment";

--- a/extension/src/FileFunctions.ts
+++ b/extension/src/FileFunctions.ts
@@ -90,6 +90,23 @@ export function mkDirByPathSync(targetDir: string): string {
   }, initDir);
 }
 
+export function deleteFolderRecursive(directoryPath: string): void {
+  if (fs.existsSync(directoryPath)) {
+    fs.readdirSync(directoryPath).forEach((file) => {
+      const curPath = path.join(directoryPath, file);
+      if (fs.lstatSync(curPath).isDirectory()) {
+        // recurse
+        deleteFolderRecursive(curPath);
+      } else {
+        // delete file
+        fs.unlinkSync(curPath);
+      }
+    });
+
+    fs.rmdirSync(directoryPath);
+  }
+}
+
 export function createFolderIfNotExist(folderPath: string): void {
   if (!fs.existsSync(folderPath)) {
     mkDirByPathSync(folderPath);

--- a/extension/src/FileFunctions.ts
+++ b/extension/src/FileFunctions.ts
@@ -35,10 +35,7 @@ export function loadJson(filePath: string): unknown {
   return json;
 }
 
-export async function zipFiles(
-  compressFiles: string[],
-  exportPath: string
-): Promise<void> {
+export function zipFiles(compressFiles: string[], exportPath: string): void {
   createFolderIfNotExist(exportPath);
   compressFiles.forEach((filePath) => {
     createZipFile(filePath, exportPath);

--- a/extension/src/FileFunctions.ts
+++ b/extension/src/FileFunctions.ts
@@ -41,11 +41,11 @@ export async function zipFiles(
 ): Promise<void> {
   createFolderIfNotExist(exportPath);
   compressFiles.forEach((filePath) => {
-    createXlfZipFile(filePath, exportPath);
+    createZipFile(filePath, exportPath);
   });
 }
 
-function createXlfZipFile(filePath: string, dtsWorkFolderPath: string): void {
+function createZipFile(filePath: string, dtsWorkFolderPath: string): void {
   const zip = new AdmZip();
   zip.addLocalFile(filePath);
   const ext = path.extname(filePath);

--- a/extension/src/FileFunctions.ts
+++ b/extension/src/FileFunctions.ts
@@ -29,7 +29,7 @@ export function loadJson(filePath: string): unknown {
   let fileContent = fs.readFileSync(filePath, "utf8");
   if (fileContent.charCodeAt(0) === 0xfeff) {
     // Remove BOM
-    fileContent = fileContent.substr(1);
+    fileContent = fileContent.substring(1);
   }
   const json = JSON.parse(stripJsonComments(fileContent));
   return json;

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -12,7 +12,6 @@ import {
   TransUnit,
   Xliff,
 } from "./Xliff/XLIFFDocument";
-import { createFolderIfNotExist } from "./Common";
 import { AppManifest, Settings } from "./Settings/Settings";
 import { TranslationMode, TransUnitElementType } from "./Enums";
 import { LanguageFunctionsSettings } from "./Settings/LanguageFunctionsSettings";
@@ -257,39 +256,6 @@ export async function formatCurrentXlfFileForDts(
     filePath,
     languageFunctionsSettings.replaceSelfClosingXlfTags
   );
-}
-
-export async function zipXlfFiles(
-  settings: Settings,
-  appManifest: AppManifest,
-  dtsWorkFolderPath: string
-): Promise<void> {
-  const gXlfFilePath = WorkspaceFunctions.getGXlfFilePath(
-    settings,
-    appManifest
-  );
-  const langXlfFileUri = WorkspaceFunctions.getLangXlfFiles(
-    settings,
-    appManifest
-  );
-  createFolderIfNotExist(dtsWorkFolderPath);
-  createXlfZipFile(gXlfFilePath, dtsWorkFolderPath);
-  langXlfFileUri.forEach((filePath) => {
-    createXlfZipFile(filePath, dtsWorkFolderPath);
-  });
-}
-
-function createXlfZipFile(filePath: string, dtsWorkFolderPath: string): void {
-  const zip = new AdmZip();
-  zip.addLocalFile(filePath);
-  const zipFilePath = path.join(
-    dtsWorkFolderPath,
-    `${path.basename(filePath, ".xlf")}.zip`
-  );
-  if (fs.existsSync(zipFilePath)) {
-    fs.unlinkSync(zipFilePath);
-  }
-  zip.writeZip(zipFilePath);
 }
 
 export function importDtsTranslatedFile(

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -10,6 +10,7 @@ import * as ALParser from "./ALObject/ALParser";
 import * as path from "path";
 import * as PowerShellFunctions from "./PowerShellFunctions";
 import * as DocumentFunctions from "./DocumentFunctions";
+import * as FileFunctions from "./FileFunctions";
 import { TargetState, Xliff } from "./Xliff/XLIFFDocument";
 import { baseAppTranslationFiles } from "./externalresources/BaseAppTranslationFiles";
 import { XliffEditorPanel } from "./XliffEditor/XliffEditorPanel";
@@ -1049,11 +1050,12 @@ export function openDTS(): void {
     url = `https://support.lcs.dynamics.com/RegFTranslationRequestProject/Index/${dtsProjectId}`;
   }
   const settings = SettingsLoader.getSettings();
-  LanguageFunctions.zipXlfFiles(
-    settings,
-    SettingsLoader.getAppManifest(),
-    settings.dtsWorkFolderPath
-  );
+  const appManifest = SettingsLoader.getAppManifest();
+  const xlfFiles = [
+    WorkspaceFunctions.getGXlfFilePath(settings, appManifest),
+    ...WorkspaceFunctions.getLangXlfFiles(settings, appManifest),
+  ];
+  FileFunctions.zipFiles(xlfFiles, settings.dtsWorkFolderPath);
   vscode.env.openExternal(vscode.Uri.parse(url));
 }
 

--- a/extension/src/test/Common.test.ts
+++ b/extension/src/test/Common.test.ts
@@ -1,12 +1,7 @@
 import * as assert from "assert";
-import * as path from "path";
-import * as fs from "fs";
 import * as Common from "../Common";
 
 suite("Common", function () {
-  const parentPath = path.resolve(__dirname, "common-test");
-  const newPath = path.resolve(parentPath, "new/path/", Common.formatDate());
-
   test("convertLinefeedToBr", function () {
     assert.strictEqual(
       Common.convertLinefeedToBR("\n\n\n"),
@@ -27,20 +22,6 @@ suite("Common", function () {
       Common.formatDate(d),
       "2001-01-01",
       "Incorrect date string returned"
-    );
-  });
-
-  test("deleteFolderRecursive", function () {
-    Common.deleteFolderRecursive(parentPath);
-    assert.strictEqual(
-      fs.existsSync(newPath),
-      false,
-      "Child path should be deleted"
-    );
-    assert.strictEqual(
-      fs.existsSync(parentPath),
-      false,
-      "Parent path should be deleted."
     );
   });
 });

--- a/extension/src/test/Common.test.ts
+++ b/extension/src/test/Common.test.ts
@@ -6,7 +6,6 @@ import * as Common from "../Common";
 suite("Common", function () {
   const parentPath = path.resolve(__dirname, "common-test");
   const newPath = path.resolve(parentPath, "new/path/", Common.formatDate());
-  const invalidPathChars = `/?<>\\:*|."`;
 
   test("convertLinefeedToBr", function () {
     assert.strictEqual(
@@ -29,33 +28,6 @@ suite("Common", function () {
       "2001-01-01",
       "Incorrect date string returned"
     );
-  });
-
-  test("createFolderIfNotExist", function () {
-    assert.strictEqual(
-      fs.existsSync(newPath),
-      false,
-      "Test folder should not exist. This could be an indication that the 'deleteFolderRecursive' test is not working."
-    );
-    Common.createFolderIfNotExist(newPath);
-    assert.ok(fs.existsSync(newPath), "Could not find created folder.");
-
-    // Test error code path
-    if (process.platform === "win32") {
-      // Linux: pretty much allows any character in a path.
-      // MacOS: We're currently not running test on MacOS.
-      let errorMsg = "";
-      try {
-        Common.createFolderIfNotExist(newPath + invalidPathChars);
-      } catch (e) {
-        errorMsg = (e as Error).message;
-      }
-      assert.strictEqual(
-        errorMsg.length > 0,
-        true,
-        "Expected Error to be thrown"
-      );
-    }
   });
 
   test("deleteFolderRecursive", function () {

--- a/extension/src/test/FileFunctions.test.ts
+++ b/extension/src/test/FileFunctions.test.ts
@@ -1,0 +1,77 @@
+import * as assert from "assert";
+import * as FileFunctions from "../FileFunctions";
+import * as path from "path";
+import * as fs from "fs";
+import * as Common from "../Common";
+
+const WORKFLOW = process.env.GITHUB_ACTION; // Only run in GitHub Workflow
+suite("FileFunctions Tests", function () {
+  test("zipFiles()", async function () {
+    if (!WORKFLOW) {
+      this.skip();
+    }
+    const testAppTranslationsPath = path.join(
+      __dirname,
+      "../../..",
+      "test-app/Xliff-test/Translations/"
+    );
+    const compressFiles: string[] = [
+      path.join(testAppTranslationsPath, "Al.da-dk.xlf"),
+      path.join(testAppTranslationsPath, "Al.g.xlf"),
+      path.join(testAppTranslationsPath, "Al.sv-se.xlf"),
+    ];
+    const expectedFiles = [
+      {
+        name: "Al.da-dk.zip",
+      },
+      {
+        name: "Al.g.zip",
+      },
+      {
+        name: "Al.sv-se.zip",
+      },
+    ];
+    const exportPath = path.join(__dirname, "temp/dts");
+
+    await FileFunctions.zipFiles(compressFiles, exportPath);
+    const zipFiles = fs.readdirSync(exportPath, { withFileTypes: true });
+    assert.strictEqual(zipFiles.length, 3, "Unexpected number of zip-files");
+
+    zipFiles.forEach((z) => {
+      assert.ok(
+        expectedFiles.find((zip) => zip.name === z.name),
+        `New file exported ${z.name}. Is this correct?`
+      );
+    });
+  });
+
+  test("createFolderIfNotExist()", function () {
+    const parentPath = path.resolve(__dirname, "common-test");
+    const newPath = path.resolve(parentPath, "new/path/", Common.formatDate());
+    const invalidPathChars = `/?<>\\:*|."`;
+    assert.strictEqual(
+      fs.existsSync(newPath),
+      false,
+      "Test folder should not exist. This could be an indication that the 'deleteFolderRecursive' test is not working."
+    );
+    FileFunctions.createFolderIfNotExist(newPath);
+    assert.ok(fs.existsSync(newPath), "Could not find created folder.");
+
+    // Test error code path
+    if (process.platform === "win32") {
+      // Linux: pretty much allows any character in a path.
+      // MacOS: We're currently not running test on MacOS.
+      let errorMsg = "";
+      try {
+        FileFunctions.createFolderIfNotExist(newPath + invalidPathChars);
+      } catch (e) {
+        errorMsg = (e as Error).message;
+      }
+      assert.strictEqual(
+        errorMsg.length > 0,
+        true,
+        "Expected Error to be thrown"
+      );
+    }
+  });
+});

--- a/extension/src/test/FileFunctions.test.ts
+++ b/extension/src/test/FileFunctions.test.ts
@@ -6,6 +6,9 @@ import * as Common from "../Common";
 
 const WORKFLOW = process.env.GITHUB_ACTION; // Only run in GitHub Workflow
 suite("FileFunctions Tests", function () {
+  const parentPath = path.resolve(__dirname, "filefunctions-test");
+  const newPath = path.resolve(parentPath, "new/path/", Common.formatDate());
+
   test("zipFiles()", async function () {
     if (!WORKFLOW) {
       this.skip();
@@ -46,8 +49,6 @@ suite("FileFunctions Tests", function () {
   });
 
   test("createFolderIfNotExist()", function () {
-    const parentPath = path.resolve(__dirname, "common-test");
-    const newPath = path.resolve(parentPath, "new/path/", Common.formatDate());
     const invalidPathChars = `/?<>\\:*|."`;
     assert.strictEqual(
       fs.existsSync(newPath),
@@ -73,5 +74,19 @@ suite("FileFunctions Tests", function () {
         "Expected Error to be thrown"
       );
     }
+  });
+
+  test("deleteFolderRecursive", function () {
+    FileFunctions.deleteFolderRecursive(parentPath);
+    assert.strictEqual(
+      fs.existsSync(newPath),
+      false,
+      "Child path should be deleted"
+    );
+    assert.strictEqual(
+      fs.existsSync(parentPath),
+      false,
+      "Parent path should be deleted."
+    );
   });
 });

--- a/extension/src/test/FileFunctions.test.ts
+++ b/extension/src/test/FileFunctions.test.ts
@@ -9,7 +9,7 @@ suite("FileFunctions Tests", function () {
   const parentPath = path.resolve(__dirname, "filefunctions-test");
   const newPath = path.resolve(parentPath, "new/path/", Common.formatDate());
 
-  test("zipFiles()", async function () {
+  test("zipFiles()", function () {
     if (!WORKFLOW) {
       this.skip();
     }
@@ -36,7 +36,7 @@ suite("FileFunctions Tests", function () {
     ];
     const exportPath = path.join(__dirname, "temp/dts");
 
-    await FileFunctions.zipFiles(compressFiles, exportPath);
+    FileFunctions.zipFiles(compressFiles, exportPath);
     const zipFiles = fs.readdirSync(exportPath, { withFileTypes: true });
     assert.strictEqual(zipFiles.length, 3, "Unexpected number of zip-files");
 

--- a/extension/src/test/LanguageFunctions.test.ts
+++ b/extension/src/test/LanguageFunctions.test.ts
@@ -45,8 +45,6 @@ testFiles.forEach((f) => {
   langFilesUri.push(toPath);
 });
 
-const WORKFLOW = process.env.GITHUB_ACTION; // Only run in GitHub Workflow
-
 suite("DTS Import Tests", function () {
   const sourceXliff = Xliff.fromString(`<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
@@ -1250,37 +1248,6 @@ suite("Language Functions Tests", function () {
       expected.length,
       "Unexpected length."
     );
-  });
-
-  test("zipXlfFiles()", async function () {
-    if (!WORKFLOW) {
-      this.skip();
-    }
-    const dtsWorkFolderPath = path.join(__dirname, "temp/dts");
-    await LanguageFunctions.zipXlfFiles(
-      settings,
-      appManifest,
-      dtsWorkFolderPath
-    );
-    const zipFiles = fs.readdirSync(dtsWorkFolderPath, { withFileTypes: true });
-    assert.strictEqual(zipFiles.length, 3, "Unexpected number of zip-files");
-    const expectedFiles = [
-      {
-        name: "Al.da-dk.zip",
-      },
-      {
-        name: "Al.g.zip",
-      },
-      {
-        name: "Al.sv-se.zip",
-      },
-    ];
-    zipFiles.forEach((z) => {
-      assert.ok(
-        expectedFiles.find((zip) => zip.name === z.name),
-        `New file exported ${z.name}. Is this correct?`
-      );
-    });
   });
 
   test("allUntranslatedSearchParameters()", function () {


### PR DESCRIPTION
<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Passing settings and app manifest to `zipXlfFiles` just to get the xlf files seemed superfluous so I made it more generic.

Changes proposed in this pull request:

- `zipXlfFiles` is now refactored be the more generic `zipFiles`. 
- `mkDirByPathSync`, `deleteFolderRecursive` and `createFolderIfNotExist` moved from `Common.ts` to `FileFunctions.ts`
