### PR TITLE
Add schema for dictionary

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -51,7 +51,8 @@
     ],
     "main": "./dist/extension.js",
     "files": [
-        "./frontend/**"
+        "./frontend/**",
+        "./syntaxes/**"
     ],
     "contributes": {
         "menus": {
@@ -582,7 +583,13 @@
                     "scope": "resource"
                 }
             }
-        }
+        },
+        "jsonValidation": [
+            {
+                "fileMatch": "*.dts.json",
+                "url": "./syntaxes/dtsDictionarySyntax.json"
+            }
+        ]
     },
     "extensionDependencies": [],
     "scripts": {

--- a/extension/syntaxes/dtsDictionarySyntax.json
+++ b/extension/syntaxes/dtsDictionarySyntax.json
@@ -1,0 +1,97 @@
+{
+    "$id": "NAB AL Tools DTS Dictionary Syntax",
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "description": "Schema for a dts dictionary.",
+    "type": "object",
+    "required": [
+        "language",
+        "wordList"
+    ],
+    "properties": {
+        "language": {
+            "description": "Specifies which langugage the dictionary will be used for.",
+            "type": "string",
+            "minLength": 5,
+            "enum": [
+                "cs-cz",
+                "da-dk",
+                "de-at",
+                "de-ch",
+                "de-de",
+                "en-au",
+                "en-ca",
+                "en-gb",
+                "en-nz",
+                "en-us",
+                "es-es_tradnl",
+                "es-mx",
+                "fi-fi",
+                "fr-be",
+                "fr-ca",
+                "fr-ch",
+                "fr-fr",
+                "is-is",
+                "it-ch",
+                "it-it",
+                "nb-no",
+                "nl-be",
+                "nl-nl",
+                "ru-ru",
+                "sv-se"
+            ]
+        },
+        "wordList": {
+            "description": "List of words and replacement values.",
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/wordListItem"
+            }
+        }
+    },
+    "definitions": {
+        "wordListItem": {
+            "description": "Word list item.",
+            "type": "object",
+            "uniqueItems": true,
+            "required": [
+                "word",
+                "replacement"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "word": {
+                    "description": "Word to search for.",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "replacement": {
+                    "description": "Replacement value.",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "settings": {
+                    "description": "Search & replace settings.",
+                    "type": "object",
+                    "properties": {
+                        "matchWholeWord": {
+                            "type": "boolean",
+                            "description": "Word boundary search."
+                        },
+                        "matchCasing": {
+                            "type": "boolean",
+                            "description": "Determines if search is performed case sensitive."
+                        },
+                        "useRegex": {
+                            "type": "boolean",
+                            "description": "Determines if words containing regex characters should be escaped."
+                        },
+                        "keepCasingOnFirstCharacter": {
+                            "type": "boolean",
+                            "description": "Keep casing on first character when replacing words."
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/extension/syntaxes/dtsDictionarySyntax.json
+++ b/extension/syntaxes/dtsDictionarySyntax.json
@@ -9,36 +9,9 @@
     ],
     "properties": {
         "language": {
-            "description": "Specifies which langugage the dictionary will be used for.",
+            "description": "Specifies which langugage the dictionary will be used for. Should match the value of `target-language` in the xlf.",
             "type": "string",
-            "minLength": 5,
-            "enum": [
-                "cs-cz",
-                "da-dk",
-                "de-at",
-                "de-ch",
-                "de-de",
-                "en-au",
-                "en-ca",
-                "en-gb",
-                "en-nz",
-                "en-us",
-                "es-es_tradnl",
-                "es-mx",
-                "fi-fi",
-                "fr-be",
-                "fr-ca",
-                "fr-ch",
-                "fr-fr",
-                "is-is",
-                "it-ch",
-                "it-it",
-                "nb-no",
-                "nl-be",
-                "nl-nl",
-                "ru-ru",
-                "sv-se"
-            ]
+            "minLength": 5
         },
         "wordList": {
             "description": "List of words and replacement values.",


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
Fixes #237  .

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- Adds schema for DTS dictionary.

Additional comments
Went with the enum for language code, it's either that or regex. Enum felt more helpful to the user and could give us a heads up if we're missing a base app translation map.