### PR TITLE
refactor: move xliff constants

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -111,12 +111,6 @@
                 "@types/node": "*"
             }
         },
-        "@types/escape-string-regexp": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@types/escape-string-regexp/-/escape-string-regexp-1.0.0.tgz",
-            "integrity": "sha512-KAruqgk9/340M4MYYasdBET+lyYN8KMXUuRKWO72f4SbmIMMFp9nnJiXUkJS0HC2SFe4x0R/fLozXIzqoUfSjA==",
-            "dev": true
-        },
         "@types/eslint": {
             "version": "7.2.10",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.10.tgz",

--- a/extension/package.json
+++ b/extension/package.json
@@ -591,7 +591,6 @@
         "@xmldom/xmldom": "^0.7.5",
         "adm-zip": "^0.5.5",
         "compare-versions": "^3.6.0",
-        "escape-string-regexp": "^1.0.5",
         "format-duration": "^1.3.1",
         "javascript": "^1.0.0",
         "lodash": "^4.17.21",
@@ -605,7 +604,6 @@
     },
     "devDependencies": {
         "@types/adm-zip": "^0.4.34",
-        "@types/escape-string-regexp": "^1.0.0",
         "@types/format-duration": "^1.0.1",
         "@types/glob": "^7.1.3",
         "@types/lodash": "^4.14.168",

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -3,7 +3,6 @@ import * as vscode from "vscode";
 import * as fs from "fs";
 import * as path from "path";
 import * as WorkspaceFunctions from "./WorkspaceFunctions";
-import * as escapeStringRegexp from "escape-string-regexp";
 import {
   CustomNoteType,
   TargetState,
@@ -12,7 +11,7 @@ import {
   TransUnit,
   Xliff,
 } from "./Xliff/XLIFFDocument";
-import { createFolderIfNotExist } from "./Common";
+import { createFolderIfNotExist, escapeRegex } from "./Common";
 import { AppManifest, Settings } from "./Settings/Settings";
 import { TranslationMode, TransUnitElementType } from "./Enums";
 import { LanguageFunctionsSettings } from "./Settings/LanguageFunctionsSettings";
@@ -220,7 +219,7 @@ export function allUntranslatedSearchParameters(
     searchStrings: languageFunctionsSettings.useExternalTranslationTool
       ? targetStateActionNeededAttributes()
       : Object.values(TranslationToken).map((t) => {
-          return escapeStringRegexp(t);
+          return escapeRegex(t);
         }),
     fileFilter: languageFunctionsSettings.searchOnlyXlfFiles ? "*.xlf" : "",
   };

--- a/extension/src/XlfHighlighter.ts
+++ b/extension/src/XlfHighlighter.ts
@@ -2,8 +2,8 @@ import * as vscode from "vscode";
 import {
   translationTokenSearchExpression,
   refreshXlfNoteSearchExpression,
-} from "./constants";
-import { invalidXmlSearchExpression } from "./Xliff/XLIFFDocument";
+  invalidXmlSearchExpression,
+} from "./Xliff/XLIFFDocument";
 import { Settings } from "./Settings/Settings";
 let xlfHighlightsDecoration;
 let decorationType: vscode.TextEditorDecorationType;

--- a/extension/src/Xliff/XLIFFDocument.ts
+++ b/extension/src/Xliff/XLIFFDocument.ts
@@ -1044,3 +1044,19 @@ export function targetStateActionNeededAttributes(
     return `state="${state}"`;
   });
 }
+
+// RegEx strings:
+// All translation tokens
+
+export const translationTokenSearchExpression = `${Common.escapeRegex(
+  TranslationToken.notTranslated
+)}|${Common.escapeRegex(TranslationToken.review)}|${Common.escapeRegex(
+  TranslationToken.suggestion
+)}|${Common.escapeRegex("[NAB:")}|state="(${TargetState.needsAdaptation}|${
+  TargetState.needsL10n
+}|${TargetState.needsReviewAdaptation}|${TargetState.needsReviewL10n}|${
+  TargetState.needsReviewTranslation
+}|${TargetState.needsTranslation}|${TargetState.new})"`;
+
+// <note from="NAB AL Tool Refresh Xlf" annotates="general" priority="3">Source has been modified.</note>
+export const refreshXlfNoteSearchExpression = `<note from="${CustomNoteType.refreshXlfHint}" annotates="general" priority="3">(?<note>.*)<`;

