### PR TITLE
Hover for translations

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -568,6 +568,12 @@
                     "default": false,
                     "description": "Specifies if \"NAB: Refresh XLF files from g.xlf\" should run after no more trans-units in need of action is found.",
                     "scope": "resource"
+                },
+                "NAB.EnableTranslationsOnHover": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Specifies if the translations for any multi language enabled text should be shown when hovering over the line of AL code",
+                    "scope": "resource"
                 }
             }
         }

--- a/extension/src/ALObject/ALParser.ts
+++ b/extension/src/ALObject/ALParser.ts
@@ -654,7 +654,7 @@ function loadObjectDescriptor(
     case ALObjectType.xmlPort:
     case ALObjectType.enum: {
       const regexString = `(?<objectType>\\w+) +(?<objectId>[0-9]+) +(?<objectName>${wordPattern})(?<implements>(\\s+implements\\s+(${wordPattern}))(?<implementsMore>\\s*,\\s*(${wordPattern}))*)?(?<comment>\\s*\\/\\/.*)?$`;
-      const objectDescriptorPattern = new RegExp(regexString);
+      const objectDescriptorPattern = new RegExp(regexString, "i");
       const currObject = objectDescriptorCode.match(objectDescriptorPattern);
       if (currObject === null || currObject.groups === undefined) {
         throw new Error(
@@ -670,7 +670,8 @@ function loadObjectDescriptor(
     case ALObjectType.tableExtension:
     case ALObjectType.enumExtension: {
       const objectDescriptorPattern = new RegExp(
-        `(?<objectType>\\w+) +(?<objectId>[0-9]+) +(?<objectName>${wordPattern})\\s+extends\\s+((?<extendedObjectName>${wordPattern}))\\s*(\\/\\/\\s*)?(?<extendedObjectId>[0-9]+)?(\\s*\\((?<extendedTableId>[0-9]+)?\\))?`
+        `(?<objectType>\\w+) +(?<objectId>[0-9]+) +(?<objectName>${wordPattern})\\s+extends\\s+((?<extendedObjectName>${wordPattern}))\\s*(\\/\\/\\s*)?(?<extendedObjectId>[0-9]+)?(\\s*\\((?<extendedTableId>[0-9]+)?\\))?`,
+        "i"
       );
       const currObject = objectDescriptorCode.match(objectDescriptorPattern);
       if (currObject === null) {
@@ -721,7 +722,8 @@ function loadObjectDescriptor(
     }
     case ALObjectType.pageCustomization: {
       const objectDescriptorPattern = new RegExp(
-        `(?<objectType>\\w+)( +(?<objectName>${wordPattern})) +customizes( +"?[ a-zA-Z0-9._&-]+\\/?[ a-zA-Z0-9._&-]+"?) (\\/\\/+ *)?([0-9]+)?`
+        `(?<objectType>\\w+)( +(?<objectName>${wordPattern})) +customizes( +"?[ a-zA-Z0-9._&-]+\\/?[ a-zA-Z0-9._&-]+"?) (\\/\\/+ *)?([0-9]+)?`,
+        "i"
       );
       const currObject = objectDescriptorCode.match(objectDescriptorPattern);
       if (currObject === null) {

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -424,10 +424,10 @@ export function getTransUnitID(
   return { lineNo: activeLineNo - count + 1, id: result[1] };
 }
 
-export async function revealTransUnitTarget(
+export function revealTransUnitTarget(
   transUnitId: string,
   langFilePath: string
-): Promise<TextDocumentMatch | undefined> {
+): TextDocumentMatch | undefined {
   if (!vscode.window.activeTextEditor) {
     return;
   }

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -1128,7 +1128,8 @@ export function getHoverText(
   document: vscode.TextDocument,
   position: vscode.Position
 ): vscode.MarkdownString[] {
-  if (!SettingsLoader.getSettings().enableTranslationsOnHover) {
+  const settings = SettingsLoader.getSettings();
+  if (!settings.enableTranslationsOnHover) {
     return [];
   }
 
@@ -1152,7 +1153,7 @@ export function getHoverText(
   const transUnitId = selectedMlObject[0].xliffId();
 
   const langFilePaths = WorkspaceFunctions.getLangXlfFiles(
-    SettingsLoader.getSettings(),
+    settings,
     SettingsLoader.getAppManifest()
   );
 

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -1154,7 +1154,7 @@ export function getHoverText(
     const transUnit = xliffDoc.getTransUnitById(transUnitId);
     if (transUnit) {
       translations.push(
-        `${xliffDoc.targetLanguage}: ${transUnit.target.textContent}\n`
+        `|${xliffDoc.targetLanguage} | ${transUnit.target.textContent}|`
       );
     }
   }
@@ -1163,8 +1163,10 @@ export function getHoverText(
   if (translations.length === 0) {
     markdownString.appendMarkdown("_No translations found_\n");
   } else {
+    markdownString.appendMarkdown("| Language | Translation |\n");
+    markdownString.appendMarkdown("| :---- | :---- |\n");
     for (const translation of translations) {
-      markdownString.appendText(`${translation}\n`);
+      markdownString.appendMarkdown(`${translation}\n`);
     }
   }
   returnValues.push(markdownString);

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -1154,32 +1154,33 @@ export function getHoverText(
     SettingsLoader.getSettings(),
     SettingsLoader.getAppManifest()
   );
-  const translations: string[] = [];
 
+  const markdownString = new vscode.MarkdownString();
   for (const langFilePath of langFilePaths) {
     const xliffDoc = XliffCache.getXliffDocumentFromCache(langFilePath);
     const transUnit = xliffDoc.getTransUnitById(transUnitId);
     if (transUnit) {
+      if (markdownString.value.length === 0) {
+        markdownString.appendMarkdown(
+          "| Language&nbsp;&nbsp; | Translation |\n"
+        );
+        markdownString.appendMarkdown("| :---- | :---- |\n");
+      }
       const paramsObj: IOpenXliffIdParam = {
         languageCode: xliffDoc.targetLanguage,
         transUnitId: transUnitId,
       };
       const params = encodeURIComponent(JSON.stringify(paramsObj));
-      translations.push(
-        `| [${xliffDoc.targetLanguage}](command:nab.openXliffId?${params} "Navigate to translation") | ${transUnit.target.textContent} |`
+      markdownString.appendMarkdown(
+        `| [${xliffDoc.targetLanguage}](command:nab.openXliffId?${params} "Navigate to translation") | `
       );
+      markdownString.appendText(transUnit.target.textContent); // as Text since it needs to be escaped
+      markdownString.appendMarkdown(" |");
     }
   }
-  const markdownString = new vscode.MarkdownString();
 
-  if (translations.length === 0) {
+  if (markdownString.value.length === 0) {
     markdownString.appendMarkdown("_No translations found_\n");
-  } else {
-    markdownString.appendMarkdown("| Language | Translation |\n");
-    markdownString.appendMarkdown("| :---- | :---- |\n");
-    for (const translation of translations) {
-      markdownString.appendMarkdown(`${translation}\n`);
-    }
   }
   markdownString.isTrusted = true;
   returnValues.push(markdownString);

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -12,6 +12,7 @@ import * as PowerShellFunctions from "./PowerShellFunctions";
 import * as DocumentFunctions from "./DocumentFunctions";
 import * as FileFunctions from "./FileFunctions";
 import * as XliffCache from "./Xliff/XliffCache";
+import { IOpenXliffIdParam } from "./Types";
 import { TargetState, Xliff } from "./Xliff/XLIFFDocument";
 import { baseAppTranslationFiles } from "./externalresources/BaseAppTranslationFiles";
 import { XliffEditorPanel } from "./XliffEditor/XliffEditorPanel";
@@ -1212,10 +1213,6 @@ export function openXliffId(params: IOpenXliffIdParam): void {
   }
 }
 
-interface IOpenXliffIdParam {
-  transUnitId: string;
-  languageCode: string;
-}
 export function onDidChangeTextDocument(
   event: vscode.TextDocumentChangeEvent
 ): void {

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -1126,8 +1126,11 @@ export function getHoverText(
   document: vscode.TextDocument,
   position: vscode.Position
 ): vscode.MarkdownString[] {
-  const returnValues = [];
+  if (!SettingsLoader.getSettings().enableTranslationsOnHover) {
+    return [];
+  }
 
+  const returnValues = [];
   const selectedLineNo = position.line;
 
   const navObj = ALParser.getALObjectFromText(document.getText(), true);

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -1189,17 +1189,17 @@ export function getHoverText(
 }
 
 export function openXliffId(params: IOpenXliffIdParam): void {
-  const langFiles = WorkspaceFunctions.getLangXlfFiles(
+  const langFilePaths = WorkspaceFunctions.getLangXlfFiles(
     SettingsLoader.getSettings(),
     SettingsLoader.getAppManifest()
   );
 
-  for (const langFile of langFiles) {
-    const langXliff = Xliff.fromFileSync(langFile);
+  for (const langFilePath of langFilePaths) {
+    const langXliff = XliffCache.getXliffDocumentFromCache(langFilePath);
     if (langXliff.targetLanguage === params.languageCode) {
       const foundTarget = LanguageFunctions.revealTransUnitTarget(
         params.transUnitId,
-        langFile
+        langFilePath
       );
       if (foundTarget) {
         DocumentFunctions.openTextFileWithSelection(

--- a/extension/src/Settings/Settings.ts
+++ b/extension/src/Settings/Settings.ts
@@ -55,6 +55,7 @@ export class Settings {
   public xliffCSVImportTargetState = "translated";
   public loadSymbols = true;
   public refreshXlfAfterFindNextUntranslated = false;
+  public enableTranslationsOnHover = true;
   public useDictionaryInDTSImport = true;
 
   constructor(workspaceFolderPath: string) {

--- a/extension/src/Settings/SettingsMap.ts
+++ b/extension/src/Settings/SettingsMap.ts
@@ -50,4 +50,5 @@ export const settingsMap = new Map<string, keyof Settings>([
     "NAB.RefreshXlfAfterFindNextUntranslated",
     "refreshXlfAfterFindNextUntranslated",
   ],
+  ["NAB.EnableTranslationsOnHover", "enableTranslationsOnHover"],
 ]);

--- a/extension/src/Types.ts
+++ b/extension/src/Types.ts
@@ -3,3 +3,8 @@ export type TextDocumentMatch = {
   position: number;
   length: number;
 };
+
+export interface IOpenXliffIdParam {
+  transUnitId: string;
+  languageCode: string;
+}

--- a/extension/src/Xliff/XliffCache.ts
+++ b/extension/src/Xliff/XliffCache.ts
@@ -1,0 +1,30 @@
+import { Xliff } from "./XLIFFDocument";
+import * as path from "path";
+
+const cachedXliffDocuments: Map<string, Xliff> = new Map();
+
+export function getXliffDocumentFromCache(filePath: string): Xliff {
+  const fileName = path.basename(filePath);
+  if (!xliffDocumentInCache(fileName)) {
+    const newXliffDocument = Xliff.fromFileSync(filePath);
+    cachedXliffDocuments.set(fileName, newXliffDocument);
+    return newXliffDocument;
+  }
+  const xliffDocument = cachedXliffDocuments.get(fileName);
+  if (xliffDocument) {
+    return xliffDocument;
+  }
+  throw new Error(`${fileName} not found.`);
+}
+export function updateXliffDocumentInCache(
+  filePath: string,
+  content: string
+): void {
+  const fileName = path.basename(filePath);
+  const newXliffDocument = Xliff.fromString(content);
+  cachedXliffDocuments.set(fileName, newXliffDocument);
+}
+
+function xliffDocumentInCache(fileName: string): boolean {
+  return cachedXliffDocuments.has(fileName);
+}

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -186,6 +186,9 @@ export function activate(context: vscode.ExtensionContext): void {
         },
       }
     ),
+    vscode.commands.registerCommand("nab.openXliffId", (params) => {
+      NABfunctions.openXliffId(params);
+    }),
   ];
 
   context.subscriptions.concat(commandlist);

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -176,6 +176,16 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.window.onDidChangeActiveTextEditor((editor) =>
       xlfHighlighter.onDidChangeActiveTextEditor(editor)
     ),
+    vscode.languages.registerHoverProvider(
+      { scheme: "file", language: "al" },
+      {
+        provideHover(document, position) {
+          return {
+            contents: NABfunctions.getHoverText(document, position),
+          };
+        },
+      }
+    ),
   ];
 
   context.subscriptions.concat(commandlist);

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -170,9 +170,10 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.debug.onDidTerminateDebugSession((debugSession) =>
       DebugTests.handleTerminateDebugSession(debugSession)
     ),
-    vscode.workspace.onDidChangeTextDocument((event) =>
-      xlfHighlighter.onDidChangeTextDocument(event)
-    ),
+    vscode.workspace.onDidChangeTextDocument((event) => {
+      xlfHighlighter.onDidChangeTextDocument(event);
+      NABfunctions.onDidChangeTextDocument(event);
+    }),
     vscode.window.onDidChangeActiveTextEditor((editor) =>
       xlfHighlighter.onDidChangeActiveTextEditor(editor)
     ),

--- a/extension/src/test/ALObjectTestLibrary.ts
+++ b/extension/src/test/ALObjectTestLibrary.ts
@@ -125,6 +125,11 @@ export function getValidObjectDescriptors(): {
   return [
     {
       objectDescriptor:
+        'codeunit 70314129 "QWESR IQCM S/Ftp Handler" Implements "QWESR IQCM"',
+      objectName: "QWESR IQCM S/Ftp Handler",
+    },
+    {
+      objectDescriptor:
         'codeunit 70314129 "QWESR IQCM S/Ftp Handler" implements "QWESR IQCM", "QWESR IQCM Import", "QWESR IQCM Export"',
       objectName: "QWESR IQCM S/Ftp Handler",
     },


### PR DESCRIPTION
Fixes #231.

Changes proposed in this pull request:

- Show translations on hover, with link to the translation unit in the xlf file
- A setting to disable this feature, it can be slow with BIG XLF files, EnableTranslationsOnHover
- Caching of XLF files. Enabled by above setting. 
- Fixed a few regex matching that were case sensitive, it couldn't parse the base-app..

Additional comments
The caching might be useful for other XLIFF functions as well...

Tests are still missing, but don't know if we need to do them until we polished the hover texts a bit more... 