### PR TITLE
feat: Convert Xml PermissionSet to PermissionSet objects

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -7,6 +7,22 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 -->
 
+## [1.12] - 2022-01
+
+- New features:
+  - `NAB: Convert to PermissionSet object` converts a PermissionSet defined in XML into a PermissionSet object.
+    - The user is prompted to supply a prefix that will be used for the object names. The default value is fetched from the first `mandatoryAffixes` in the AppSourceCop.json, if available.
+    - The prefix is added to the old RoleID as a suggested Name for the new PermissionSet object.
+    - The old RoleName is added as a suggested Caption for the new PermissionSet object.
+    - The Name and Caption is editable before conversion starts.
+    - Some validation tests are being done on the provided names and captions.
+      - Max length
+      - Non-empty
+      - Some illegal characters
+      - etc.
+    - After the PermissionSet objects has been created, the old Xml PermissionSet files are deleted.
+    - An upgrade codeunit is created that maps the usage of the old Xml PermissionSet to the new PermissionSet object.
+
 ## [1.10] - 2021-12-20
 
 - New features:

--- a/extension/README.md
+++ b/extension/README.md
@@ -38,6 +38,7 @@ NAB AL Tools supports the pre-release functionality in VSCode v1.63 and later (r
   * [NAB: Export Translations to .csv](#nab-export-translations-to-csv)
   * [NAB: Export Translations to .csv (Select columns and filter)](#nab-export-translations-to-csv-select-columns-and-filter)
   * [NAB: Import Translations from .csv](#nab-import-translations-from-csv)
+  * [NAB: Convert to PermissionSet object](#nab-convert-to-permissionset-object)
 * [Snippets](#snippets)
 
 [Requirements](#requirements)
@@ -509,6 +510,22 @@ If the the app is configured to use an external translation tool (i.e. working w
 2. Select which XLF file to update.
 3. Select .csv file to import.
 4. File is imported, any changed target values are updated and the number of updated translation units is shown in an information box.
+
+### NAB: Convert to PermissionSet object
+
+Converts a PermissionSet defined in XML into a PermissionSet object.
+
+* The user is prompted to supply a prefix that will be used for the object names. The default value is fetched from the first `mandatoryAffixes` in the AppSourceCop.json, if available.
+* The prefix is added to the old RoleID as a suggested Name for the new PermissionSet object.
+* The old RoleName is added as a suggested Caption for the new PermissionSet object.
+* The Name and Caption is editable before conversion starts.
+* Some validation tests are being done on the provided names and captions.
+  * Max length
+  * Non-empty
+  * Some illegal characters
+  * etc.
+* After the PermissionSet objects has been created, the old Xml PermissionSet files are deleted.
+* An upgrade codeunit is created that maps the usage of the old Xml PermissionSet to the new PermissionSet object.
 
 ### Snippets
 

--- a/extension/frontend/PermissionSetNameEditor/main.css
+++ b/extension/frontend/PermissionSetNameEditor/main.css
@@ -1,0 +1,36 @@
+.color-list {
+    list-style: none;
+    padding: 0;
+}
+
+.color-entry {
+    width: 100%;
+    display: flex;
+    margin-bottom: 0.4em;
+    border: 1px solid var(--vscode-input-border);
+}
+
+.color-preview {
+    width: 2em;
+    height: 2em;
+}
+
+.color-preview:hover {
+    outline: inset white;
+}
+
+.color-input {
+    display: block;
+    flex: 1;
+    width: 100%;
+    color: var(--vscode-input-foreground);
+    background-color: var(--vscode-input-background);
+    border: none;
+    padding: 0 0.6em;
+}
+
+.add-color-button {
+    display: block;
+    border: none;
+    margin: 0 auto;
+}

--- a/extension/frontend/PermissionSetNameEditor/main.js
+++ b/extension/frontend/PermissionSetNameEditor/main.js
@@ -1,0 +1,157 @@
+/**
+ * This script will be run within the webview itself
+ * It cannot access the main VS Code APIs directly.
+ */
+(function () {
+    const vscode = acquireVsCodeApi();
+    const validKeys = {
+        arrowDown: "ArrowDown",
+        arrowUp: "ArrowUp",
+        f8: "F8",
+    };
+
+    function isNullOrUndefined(value) {
+        return value === null || value === undefined;
+    }
+
+    window.onload = function () {
+        const oldState = vscode.getState();
+        if (oldState !== undefined) {
+            let pos = document.getElementById(oldState.position);
+            if (pos !== undefined) {
+                pos.scrollIntoView({ inline: "center" });
+                window.scrollBy(0, -40);
+                pos.focus();
+            }
+        }
+    };
+
+    // Handle messages sent from the extension to the webview
+    window.addEventListener("message", (event) => {
+        const message = event.data; // The json data that the extension sent
+        switch (message.command) {
+            case "update": {
+                let suggestedTranslations = message.data;
+                suggestedTranslations.forEach((x) => {
+                    if (document.getElementById(x.id) !== undefined) {
+                        if (x.targetText) {
+                            document.getElementById(`${x.id}`).innerHTML =
+                                x.targetText;
+                        }
+                        document.getElementById(`${x.id}-notes`).innerHTML =
+                            x.noteText;
+                    }
+                });
+                break;
+            }
+            default:
+                break;
+        }
+    });
+
+    let inputs = document.getElementsByTagName("textarea");
+    for (let i = 0; i < inputs.length; i++) {
+        const textArea = inputs[i];
+        // Save changes to the new name
+        textArea.addEventListener(
+            "change",
+            (e) => {
+                vscode.postMessage({
+                    command: "update",
+                    text: `Updated PermissionSet Name: ${e.target.id}`,
+                    roleID: e.target.id,
+                    newName: e.target.value,
+                });
+            },
+            false
+        );
+        textArea.addEventListener(
+            "focus",
+            (e) => {
+                updateState({ position: e.target.id });
+            },
+            false
+        );
+    }
+
+    // Buttons
+    addButtonEventListener("btn-cancel", "click", () => {
+        vscode.postMessage({
+            command: "cancel",
+            text: "Cancel",
+        });
+    });
+    addButtonEventListener("btn-ok", "click", () => {
+        vscode.postMessage({
+            command: "ok",
+            text: "OK",
+        });
+    });
+
+    function addButtonEventListener(id, event, func) {
+        el = document.getElementById(id);
+        if (isNullOrUndefined(el)) {
+            //console.log("Could not get element", id); // debugging
+            return;
+        }
+        el.addEventListener(event, func);
+    }
+
+    document.addEventListener("keydown", (e) => {
+        if (Object.values(validKeys).indexOf(e.key) === -1) {
+            return;
+        }
+        if (isNullOrUndefined(e.target.closest("tr"))) {
+            return;
+        }
+        let currentRow = document.getElementById(e.target.closest("tr").id);
+        let previousRow = currentRow.previousElementSibling;
+        let nextRow = currentRow.nextElementSibling;
+        switch (e.key) {
+            case validKeys.arrowDown:
+                if (isNullOrUndefined(nextRow)) {
+                    return;
+                }
+                setFocus(
+                    nextRow
+                        .getElementsByClassName("target-cell")[0]
+                        .getElementsByTagName("textarea")[0]
+                );
+                break;
+            case validKeys.arrowUp:
+                if (isNullOrUndefined(previousRow)) {
+                    return;
+                }
+                setFocus(
+                    previousRow
+                        .getElementsByClassName("target-cell")[0]
+                        .getElementsByTagName("textarea")[0]
+                );
+                break;
+            case validKeys.f8: {
+                if (isNullOrUndefined(previousRow)) {
+                    return;
+                }
+                let copyValue = previousRow
+                    .getElementsByClassName("target-cell")[0]
+                    .getElementsByTagName("textarea")[0].value;
+                e.target.value = copyValue;
+                e.target.dispatchEvent(new Event("change"));
+                break;
+            }
+            default:
+                throw new Error(`Invalid key: ${e.key}`);
+        }
+    });
+
+    function setFocus(textArea) {
+        if (isNullOrUndefined(textArea)) {
+            return;
+        }
+        textArea.focus();
+    }
+
+    function updateState(state = { position: undefined }) {
+        vscode.setState(state);
+    }
+})();

--- a/extension/frontend/PermissionSetNameEditor/main.js
+++ b/extension/frontend/PermissionSetNameEditor/main.js
@@ -4,11 +4,6 @@
  */
 (function () {
     const vscode = acquireVsCodeApi();
-    const validKeys = {
-        arrowDown: "ArrowDown",
-        arrowUp: "ArrowUp",
-        f8: "F8",
-    };
 
     function isNullOrUndefined(value) {
         return value === null || value === undefined;
@@ -57,10 +52,12 @@
             "change",
             (e) => {
                 vscode.postMessage({
-                    command: "update",
-                    text: `Updated PermissionSet Name: ${e.target.id}`,
-                    roleID: e.target.id,
-                    newName: e.target.value,
+                    command: `update-${
+                        e.target.id.endsWith("-name") ? "name" : "caption"
+                    }`,
+                    text: `Updated PermissionSet, ${e.target.id}:${e.target.value}`,
+                    roleID: e.target.closest("tr").id,
+                    newValue: e.target.value,
                 });
             },
             false
@@ -91,64 +88,9 @@
     function addButtonEventListener(id, event, func) {
         el = document.getElementById(id);
         if (isNullOrUndefined(el)) {
-            //console.log("Could not get element", id); // debugging
             return;
         }
         el.addEventListener(event, func);
-    }
-
-    document.addEventListener("keydown", (e) => {
-        if (Object.values(validKeys).indexOf(e.key) === -1) {
-            return;
-        }
-        if (isNullOrUndefined(e.target.closest("tr"))) {
-            return;
-        }
-        let currentRow = document.getElementById(e.target.closest("tr").id);
-        let previousRow = currentRow.previousElementSibling;
-        let nextRow = currentRow.nextElementSibling;
-        switch (e.key) {
-            case validKeys.arrowDown:
-                if (isNullOrUndefined(nextRow)) {
-                    return;
-                }
-                setFocus(
-                    nextRow
-                        .getElementsByClassName("target-cell")[0]
-                        .getElementsByTagName("textarea")[0]
-                );
-                break;
-            case validKeys.arrowUp:
-                if (isNullOrUndefined(previousRow)) {
-                    return;
-                }
-                setFocus(
-                    previousRow
-                        .getElementsByClassName("target-cell")[0]
-                        .getElementsByTagName("textarea")[0]
-                );
-                break;
-            case validKeys.f8: {
-                if (isNullOrUndefined(previousRow)) {
-                    return;
-                }
-                let copyValue = previousRow
-                    .getElementsByClassName("target-cell")[0]
-                    .getElementsByTagName("textarea")[0].value;
-                e.target.value = copyValue;
-                e.target.dispatchEvent(new Event("change"));
-                break;
-            }
-            default:
-                throw new Error(`Invalid key: ${e.key}`);
-        }
-    });
-
-    function setFocus(textArea) {
-        if (isNullOrUndefined(textArea)) {
-            return;
-        }
-        textArea.focus();
     }
 
     function updateState(state = { position: undefined }) {

--- a/extension/frontend/PermissionSetNameEditor/reset.css
+++ b/extension/frontend/PermissionSetNameEditor/reset.css
@@ -48,15 +48,28 @@ table {
 table, td {
     position: relative;
 }
-
+thead {
+      text-align: left;
+}
 th {
     position: sticky;
     margin-top: 5px;
+    padding: 6px 4px;
     top: 30px;
     z-index: 99;
     box-shadow: 0 2px 2px -1px rgba(0, 0, 0, 0.4);
     background-color: var(--vscode-editor-inactiveSelectionBackground);
 }
+th.xmlpermissionset {
+    width: 25%;
+}
+th.new-name {
+    width: 25%;
+}
+th.new-caption {
+    width: 50%;
+}
+
 table td {
     vertical-align: middle;
 }

--- a/extension/frontend/PermissionSetNameEditor/reset.css
+++ b/extension/frontend/PermissionSetNameEditor/reset.css
@@ -41,8 +41,7 @@ textarea {
 
 table {
     width: 100%;
-    border-collapse: collapse;
-    /* table-layout: fixed; */
+    border-collapse: separate;
 }
 
 table, td {
@@ -52,7 +51,6 @@ thead {
       text-align: left;
 }
 th {
-    position: sticky;
     margin-top: 5px;
     padding: 6px 4px;
     top: 30px;
@@ -60,23 +58,28 @@ th {
     box-shadow: 0 2px 2px -1px rgba(0, 0, 0, 0.4);
     background-color: var(--vscode-editor-inactiveSelectionBackground);
 }
-th.xmlpermissionset {
-    width: 25%;
+
+th.roleid {
+    width: 30%;
 }
-th.new-name {
-    width: 25%;
+th.object-name {
+    width: 30%;
 }
-th.new-caption {
-    width: 50%;
+th.object-caption {
+    width: 40%;
 }
 
 table td {
     vertical-align: middle;
 }
+
 div.sticky {
   position: sticky;
   top: 0;
   z-index: 100;
+  width: fit-content;
+  margin-left: auto; 
+  margin-right: 0;
   background-color:  var(--vscode-editor-inactiveSelectionBackground);
 }
 

--- a/extension/frontend/PermissionSetNameEditor/reset.css
+++ b/extension/frontend/PermissionSetNameEditor/reset.css
@@ -1,0 +1,72 @@
+html {
+    box-sizing: border-box;
+    font-size: 14px;
+}
+
+*,
+*:before,
+*:after {
+    box-sizing: inherit;
+}
+
+body,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+ol,
+ul {
+    margin: 0;
+    padding: 0;
+    font-weight: normal;
+}
+
+img {
+    max-width: 100%;
+    height: auto;
+}
+
+tr:nth-child(even) td:nth-child(-n+2){background-color:  var(--vscode-editor-inactiveSelectionBackground);} 
+tr:hover {background-color: var(--vscode-editor-selectionBackground);}
+
+textarea {
+    width: 100%;
+    top: 0; left: 0; right: 0; bottom: 0;
+    position: absolute; 
+    resize: none;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    /* table-layout: fixed; */
+}
+
+table, td {
+    position: relative;
+}
+
+th {
+    position: sticky;
+    margin-top: 5px;
+    top: 30px;
+    z-index: 99;
+    box-shadow: 0 2px 2px -1px rgba(0, 0, 0, 0.4);
+    background-color: var(--vscode-editor-inactiveSelectionBackground);
+}
+table td {
+    vertical-align: middle;
+}
+div.sticky {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background-color:  var(--vscode-editor-inactiveSelectionBackground);
+}
+
+tr {
+    height: 30px;
+}

--- a/extension/frontend/PermissionSetNameEditor/vscode.css
+++ b/extension/frontend/PermissionSetNameEditor/vscode.css
@@ -1,0 +1,91 @@
+:root {
+	--container-paddding: 20px;
+	--input-padding-vertical: 6px;
+	--input-padding-horizontal: 4px;
+	--input-margin-vertical: 4px;
+	--input-margin-horizontal: 0;
+}
+
+body {
+	padding: 0 var(--container-paddding);
+	color: var(--vscode-foreground);
+	font-size: var(--vscode-font-size);
+	font-weight: var(--vscode-font-weight);
+	font-family: var(--vscode-font-family);
+	background-color: var(--vscode-editor-background);
+}
+
+ol,
+ul {
+	padding-left: var(--container-paddding);
+}
+
+body > *,
+form > * {
+	margin-block-start: var(--input-margin-vertical);
+	margin-block-end: var(--input-margin-vertical);
+}
+
+*:focus {
+	outline-color: var(--vscode-focusBorder) !important;
+}
+
+a {
+	color: var(--vscode-textLink-foreground);
+}
+
+a:hover,
+a:active {
+	color: var(--vscode-textLink-activeForeground);
+}
+
+code {
+	font-size: var(--vscode-editor-font-size);
+	font-family: var(--vscode-editor-font-family);
+}
+
+button {
+	border: none;
+	padding: var(--input-padding-vertical) var(--input-padding-horizontal);
+	width: 100%;
+	text-align: center;
+	outline: 1px solid transparent;
+	outline-offset: 2px !important;
+	color: var(--vscode-button-foreground);
+	background: var(--vscode-button-background);
+}
+
+button:hover {
+	cursor: pointer;
+	background: var(--vscode-button-hoverBackground);
+}
+
+button:focus {
+	outline-color: var(--vscode-focusBorder);
+}
+
+button.secondary {
+	color: var(--vscode-button-secondaryForeground);
+	background: var(--vscode-button-secondaryBackground);
+}
+
+button.secondary:hover {
+	background: var(--vscode-button-secondaryHoverBackground);
+}
+
+textarea {
+	display: block;
+	width: 100%;
+	height: auto;
+	border: none;
+	font-family: var(--vscode-font-family);
+	padding: var(--input-padding-vertical) var(--input-padding-horizontal);
+	color: var(--vscode-input-foreground);
+	outline-color: var(--vscode-input-border);
+	background-color: var(--vscode-input-background);
+}
+
+input::placeholder,
+textarea::placeholder {
+	color: var(--vscode-input-placeholderForeground);
+}

--- a/extension/frontend/PermissionSetNameEditor/vscode.css
+++ b/extension/frontend/PermissionSetNameEditor/vscode.css
@@ -47,7 +47,7 @@ code {
 button {
 	border: none;
 	padding: var(--input-padding-vertical) var(--input-padding-horizontal);
-	width: 100%;
+	width: fit-content;
 	text-align: center;
 	outline: 1px solid transparent;
 	outline-offset: 2px !important;

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -407,9 +407,9 @@
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.56.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.56.0.tgz",
-            "integrity": "sha512-Q5VmQxOx+L1Y6lIJiGcJzwcyV3pQo/eiW8P+7sNLhFI16tJCwtua2DLjHRcpjbCLNVYpQM73kzfFo1Z0HyP9eQ==",
+            "version": "1.63.1",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.63.1.tgz",
+            "integrity": "sha512-Z+ZqjRcnGfHP86dvx/BtSwWyZPKQ/LBdmAVImY82TphyjOw2KgTKcp7Nx92oNwCTsHzlshwexAG/WiY2JuUm3g==",
             "dev": true
         },
         "@types/xmldom": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -250,6 +250,10 @@
             {
                 "command": "nab.importTranslationCSV",
                 "title": "NAB: Import Translations from .csv"
+            },
+            {
+                "command": "nab.convertToPermissionSet",
+                "title": "NAB: Convert to PermissionSet object"
             }
         ],
         "keybindings": [
@@ -636,7 +640,7 @@
         "@types/semver": "^7.3.5",
         "@types/strip-json-comments": "^3.0.0",
         "@types/uuid": "^8.3.3",
-        "@types/vscode": "^1.50.0",
+        "@types/vscode": "^1.63.0",
         "@types/xmldom": "^0.1.30",
         "@typescript-eslint/eslint-plugin": "^4.22.1",
         "@typescript-eslint/parser": "^4.22.1",

--- a/extension/src/ALObject/ALElementTypes.ts
+++ b/extension/src/ALObject/ALElementTypes.ts
@@ -797,7 +797,7 @@ export class ALPermissionSet extends ALObject {
 {
     Access = Internal;
     Assignable = ${this.assignable};
-    Caption = '${this.caption.substr(0, 30)}', Locked = true;
+    Caption = '${this.caption}', Locked = true;
 
     Permissions =
          ${this.permissions

--- a/extension/src/ALObject/ALElementTypes.ts
+++ b/extension/src/ALObject/ALElementTypes.ts
@@ -802,10 +802,9 @@ export class ALPermissionSet extends ALObject {
     Permissions =
          ${this.permissions
            .sort((a, b) => {
-             if (a.type !== b.type) {
-               return a.type.localeCompare(b.type);
-             }
-             return a.name.localeCompare(b.name);
+             return a.type !== b.type
+               ? a.type.localeCompare(b.type)
+               : a.name.localeCompare(b.name);
            })
            .map((x) => x.toString())
            .join(",\r\n         ")};

--- a/extension/src/ALObject/ALElementTypes.ts
+++ b/extension/src/ALObject/ALElementTypes.ts
@@ -797,11 +797,7 @@ export class ALPermissionSet extends ALObject {
 {
     Access = Internal;
     Assignable = ${this.assignable};
-    Caption = '${this.caption.substr(0, 30)}', Locked = true;${
-      this.caption.length > 30
-        ? ` // TODO: The RoleName "${this.caption}" was longer than the allowed length of a PermissionSet Caption (30 characters). Please review.`
-        : ""
-    }
+    Caption = '${this.caption.substr(0, 30)}', Locked = true;
 
     Permissions =
          ${this.permissions

--- a/extension/src/ALObject/ALElementTypes.ts
+++ b/extension/src/ALObject/ALElementTypes.ts
@@ -775,3 +775,64 @@ export class EOL {
     return "\n";
   }
 }
+
+export class ALPermissionSet extends ALObject {
+  assignable = true;
+  permissions: ALPermission[] = [];
+  private _caption: string;
+  constructor(objectName: string, caption: string, objectId: number) {
+    super([], ALObjectType.permissionSet, 0, objectName, objectId);
+    this._caption = caption;
+  }
+
+  public get caption(): string {
+    return this._caption;
+  }
+  public set caption(value: string) {
+    this._caption = value;
+  }
+
+  public toString(): string {
+    return `permissionSet ${this.objectId} "${this.objectName}"
+{
+    Access = Internal;
+    Assignable = ${this.assignable};
+    Caption = '${this.caption.substr(0, 30)}', Locked = true;${
+      this.caption.length > 30
+        ? ` // TODO: The RoleName "${this.caption}" was longer than the allowed length of a PermissionSet Caption (30 characters). Please review.`
+        : ""
+    }
+
+    Permissions =
+         ${this.permissions
+           .sort((a, b) => {
+             if (a.type !== b.type) {
+               return a.type.localeCompare(b.type);
+             }
+             return a.name.localeCompare(b.name);
+           })
+           .map((x) => x.toString())
+           .join(",\r\n         ")};
+}`;
+  }
+}
+
+export class ALPermission {
+  type: ALObjectType;
+  name: string;
+  objectPermissions: string;
+
+  constructor(type: ALObjectType, name: string, objectPermissions: string) {
+    this.type = type;
+    this.name = name;
+    this.objectPermissions = objectPermissions;
+  }
+  public toString(): string {
+    if (this.objectPermissions === "") {
+      return "";
+    }
+    return `${this.type} ${
+      this.name.match("[ .-]") ? '"' + this.name + '"' : this.name
+    } = ${this.objectPermissions}`;
+  }
+}

--- a/extension/src/ALObject/Enums.ts
+++ b/extension/src/ALObject/Enums.ts
@@ -1,6 +1,7 @@
 // BC ObjectType: ", Table,, Report,, Codeunit, XMLport, MenuSuite, Page, Query,,,,, PageExtension, TableExtension"
 export enum ALObjectType {
   none = "None",
+  tableData = "TableData",
   table = "Table",
   report = "Report",
   codeunit = "Codeunit",

--- a/extension/src/ALObject/Maps.ts
+++ b/extension/src/ALObject/Maps.ts
@@ -12,6 +12,7 @@ export const alObjectTypeMap = new Map<string, ALObjectType>([
   ["report", ALObjectType.report],
   ["requestpage", ALObjectType.requestPage],
   ["table", ALObjectType.table],
+  ["tableData", ALObjectType.tableData],
   ["xmlport", ALObjectType.xmlPort],
   ["enum", ALObjectType.enum],
   ["pageextension", ALObjectType.pageExtension],
@@ -60,10 +61,23 @@ export const alPropertyTypeMap = new Map<string, ALPropertyType>([
   ["entitysetname", ALPropertyType.entitySetName],
   ["extensible", ALPropertyType.extensible],
 ]);
+
 export const alCodeunitSubtypeMap = new Map<string, ALCodeunitSubtype>([
   ["normal", ALCodeunitSubtype.normal],
   ["test", ALCodeunitSubtype.test],
   ["testrunner", ALCodeunitSubtype.testRunner],
   ["install", ALCodeunitSubtype.install],
   ["upgrade", ALCodeunitSubtype.upgrade],
+]);
+
+export const alObjectTypeNumberMap = new Map<number, ALObjectType>([
+  [0, ALObjectType.tableData],
+  [1, ALObjectType.table],
+  [3, ALObjectType.report],
+  [5, ALObjectType.codeunit],
+  [6, ALObjectType.xmlPort],
+  [8, ALObjectType.page],
+  [9, ALObjectType.query],
+  [16, ALObjectType.enum],
+  [18, ALObjectType.profile],
 ]);

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -1329,6 +1329,13 @@ export async function convertToPermissionSet(
   logger.log("Running: convertToPermissionSet");
   Telemetry.trackEvent("convertToPermissionSet");
   try {
+    const settings = SettingsLoader.getSettings();
+    const permissionSetFilePaths = WorkspaceFunctions.getPermissionSetFiles(
+      settings.workspaceFolderPath
+    );
+    if (permissionSetFilePaths.length === 0) {
+      throw new Error("No XmlPermissionSets found.");
+    }
     const prefix = await getUserInput({
       prompt: "Prefix for new objects? (including any trailing spaces)",
       title: "Object Prefix", // TODO: Default value from AppSourceCop.json
@@ -1336,10 +1343,6 @@ export async function convertToPermissionSet(
     if (prefix === undefined) {
       return;
     }
-    const settings = SettingsLoader.getSettings();
-    const permissionSetFilePaths = WorkspaceFunctions.getPermissionSetFiles(
-      settings.workspaceFolderPath
-    );
 
     const xmlPermissionSets = await PermissionSetFunctions.getXmlPermissionSets(
       permissionSetFilePaths,

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -1343,7 +1343,7 @@ export async function convertToPermissionSet(
     const appSourceCopSettings = SettingsLoader.getAppSourceCopSettings();
     const defaultPrefix =
       appSourceCopSettings.mandatoryAffixes.length > 0
-        ? appSourceCopSettings.mandatoryAffixes[0] + " "
+        ? appSourceCopSettings.mandatoryAffixes[0].trim() + " "
         : "";
     const permissionSetFilePaths = WorkspaceFunctions.getPermissionSetFiles(
       settings.workspaceFolderPath

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -1330,6 +1330,11 @@ export async function convertToPermissionSet(
   Telemetry.trackEvent("convertToPermissionSet");
   try {
     const settings = SettingsLoader.getSettings();
+    const appSourceCopSettings = SettingsLoader.getAppSourceCopSettings();
+    const defaultPrefix =
+      appSourceCopSettings.mandatoryAffixes.length > 0
+        ? appSourceCopSettings.mandatoryAffixes[0] + " "
+        : "";
     const permissionSetFilePaths = WorkspaceFunctions.getPermissionSetFiles(
       settings.workspaceFolderPath
     );
@@ -1338,7 +1343,8 @@ export async function convertToPermissionSet(
     }
     const prefix = await getUserInput({
       prompt: "Prefix for new objects? (including any trailing spaces)",
-      title: "Object Prefix", // TODO: Default value from AppSourceCop.json
+      title: "Object Prefix",
+      value: defaultPrefix,
     });
     if (prefix === undefined) {
       return;

--- a/extension/src/PermissionSet/PermissionSetFunctions.ts
+++ b/extension/src/PermissionSet/PermissionSetFunctions.ts
@@ -61,16 +61,22 @@ export async function startConversion(
               false,
               true
             );
-            await convertToPermissionSet(
+            const folderPath = await convertToPermissionSet(
               manifest,
               alObjects,
               prefix,
               xmlPermissionSets
             );
             vscode.window.showInformationMessage(
-              `PermissionSet objects created and old XML PermissionSets deleted.` // TODO: Upgrade code
+              `PermissionSet objects created, old XML PermissionSets deleted and an upgrade codeunit created.`
             );
-            // TODO: Loop createdPermissionSets and create upgrade codeunit with mapping from oldPermissionSets
+            createUpgradeCodeunit(
+              xmlPermissionSets,
+              prefix,
+              manifest,
+              alObjects,
+              folderPath
+            );
             logger.log("Done: convertToPermissionSet");
             resolve();
           } catch (error) {
@@ -88,11 +94,12 @@ export async function convertToPermissionSet(
   alObjects: ALObject[],
   prefix: string,
   xmlPermissionSets: XmlPermissionSet[]
-): Promise<void> {
+): Promise<string> {
   let lastUsedId = 0;
+  let lastFolderPath = "";
   for (const xmlPermissionSet of xmlPermissionSets) {
     const folderPath = path.parse(xmlPermissionSet.filePath).dir;
-
+    lastFolderPath = folderPath;
     const newPermissionSet: ALPermissionSet = new ALPermissionSet(
       xmlPermissionSet.suggestedNewName,
       xmlPermissionSet.roleName,
@@ -140,6 +147,7 @@ export async function convertToPermissionSet(
       fs.unlinkSync(xmlPermissionSet.filePath);
     }
   }
+  return lastFolderPath;
 }
 
 function getObjectName(
@@ -222,4 +230,88 @@ function getPermissionCasing(character: string, permission: string): string {
     default:
       return "";
   }
+}
+function createUpgradeCodeunit(
+  xmlPermissionSets: XmlPermissionSet[],
+  prefix: string,
+  manifest: AppManifest,
+  alObjects: ALObject[],
+  folderPath: string
+): void {
+  const objectId = getFirstAvailableObjectId(
+    alObjects,
+    manifest,
+    ALObjectType.codeunit,
+    0
+  );
+  const objectName = `${prefix}PermissionSet Upgrade`;
+  const filePath = path.join(folderPath, "PermissionSetUpgrade.codeunit.al");
+  const code = `codeunit ${objectId} "${objectName}"
+{
+    Access = Internal;
+    Subtype = Upgrade;
+
+    trigger OnUpgradePerDatabase()
+    begin
+        if GetDataVersion() <= Version.Create('${manifest.version}') then
+            UpgradePermissionSets();
+    end;
+
+    local procedure UpgradePermissionSets()
+    begin
+        ${xmlPermissionSets
+          .map(
+            (x) =>
+              `UpgradePermissionSet('${x.roleID}', '${x.suggestedNewName}');`
+          )
+          .join("\r\n        ")}
+    end;
+
+    local procedure UpgradePermissionSet(OldPermissionSetCode: Code[20]; NewPermissionSetCode: Code[20])
+    var
+        UserGroupPermissionSet: Record "User Group Permission Set";
+        UserGroupPermissionSet2: Record "User Group Permission Set";
+        AccessControl: Record "Access Control";
+        AccessControl2: Record "Access Control";
+        AppId: Guid;
+        CurrentAppInfo: ModuleInfo;
+    begin
+        NavApp.GetCurrentModuleInfo(CurrentAppInfo);
+        AppId := CurrentAppInfo.Id();
+        UserGroupPermissionSet.SetRange("App ID", AppId);
+        UserGroupPermissionSet.SetRange(Scope, UserGroupPermissionSet.Scope::Tenant);
+        UserGroupPermissionSet.SetRange("Role ID", OldPermissionSetCode);
+        if UserGroupPermissionSet.FindSet() then begin
+            repeat
+                UserGroupPermissionSet2 := UserGroupPermissionSet;
+                UserGroupPermissionSet2.Scope := UserGroupPermissionSet2.Scope::System;
+                UserGroupPermissionSet2."Role ID" := NewPermissionSetCode;
+                UserGroupPermissionSet2.Insert();
+            until UserGroupPermissionSet.Next() = 0;
+            UserGroupPermissionSet.DeleteAll();
+        end;
+
+        AccessControl.SetRange("App ID", AppId);
+        AccessControl.SetRange(Scope, AccessControl.Scope::Tenant);
+        AccessControl.SetRange("Role ID", OldPermissionSetCode);
+        if AccessControl.FindSet() then begin
+            repeat
+                AccessControl2 := AccessControl;
+                AccessControl2.Scope := AccessControl2.Scope::System;
+                AccessControl2."Role ID" := NewPermissionSetCode;
+                AccessControl2.Insert();
+            until AccessControl.Next() = 0;
+            AccessControl.DeleteAll();
+        end;
+    end;
+
+    local procedure GetDataVersion(): Version
+    var
+        ModInfo: ModuleInfo;
+    begin
+        NavApp.GetCurrentModuleInfo(ModInfo);
+        exit(ModInfo.DataVersion());
+    end;
+}`;
+  fs.writeFileSync(filePath, code, { encoding: "utf8" });
 }

--- a/extension/src/PermissionSet/PermissionSetFunctions.ts
+++ b/extension/src/PermissionSet/PermissionSetFunctions.ts
@@ -134,6 +134,8 @@ export async function convertToPermissionSet(
     fs.writeFileSync(newFilePath, newPermissionSet.toString(), {
       encoding: "utf8",
     });
+  }
+  for (const xmlPermissionSet of xmlPermissionSets) {
     if (fs.existsSync(xmlPermissionSet.filePath)) {
       fs.unlinkSync(xmlPermissionSet.filePath);
     }

--- a/extension/src/PermissionSet/PermissionSetFunctions.ts
+++ b/extension/src/PermissionSet/PermissionSetFunctions.ts
@@ -1,0 +1,180 @@
+import * as fs from "fs";
+import * as path from "path";
+import { AppManifest } from "../Settings/Settings";
+import {
+  ALObject,
+  ALPermission,
+  ALPermissionSet,
+} from "../ALObject/ALElementTypes";
+import { ALControlType, ALObjectType } from "../ALObject/Enums";
+import { XmlPermissionSet, XmlPermissionSets } from "./XmlPermissionSet";
+import { alObjectTypeNumberMap } from "../ALObject/Maps";
+
+export async function convertToPermissionSet(
+  manifest: AppManifest,
+  alObjects: ALObject[],
+  prefix: string,
+  permissionSetFilePaths: string[]
+): Promise<void> {
+  const maxPermissionSetNameLength = 20;
+  let lastUsedId = 0;
+  const createdPermissionSets: ALPermissionSet[] = [];
+  const oldPermissionSets: XmlPermissionSet[] = [];
+  for (const filePath of permissionSetFilePaths) {
+    const fileContent = fs.readFileSync(filePath, "utf8");
+    if (!fileContent.match(/<PermissionSets>/im)) {
+      throw new Error(
+        "The current document is not a valid PermissionSet xml file."
+      );
+    }
+    const folderPath = path.parse(filePath).dir;
+
+    const xmlPermissionSets = new XmlPermissionSets(fileContent);
+
+    for (const xmlPermissionSet of xmlPermissionSets.permissionSets) {
+      let permissionSetName = (prefix + xmlPermissionSet.roleID).substr(
+        0,
+        maxPermissionSetNameLength
+      );
+      let i = 2;
+      while (
+        createdPermissionSets.find((x) => x.objectName === permissionSetName)
+      ) {
+        permissionSetName =
+          permissionSetName.substr(
+            0,
+            permissionSetName.length - i.toString().length
+          ) + i.toString();
+        i++;
+      }
+
+      const newPermissionSet: ALPermissionSet = new ALPermissionSet(
+        permissionSetName,
+        xmlPermissionSet.roleName,
+        getFirstAvailableObjectId(
+          alObjects,
+          manifest,
+          ALObjectType.permissionSet,
+          lastUsedId
+        )
+      );
+      lastUsedId = newPermissionSet.objectId;
+      for (const permission of xmlPermissionSet.permissions) {
+        const newPermission: ALPermission = new ALPermission(
+          getType(permission.objectType),
+          getObjectName(
+            alObjects,
+            getType(permission.objectType),
+            permission.objectID
+          ),
+          getPermissions(
+            permission.readPermission,
+            permission.insertPermission,
+            permission.modifyPermission,
+            permission.deletePermission,
+            permission.executePermission
+          )
+        );
+        newPermissionSet.permissions.push(newPermission);
+      }
+      const newFilePath = path.join(
+        folderPath,
+        `${newPermissionSet.name
+          .substr(prefix.length)
+          .replace(/[ .-]/i, "")}.permissionset.al`
+      );
+      if (fs.existsSync(newFilePath)) {
+        throw new Error(`File "${newFilePath}" already exists.`);
+      }
+      fs.writeFileSync(newFilePath, newPermissionSet.toString(), {
+        encoding: "utf8",
+      });
+      createdPermissionSets.push(newPermissionSet);
+      oldPermissionSets.push(xmlPermissionSet);
+    }
+    fs.unlinkSync(filePath);
+  }
+  // TODO: Loop createdPermissionSets and create upgrade codeunit with mapping from oldPermissionSets
+}
+
+function getObjectName(
+  alObjects: ALObject[],
+  objectType: ALObjectType,
+  objectID: number
+): string {
+  if (objectID === 0) {
+    return "*";
+  }
+  const searchObjectType: ALObjectType =
+    objectType === ALObjectType.tableData ? ALObjectType.table : objectType;
+  const obj = alObjects.find(
+    (x) =>
+      x.type === ALControlType.object &&
+      x.objectType === searchObjectType &&
+      x.objectId === objectID
+  );
+  if (!obj) {
+    throw new Error(`${searchObjectType} ${objectID} not found.`);
+  }
+  return obj.objectName;
+}
+function getFirstAvailableObjectId(
+  alObjects: ALObject[],
+  manifest: AppManifest,
+  objectType: ALObjectType,
+  lastUsedId: number
+): number {
+  const idRanges = manifest.idRanges.sort((a, b) => (a.from < b.from ? -1 : 1));
+  for (const idRange of idRanges) {
+    const startNumber =
+      lastUsedId < idRange.from ? idRange.from : lastUsedId + 1;
+    for (let i = startNumber; i < idRange.to; i++) {
+      const obj = alObjects.find(
+        (x) =>
+          x.type === ALControlType.object &&
+          x.objectType === objectType &&
+          x.objectId === i
+      );
+      if (!obj) {
+        return i;
+      }
+    }
+  }
+
+  return 50000; // Fallback if no free Id's found, let the compiler complain.
+}
+
+function getType(objectTypeText: string): ALObjectType {
+  const objectTypeNumber: number = Number.parseInt(objectTypeText);
+  const objectType = alObjectTypeNumberMap.get(objectTypeNumber);
+  if (!objectType) {
+    throw new Error(`No object type found for "${objectTypeText}"`);
+  }
+  return objectType;
+}
+function getPermissions(
+  readPermission: string,
+  insertPermission: string,
+  modifyPermission: string,
+  deletePermission: string,
+  executePermission: string
+): string {
+  return `${getPermissionCasing("r", readPermission)}${getPermissionCasing(
+    "i",
+    insertPermission
+  )}${getPermissionCasing("m", modifyPermission)}${getPermissionCasing(
+    "d",
+    deletePermission
+  )}${getPermissionCasing("x", executePermission)}`;
+}
+
+function getPermissionCasing(character: string, permission: string): string {
+  switch (permission) {
+    case "1":
+      return character.toUpperCase();
+    case "2":
+      return character.toLowerCase();
+    default:
+      return "";
+  }
+}

--- a/extension/src/PermissionSet/PermissionSetFunctions.ts
+++ b/extension/src/PermissionSet/PermissionSetFunctions.ts
@@ -14,6 +14,9 @@ import { alObjectTypeNumberMap } from "../ALObject/Maps";
 import * as SettingsLoader from "../Settings/SettingsLoader";
 import { logger } from "../Logging/LogHelper";
 
+const MAX_PERMISSION_SET_NAME_LENGTH = 20;
+const MAX_PERMISSION_SET_CAPTION_LENGTH = 30;
+
 export async function getXmlPermissionSets(
   permissionSetFilePaths: string[],
   prefix: string
@@ -148,6 +151,74 @@ export async function convertToPermissionSet(
     }
   }
   return lastFolderPath;
+}
+
+export function validateData(xmlPermissionSets: XmlPermissionSet[]): void {
+  // PermissionSet names not empty
+  let nameTest = xmlPermissionSets.find((x) => x.suggestedNewName === "");
+  if (nameTest) {
+    throw new Error(
+      `The PermissionSet "${nameTest.roleID}" has an empty name.`
+    );
+  }
+
+  // PermissionSet names max length
+  nameTest = xmlPermissionSets.find(
+    (x) => x.suggestedNewName.length > MAX_PERMISSION_SET_NAME_LENGTH
+  );
+  if (nameTest) {
+    throw new Error(
+      `The PermissionSet name "${nameTest.suggestedNewName}" has more characters (${nameTest.suggestedNewName.length}) than the allowed length of ${MAX_PERMISSION_SET_NAME_LENGTH}.`
+    );
+  }
+
+  // The PermissionSet names must be unique
+  for (const xmlPermissionSet of xmlPermissionSets) {
+    nameTest = xmlPermissionSets.find(
+      (x) =>
+        x.roleID !== xmlPermissionSet.roleID &&
+        x.suggestedNewName === xmlPermissionSet.suggestedNewName
+    );
+    if (nameTest) {
+      throw new Error(
+        `The PermissionSet name "${nameTest.suggestedNewName}" is used more than once.`
+      );
+    }
+  }
+
+  // PermissionSet names not containing illegal characters
+  nameTest = xmlPermissionSets.find((x) =>
+    x.suggestedNewName.match(/[\n\r\t"]+/)
+  );
+  if (nameTest) {
+    throw new Error(
+      `The PermissionSet name "${nameTest.suggestedNewName}" has some illegal characters.`
+    );
+  }
+
+  // PermissionSet captions not empty
+  let captionTest = xmlPermissionSets.find((x) => x.roleName === "");
+  if (captionTest) {
+    throw new Error(
+      `The PermissionSet "${captionTest.roleID}" has an empty caption.`
+    );
+  }
+  // PermissionSet captions not too long
+  captionTest = xmlPermissionSets.find(
+    (x) => x.roleName.length > MAX_PERMISSION_SET_CAPTION_LENGTH
+  );
+  if (captionTest) {
+    throw new Error(
+      `The PermissionSet name "${captionTest.roleName}" has more characters (${captionTest.roleName.length}) than the allowed length of ${MAX_PERMISSION_SET_CAPTION_LENGTH}.`
+    );
+  }
+  // PermissionSet names not containing illegal characters
+  captionTest = xmlPermissionSets.find((x) => x.roleName.match(/[\n\r\t']+/));
+  if (captionTest) {
+    throw new Error(
+      `The PermissionSet caption "${captionTest.roleName}" has some illegal characters.`
+    );
+  }
 }
 
 function getObjectName(

--- a/extension/src/PermissionSet/PermissionSetNamePanel.ts
+++ b/extension/src/PermissionSet/PermissionSetNamePanel.ts
@@ -5,8 +5,6 @@ import * as PermissionSetFunctions from "./PermissionSetFunctions";
 import { XmlPermissionSet } from "./XmlPermissionSet";
 import { logger } from "../Logging/LogHelper";
 
-const MAX_PERMISSION_SET_NAME_LENGTH = 20;
-const MAX_PERMISSION_SET_CAPTION_LENGTH = 30;
 /**
  * Manages PermissionSetNameEditor webview panels
  */
@@ -116,7 +114,7 @@ export class PermissionSetNameEditorPanel {
 
   async handleOk(): Promise<void> {
     try {
-      this.validateData();
+      PermissionSetFunctions.validateData(this._xmlPermissionSets);
     } catch (error) {
       vscode.window.showErrorMessage(`${error}`, { modal: true });
       return;
@@ -130,78 +128,6 @@ export class PermissionSetNameEditorPanel {
     } catch (error) {
       vscode.window.showErrorMessage(
         `"Convert to PermissionSet object" failed with error: ${error}`
-      );
-    }
-  }
-
-  private validateData(): void {
-    // PermissionSet names not empty
-    let nameTest = this._xmlPermissionSets.find(
-      (x) => x.suggestedNewName === ""
-    );
-    if (nameTest) {
-      throw new Error(
-        `The PermissionSet "${nameTest.roleID}" has an empty name.`
-      );
-    }
-
-    // PermissionSet names max length
-    nameTest = this._xmlPermissionSets.find(
-      (x) => x.suggestedNewName.length > MAX_PERMISSION_SET_NAME_LENGTH
-    );
-    if (nameTest) {
-      throw new Error(
-        `The PermissionSet name "${nameTest.suggestedNewName}" has more characters (${nameTest.suggestedNewName.length}) than the allowed length of ${MAX_PERMISSION_SET_NAME_LENGTH}.`
-      );
-    }
-
-    // The PermissionSet names must be unique
-    for (const xmlPermissionSet of this._xmlPermissionSets) {
-      nameTest = this._xmlPermissionSets.find(
-        (x) =>
-          x.roleID !== xmlPermissionSet.roleID &&
-          x.suggestedNewName === xmlPermissionSet.suggestedNewName
-      );
-      if (nameTest) {
-        throw new Error(
-          `The PermissionSet name "${nameTest.suggestedNewName}" is used more than once.`
-        );
-      }
-    }
-
-    // PermissionSet names not containing illegal characters
-    nameTest = this._xmlPermissionSets.find((x) =>
-      x.suggestedNewName.match(/[\n\r\t"]+/)
-    );
-    if (nameTest) {
-      throw new Error(
-        `The PermissionSet name "${nameTest.suggestedNewName}" has some illegal characters.`
-      );
-    }
-
-    // PermissionSet captions not empty
-    let captionTest = this._xmlPermissionSets.find((x) => x.roleName === "");
-    if (captionTest) {
-      throw new Error(
-        `The PermissionSet "${captionTest.roleID}" has an empty caption.`
-      );
-    }
-    // PermissionSet captions not too long
-    captionTest = this._xmlPermissionSets.find(
-      (x) => x.roleName.length > MAX_PERMISSION_SET_CAPTION_LENGTH
-    );
-    if (captionTest) {
-      throw new Error(
-        `The PermissionSet name "${captionTest.roleName}" has more characters (${captionTest.roleName.length}) than the allowed length of ${MAX_PERMISSION_SET_CAPTION_LENGTH}.`
-      );
-    }
-    // PermissionSet names not containing illegal characters
-    captionTest = this._xmlPermissionSets.find((x) =>
-      x.roleName.match(/[\n\r\t']+/)
-    );
-    if (captionTest) {
-      throw new Error(
-        `The PermissionSet caption "${captionTest.roleName}" has some illegal characters.`
       );
     }
   }

--- a/extension/src/PermissionSet/PermissionSetNamePanel.ts
+++ b/extension/src/PermissionSet/PermissionSetNamePanel.ts
@@ -294,26 +294,8 @@ export class PermissionSetNameEditorPanel {
   }
 
   permissionSetsTable(xmlPermissionSets: XmlPermissionSet[]): string {
-    const menu = html.div(
-      { class: "sticky" },
-      html.table({}, [
-        {
-          content: html.button({ id: "btn-cancel", title: "Cancel" }, "Cancel"),
-          a: undefined,
-        },
-        {
-          content: html.button(
-            { id: "btn-ok", title: "Convert PermissionSets" },
-            "OK"
-          ),
-          a: undefined,
-        },
-      ])
-    );
-    let table = menu;
-
-    table += "<table>";
-    table += html.tableHeader(["XmlPermissionSet", "New Name", "New Caption"]);
+    let table = "<table>";
+    table += html.tableHeader(["RoleID", "Object Name", "Object Caption"]);
     table += "<tbody>";
     xmlPermissionSets.forEach((xmlPermissionSet) => {
       const columns: html.HTMLTag[] = [
@@ -342,6 +324,23 @@ export class PermissionSetNameEditorPanel {
       table += html.tr({ id: `${xmlPermissionSet.roleID}` }, columns);
     });
     table += "</tbody></table>";
+    const menu = html.div(
+      { class: "sticky" },
+      html.table({}, [
+        {
+          content: html.button({ id: "btn-cancel", title: "Cancel" }, "Cancel"),
+          a: undefined,
+        },
+        {
+          content: html.button(
+            { id: "btn-ok", title: "Convert PermissionSets" },
+            "OK"
+          ),
+          a: undefined,
+        },
+      ])
+    );
+    table += menu;
     return table;
   }
 }

--- a/extension/src/PermissionSet/PermissionSetNamePanel.ts
+++ b/extension/src/PermissionSet/PermissionSetNamePanel.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import * as html from "../XliffEditor/HTML";
 import * as SettingsLoader from "../Settings/SettingsLoader";
 import * as PermissionSetFunctions from "./PermissionSetFunctions";
+import * as Telemetry from "../Telemetry";
 import { XmlPermissionSet } from "./XmlPermissionSet";
 import { logger } from "../Logging/LogHelper";
 
@@ -129,6 +130,7 @@ export class PermissionSetNameEditorPanel {
       vscode.window.showErrorMessage(
         `"Convert to PermissionSet object" failed with error: ${error}`
       );
+      Telemetry.trackException(error);
     }
   }
 

--- a/extension/src/PermissionSet/XmlPermissionSet.ts
+++ b/extension/src/PermissionSet/XmlPermissionSet.ts
@@ -1,0 +1,100 @@
+import * as xmldom from "@xmldom/xmldom";
+
+export class XmlPermissionSets {
+  permissionSets: XmlPermissionSet[] = [];
+  constructor(xml: string) {
+    const dom = xmldom.DOMParser;
+    const permissionsDom = new dom().parseFromString(xml);
+    const permissionSetsNode = permissionsDom.getElementsByTagName(
+      "PermissionSets"
+    )[0];
+    const permissionSetNodeList = permissionSetsNode.getElementsByTagName(
+      "PermissionSet"
+    );
+    for (let index = 0; index < permissionSetNodeList.length; index++) {
+      const permissionSetNode = permissionSetNodeList[index];
+      const roleId = permissionSetNode.getAttribute("RoleID");
+      if (!roleId) {
+        throw new Error("PermissionSet is missing the RoleID attribute");
+      }
+      const roleName = permissionSetNode.getAttribute("RoleName");
+      const permissionSet: XmlPermissionSet = {
+        roleID: roleId,
+        roleName: roleName ?? "",
+        permissions: [],
+      };
+      const permissionsNodeList = permissionSetNode.getElementsByTagName(
+        "Permission"
+      );
+      for (let i = 0; i < permissionsNodeList.length; i++) {
+        const permissionsNode = permissionsNodeList[i];
+        const objectType = permissionsNode.getElementsByTagName("ObjectType")[0]
+          .childNodes[0].nodeValue;
+
+        const objectId = permissionsNode.getElementsByTagName("ObjectID")[0]
+          .childNodes[0].nodeValue;
+        const readPermission =
+          permissionsNode.getElementsByTagName("ReadPermission")[0]
+            .childNodes[0].nodeValue ?? "";
+        const insertPermission =
+          permissionsNode.getElementsByTagName("InsertPermission")[0]
+            .childNodes[0].nodeValue ?? "";
+        const modifyPermission =
+          permissionsNode.getElementsByTagName("ModifyPermission")[0]
+            .childNodes[0].nodeValue ?? "";
+        const deletePermission =
+          permissionsNode.getElementsByTagName("DeletePermission")[0]
+            .childNodes[0].nodeValue ?? "";
+        const executePermission =
+          permissionsNode.getElementsByTagName("ExecutePermission")[0]
+            .childNodes[0].nodeValue ?? "";
+        if (
+          permissionsNode
+            .getElementsByTagName("SecurityFilter")[0]
+            .hasChildNodes()
+        ) {
+          throw new Error(
+            `PermissionSet ${permissionSet.roleID} har defined some SecurityFilter, which is unsupported by this function`
+          );
+        }
+        if (!objectType || objectType === "") {
+          throw new Error(
+            `A permission with empty ObjectType found in PermissionSet ${permissionSet.roleID}`
+          );
+        }
+        if (!objectId || objectId === "") {
+          throw new Error(
+            `A permission with empty ObjectID found in PermissionSet ${permissionSet.roleID}`
+          );
+        }
+        const permission: XmlPermission = {
+          objectType: objectType,
+          objectID: Number.parseInt(objectId),
+          readPermission: readPermission,
+          insertPermission: insertPermission,
+          modifyPermission: modifyPermission,
+          deletePermission: deletePermission,
+          executePermission: executePermission,
+        };
+        permissionSet.permissions.push(permission);
+      }
+      this.permissionSets.push(permissionSet);
+    }
+  }
+}
+
+export interface XmlPermissionSet {
+  permissions: XmlPermission[];
+  roleID: string;
+  roleName: string;
+}
+
+export interface XmlPermission {
+  objectType: string;
+  objectID: number;
+  readPermission: string;
+  insertPermission: string;
+  modifyPermission: string;
+  deletePermission: string;
+  executePermission: string;
+}

--- a/extension/src/PermissionSet/XmlPermissionSet.ts
+++ b/extension/src/PermissionSet/XmlPermissionSet.ts
@@ -2,7 +2,9 @@ import * as xmldom from "@xmldom/xmldom";
 
 export class XmlPermissionSets {
   permissionSets: XmlPermissionSet[] = [];
-  constructor(xml: string) {
+  filePath: string;
+  constructor(filePath: string, xml: string, prefix: string) {
+    this.filePath = filePath;
     const dom = xmldom.DOMParser;
     const permissionsDom = new dom().parseFromString(xml);
     const permissionSetsNode = permissionsDom.getElementsByTagName(
@@ -22,6 +24,8 @@ export class XmlPermissionSets {
         roleID: roleId,
         roleName: roleName ?? "",
         permissions: [],
+        filePath: filePath,
+        suggestedNewName: prefix + roleId,
       };
       const permissionsNodeList = permissionSetNode.getElementsByTagName(
         "Permission"
@@ -87,6 +91,8 @@ export interface XmlPermissionSet {
   permissions: XmlPermission[];
   roleID: string;
   roleName: string;
+  filePath: string;
+  suggestedNewName: string;
 }
 
 export interface XmlPermission {

--- a/extension/src/Settings/CliSettingsLoader.ts
+++ b/extension/src/Settings/CliSettingsLoader.ts
@@ -6,6 +6,7 @@ import {
   Settings,
   IAppManifest,
   ILaunchFile,
+  IAppSourceCopSettings,
 } from "./Settings";
 import { WorkspaceFile } from "./WorkspaceFile";
 import { settingsMap } from "./SettingsMap";
@@ -58,6 +59,19 @@ export function getLaunchSettings(workspaceFolderPath: string): LaunchSettings {
   );
 
   return launchSettings;
+}
+
+export function getAppSourceCopSettings(
+  workspaceFolderPath: string
+): IAppSourceCopSettings {
+  const filePath = join(workspaceFolderPath, "AppSourceCop.json");
+
+  const appSourceCopSettingsJson = loadJson(filePath) as IAppSourceCopSettings;
+  if (!appSourceCopSettingsJson.mandatoryAffixes) {
+    appSourceCopSettingsJson.mandatoryAffixes = [];
+  }
+
+  return appSourceCopSettingsJson;
 }
 
 export function getAppManifest(workspaceFolderPath: string): AppManifest {

--- a/extension/src/Settings/CliSettingsLoader.ts
+++ b/extension/src/Settings/CliSettingsLoader.ts
@@ -64,13 +64,7 @@ export function getAppManifest(workspaceFolderPath: string): AppManifest {
   const filePath = join(workspaceFolderPath, "app.json");
   const appSettings = loadJson(filePath) as IAppManifest;
 
-  const appManifest = new AppManifest(
-    workspaceFolderPath,
-    appSettings.id,
-    appSettings.name,
-    appSettings.publisher,
-    appSettings.version
-  );
+  const appManifest = new AppManifest(workspaceFolderPath, appSettings);
 
   return appManifest;
 }

--- a/extension/src/Settings/Settings.ts
+++ b/extension/src/Settings/Settings.ts
@@ -119,3 +119,7 @@ export class LaunchSettings {
     this.serverInstance = serverInstance;
   }
 }
+
+export interface IAppSourceCopSettings {
+  mandatoryAffixes: string[];
+}

--- a/extension/src/Settings/Settings.ts
+++ b/extension/src/Settings/Settings.ts
@@ -77,6 +77,7 @@ export interface IAppManifest {
   name: string;
   publisher: string;
   version: string;
+  idRanges: IDRange[];
 }
 export class AppManifest implements IAppManifest {
   public workspaceFolderPath: string;
@@ -84,20 +85,21 @@ export class AppManifest implements IAppManifest {
   public name: string;
   public publisher: string;
   public version: string;
+  public idRanges: IDRange[] = [];
 
-  constructor(
-    workspaceFolderPath: string,
-    id: string,
-    name: string,
-    publisher: string,
-    version: string
-  ) {
+  constructor(workspaceFolderPath: string, appManifest: IAppManifest) {
     this.workspaceFolderPath = workspaceFolderPath;
-    this.id = id;
-    this.name = name;
-    this.publisher = publisher;
-    this.version = version;
+    this.id = appManifest.id;
+    this.name = appManifest.name;
+    this.publisher = appManifest.publisher;
+    this.version = appManifest.version;
+    this.idRanges = appManifest.idRanges;
   }
+}
+
+export interface IDRange {
+  from: number;
+  to: number;
 }
 
 export interface ILaunchFile {

--- a/extension/src/Settings/SettingsLoader.ts
+++ b/extension/src/Settings/SettingsLoader.ts
@@ -1,5 +1,10 @@
 import * as vscode from "vscode";
-import { AppManifest, LaunchSettings, Settings } from "./Settings";
+import {
+  AppManifest,
+  IAppSourceCopSettings,
+  LaunchSettings,
+  Settings,
+} from "./Settings";
 import { settingsMap } from "./SettingsMap";
 import * as CliSettingsLoader from "./CliSettingsLoader";
 
@@ -25,6 +30,11 @@ export function getSettings(): Settings {
 export function getLaunchSettings(): LaunchSettings {
   const workspaceFolderPath = getWorkspaceFolderPath();
   return CliSettingsLoader.getLaunchSettings(workspaceFolderPath);
+}
+
+export function getAppSourceCopSettings(): IAppSourceCopSettings {
+  const workspaceFolderPath = getWorkspaceFolderPath();
+  return CliSettingsLoader.getAppSourceCopSettings(workspaceFolderPath);
 }
 
 export function getAppManifest(): AppManifest {

--- a/extension/src/WorkspaceFunctions.ts
+++ b/extension/src/WorkspaceFunctions.ts
@@ -234,13 +234,25 @@ export function getWebServiceFiles(root: string): string[] {
   const xmlFilePaths = FileFunctions.findFiles("*.xml", root);
 
   const wsFilePaths: string[] = [];
-  xmlFilePaths.forEach((xmlFilePath) => {
+  for (const xmlFilePath of xmlFilePaths) {
     const xmlText = fs.readFileSync(xmlFilePath, "utf8");
     if (xmlText.match(/<TenantWebServiceCollection>/im)) {
       wsFilePaths.push(xmlFilePath);
     }
-  });
+  }
   return wsFilePaths;
+}
+export function getPermissionSetFiles(root: string): string[] {
+  const xmlFilePaths = FileFunctions.findFiles("*.xml", root);
+
+  const permissionSetFilePaths: string[] = [];
+  for (const xmlFilePath of xmlFilePaths) {
+    const xmlText = fs.readFileSync(xmlFilePath, "utf8");
+    if (xmlText.match(/<PermissionSets>/im)) {
+      permissionSetFilePaths.push(xmlFilePath);
+    }
+  }
+  return permissionSetFilePaths;
 }
 
 function isValidFilesystemChar(char: string): boolean {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -138,6 +138,9 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand("nab.importTranslationCSV", () => {
       NABfunctions.importTranslationCSV();
     }),
+    vscode.commands.registerCommand("nab.convertToPermissionSet", () => {
+      NABfunctions.convertToPermissionSet();
+    }),
     vscode.commands.registerTextEditorCommand(
       "nab.AddXmlCommentBold",
       (textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit) => {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -139,7 +139,7 @@ export function activate(context: vscode.ExtensionContext): void {
       NABfunctions.importTranslationCSV();
     }),
     vscode.commands.registerCommand("nab.convertToPermissionSet", () => {
-      NABfunctions.convertToPermissionSet();
+      NABfunctions.convertToPermissionSet(context.extensionUri);
     }),
     vscode.commands.registerTextEditorCommand(
       "nab.AddXmlCommentBold",


### PR DESCRIPTION
Ref. https://www.yammer.com/dynamicsnavdev/threads/1186383901990912

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:
- Prompts user for prefix, with default value from AppSourceCop.json
- Shows a table where user can edit names and captions
- Input is validated
- New PermissionSet objects are created
- Old XmlPermissionSets are deleted
- An upgrade codeunit is created that maps usage of old PermissionSet to the new one.