--- a/extension/src/constants.ts
+++ b/extension/src/constants.ts
@@ -1,26 +1,3 @@
-import * as Common from "./Common";
-import {
-  TargetState,
-  TranslationToken,
-  CustomNoteType,
-} from "./Xliff/XLIFFDocument";
-
-// RegEx strings:
-// All translation tokens
-
-export const translationTokenSearchExpression = `${Common.escapeRegex(
-  TranslationToken.notTranslated
-)}|${Common.escapeRegex(TranslationToken.review)}|${Common.escapeRegex(
-  TranslationToken.suggestion
-)}|${Common.escapeRegex("[NAB:")}|state="(${TargetState.needsAdaptation}|${
-  TargetState.needsL10n
-}|${TargetState.needsReviewAdaptation}|${TargetState.needsReviewL10n}|${
-  TargetState.needsReviewTranslation
-}|${TargetState.needsTranslation}|${TargetState.new})"`;
-
-// <note from="NAB AL Tool Refresh Xlf" annotates="general" priority="3">Source has been modified.</note>
-export const refreshXlfNoteSearchExpression = `<note from="${CustomNoteType.refreshXlfHint}" annotates="general" priority="3">(?<note>.*)<`;
-
 // from .vscode\extensions\ms-dynamics-smb.al-6.5.413786\al.configuration.json
 export const wordPattern =
   '("(?:(?:\\"\\")|[^\\"])*")|(-?\\d*\\.\\d\\w*)|([^\\`\\~\\!\\@\\#\\%\\^\\&\\*\\(\\)\\-\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\\'\\"\\,\\.\\<\\>\\/\\?\\s]+)';

--- a/extension/src/test/XlfHighlighter.test.ts
+++ b/extension/src/test/XlfHighlighter.test.ts
@@ -3,11 +3,13 @@ import * as path from "path";
 import * as XlfHighlighter from "../XlfHighlighter";
 import * as assert from "assert";
 import { LanguageFunctionsSettings } from "../Settings/LanguageFunctionsSettings";
-import { translationTokenSearchExpression } from "../constants";
 import * as SettingsLoader from "../Settings/SettingsLoader";
 import { TranslationMode } from "../Enums";
 import * as XliffFunctions from "../XliffFunctions";
-import { invalidXmlSearchExpression } from "../Xliff/XLIFFDocument";
+import {
+  translationTokenSearchExpression,
+  invalidXmlSearchExpression,
+} from "../Xliff/XLIFFDocument";
 
 const testResourcesPath = "../../src/test/resources/highlights/";
 const translationTokenXlfUri: vscode.Uri = vscode.Uri.file(

--- a/extension/src/test/XlfHighlighter.test.ts
+++ b/extension/src/test/XlfHighlighter.test.ts
@@ -30,9 +30,9 @@ suite("Xlf Highlighter", function () {
       translationTokenSearchExpression,
       ranges
     );
-    assert.equal(ranges.length, 6, "unexpected number of ranges");
-    assert.equal(ranges[5].start.line, 49, "unexpected start line no.");
-    assert.equal(ranges[5].end.character, 23, "unexpected end char no.");
+    assert.strictEqual(ranges.length, 6, "unexpected number of ranges");
+    assert.strictEqual(ranges[5].start.line, 49, "unexpected start line no.");
+    assert.strictEqual(ranges[5].end.character, 23, "unexpected end char no.");
   });
 
   test("Ranges Invalid Xml", async function () {
@@ -45,9 +45,9 @@ suite("Xlf Highlighter", function () {
       invalidXmlSearchExpression,
       ranges
     );
-    assert.equal(ranges.length, 4, "unexpected number of ranges");
-    assert.equal(ranges[0].start.line, 9, "unexpected start line no.");
-    assert.equal(ranges[0].end.character, 41, "unexpected end char no.");
+    assert.strictEqual(ranges.length, 4, "unexpected number of ranges");
+    assert.strictEqual(ranges[0].start.line, 9, "unexpected start line no.");
+    assert.strictEqual(ranges[0].end.character, 41, "unexpected end char no.");
   });
 
   test("Refresh with Invalid Xml", async function () {


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->


<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- Remove and uninstall dependency on `escape-string-regexp`. It was only used in one occurence.
  - There is a slight difference in how [escape-string-regexp](https://github.com/sindresorhus/escape-string-regexp/blob/main/index.js) works and our own `Common.escapeRegexp` works. If it's of critical importance we should implement the same.
- RegEx constant `translationTokenSearchExpression` moved from `Common` to `XliffDocument` this leaves Common without imports from internal libraries :+1: 
