### PR TITLE
Copy all <source> to untranslated <target>

### DIFF
--- a/dev-tools/PowerShell/Get-LatestNABALTools.ps1
+++ b/dev-tools/PowerShell/Get-LatestNABALTools.ps1
@@ -23,7 +23,7 @@ if (!$vsixUrl) {
 }
 $version = "v$($listing.results.extensions.versions.version)"
 
-Write-Host "Downloadning $($version) from '$vsixUrl'"
+Write-Host "Downloading $($version) from '$vsixUrl'"
 
 $tmpFilePath = [System.IO.Path]::GetTempFileName() + '.zip'
 $response = Invoke-WebRequest -Uri $VsixUrl -Method Get -UseBasicParsing

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the "nab-al-tools" extension will be documented in this file.
 
-<!-- 
+<!--
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 -->
@@ -10,6 +10,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [1.14] - 2022-01
 
 - New features:
+  - `NAB: Copy all <source> to untranslated <target>`
+    - Copies the content of the \<source\> element to the \<target\> element for all translation units that is untranslated. All copied targets are optionally marked for review.
+    - This might be useful if your code that was converted from C/AL contained only translated texts, with no ENU (en-US) translation. After this has been done, all texts in source code can be changed to english over time. See [issue 243](https://github.com/jwikman/nab-al-tools/issues/243) for details.
   - `NAB: Convert to PermissionSet object` converts a PermissionSet defined in XML into a PermissionSet object.
     - The user is prompted to supply a prefix that will be used for the object names. The default value is fetched from the first `mandatoryAffixes` in the AppSourceCop.json, if available.
     - The prefix is added to the old RoleID as a suggested Name for the new PermissionSet object.
@@ -123,7 +126,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
     - `NAB.CreateUidForDocs`
 - Fixed:
   - When executing any of the `NAB: XML Comment - Format` functions without a selection, the cursor will now be placed inside the added formatting tag.
-  - When using the function findTranslatedTexts from some *.al file in Base Application, then it fails with breaking error "Files above 50MB cannot be synchronized with extensions.". This is now fixed in [PR 157](https://github.com/jwikman/nab-al-tools/pull/157) by [zabaq](https://github.com/zabcik) - thanks!
+  - When using the function findTranslatedTexts from some \*.al file in Base Application, then it fails with breaking error "Files above 50MB cannot be synchronized with extensions.". This is now fixed in [PR 157](https://github.com/jwikman/nab-al-tools/pull/157) by [zabaq](https://github.com/zabcik) - thanks!
   - When executing `NAB: Create translation XLF for new language`, no targets was added to the resulting xlf file. Details in [issue 162](https://github.com/jwikman/nab-al-tools/issues/162). Thanks to [Steven-Bale](https://github.com/Steven-Bale) for reporting this issue.
 
 ## [1.1.0] 2021-03-30
@@ -151,11 +154,11 @@ We're out of preview no more beta!
   - `NAB: Edit Xliff Document` opens XLF-files for editing in a webview. With the goal of reducing the clutter of XML files this feature is mainly built for translators. Command available from right clicking a XLF-file and command palette. This is the first iteration of this editor and we are grateful for any feedback you are able to send our way.
     - Keyboard navigation:
       - `Arrow Up` / `Arrow down` moves focus between lines.
-      - `F8`  copies the target text from the line above.
+      - `F8` copies the target text from the line above.
       - `TAB` focus is moved between the target textarea and the complete checkbox and then the next line.
       - `Space` can be used to toggle the complete checkbox when it's in focus.
   - `NAB: Create translation XLF for new language` creates and opens a new translation file for selected target language with the option to match translations from BaseApp to get you going. The new translation file is saved as `<app-name>.<language-code>.xlf` in workspace translation folder. Note that there is no validation of the new target language code.
-  - `NAB: Generate External Documentation` generates documentation that is intended to be used as an external documentation. I.e. to be read by someone that wants to extend the app by API, Web Services or with an extension. The documentation is created as [markdown](https://en.wikipedia.org/wiki/Markdown) files. The markdown files could  be transformed to html files with the help of [DocFx](https://dotnet.github.io/docfx/) or other tools.
+  - `NAB: Generate External Documentation` generates documentation that is intended to be used as an external documentation. I.e. to be read by someone that wants to extend the app by API, Web Services or with an extension. The documentation is created as [markdown](https://en.wikipedia.org/wiki/Markdown) files. The markdown files could be transformed to html files with the help of [DocFx](https://dotnet.github.io/docfx/) or other tools.
     - The content is generated from the AL code and the [XML Comments](https://docs.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-xml-comments) that are written in the AL code.
       - In the first release the following XML Comments are supported
         - `<summary>`
@@ -187,7 +190,7 @@ We're out of preview no more beta!
   - `NAB: Find source of current Translation Unit` did not work in some cases, [issue 93](https://github.com/jwikman/nab-al-tools/issues/93)
   - `NAB: Find Next Untranslated` now cleans up missed notes ("NAB AL Tool Refresh Xlf") that could be left behind if the refresh function wasn't run again.
   - `NAB: Find Next Untranslated` also presents any occurrence of multiple targets in the .xlf file.
-Bugs, issues and suggestions can be submitted on [GitHub](https://github.com/jwikman/nab-al-tools/issues)
+    Bugs, issues and suggestions can be submitted on [GitHub](https://github.com/jwikman/nab-al-tools/issues)
 
 ## [0.3.38] Public Beta - 2021-01-29
 
@@ -229,7 +232,7 @@ Bugs, issues and suggestions can be submitted on [GitHub](https://github.com/jwi
     - Downloads Base App translations matching the target-language of the XLF files in the current workspace.
     - The files downloaded consists of json files with a size of 5-10mb.
     - The files are downloaded to the VS Code extension folder and should not be visible or otherwise affect your workspace.
-    - *This feature is a preview and will likely be removed in the future to be handled in the background where needed*.
+    - _This feature is a preview and will likely be removed in the future to be handled in the background where needed_.
 - New settings:
   - `NAB.MatchBaseAppTranslation`
     - If enabled, the `NAB: Refresh XLF files from g.xlf` function tries to match sources in the translated xlf file with translations from the BaseApplication.

--- a/extension/README.md
+++ b/extension/README.md
@@ -24,6 +24,7 @@ NAB AL Tools supports the pre-release functionality in VSCode v1.63 and later (r
   * [NAB: Update g.xlf](#nab-update-gxlf)
   * [NAB: Update all XLF files](#nab-update-all-xlf-files)
   * [NAB: Copy \<source\> to \<target\>](#nab-copy-source-to-target)
+  * [NAB: Copy all \<source\> to untranslated \<target\>](#nab-copy-all-source-to-untranslated-target)
   * [NAB: Download Base App Translation files](#nab-download-base-app-translation-files)
   * [NAB: Match Translations From Base Application](#nab-match-translations-from-base-application)
   * [NAB: Create translation XLF for new language](#nab-create-translation-xlf-for-new-language)
@@ -123,6 +124,10 @@ Updates all language xlf files with the same sorting as the g.xlf file
 #### NAB: Copy \<source\> to \<target\>
 
 Copies the content of the \<source\> element to the \<target\> element. Use this when positioned on a target line in a xlf file.
+
+#### NAB: Copy all \<source\> to untranslated \<target\>
+
+Copies the content of the \<source\> element to the \<target\> element for all translation units that is untranslated. All copied targets are optionally marked for review. This might be useful if your code that was converted from C/AL contained only translated texts, with no ENU (en-US) translation. After this has been done, all texts in source code can be changed to english over time.
 
 #### NAB: Update g.xlf
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -183,6 +183,10 @@
                 "title": "NAB: Copy <source> to <target>"
             },
             {
+                "command": "nab.CopyAllSourceToTarget",
+                "title": "NAB: Copy all <source> to untranslated <target>"
+            },
+            {
                 "command": "nab.FindSourceOfCurrentTranslationUnit",
                 "title": "NAB: Find source of current Translation Unit",
                 "category": "navigation"

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -170,6 +170,37 @@ export async function copySourceToTarget(): Promise<void> {
   logger.log("Done: CopySourceToTarget");
 }
 
+export async function copyAllSourceToTarget(): Promise<void> {
+  logger.log("Running: CopyAllSourceToTarget");
+  Telemetry.trackEvent("copyAllSourceToTarget");
+  try {
+    const languageFunctionsSettings = new LanguageFunctionsSettings(
+      SettingsLoader.getSettings()
+    );
+    const response = await getQuickPickResult(["yes", "no"], {
+      canPickMany: false,
+      ignoreFocusOut: true,
+      title: "Mark updated targets for review?",
+    });
+    if (!response) {
+      return;
+    }
+    const setAsReview = response[0] === "yes";
+    if (
+      !(await LanguageFunctions.copyAllSourceToTarget(
+        languageFunctionsSettings,
+        setAsReview
+      ))
+    ) {
+      vscode.window.showErrorMessage("Not in a xlf file.");
+    }
+  } catch (error) {
+    showErrorAndLog("Copy all source to target", error as Error);
+    return;
+  }
+  logger.log("Done: CopyAllSourceToTarget");
+}
+
 export async function setTranslationUnitToTranslated(): Promise<void> {
   logger.log("Running: SetTranslationUnitToTranslated");
   Telemetry.trackEvent("setTranslationUnitToTranslated");

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -705,7 +705,7 @@ export async function downloadBaseAppTranslationFiles(): Promise<void> {
   );
   try {
     const result = await baseAppTranslationFiles.getBlobs(targetLanguageCodes);
-    let informationMessage = `Successfully downloaded ${result.succeded.length} translation file(s).`;
+    let informationMessage = `Successfully downloaded ${result.succeeded.length} translation file(s).`;
     informationMessage +=
       result.failed.length > 0
         ? ` Failed to download ${

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -187,11 +187,18 @@ export async function copyAllSourceToTarget(): Promise<void> {
     }
     const setAsReview = response[0] === "yes";
     if (
-      !(await LanguageFunctions.copyAllSourceToTarget(
+      vscode.window.activeTextEditor &&
+      vscode.window.activeTextEditor.document.uri.fsPath.endsWith("xlf")
+    ) {
+      // in a xlf file
+      const filePath = vscode.window.activeTextEditor.document.uri.fsPath;
+      await vscode.window.activeTextEditor.document.save();
+      await LanguageFunctions.copyAllSourceToTarget(
+        filePath,
         languageFunctionsSettings,
         setAsReview
-      ))
-    ) {
+      );
+    } else {
       vscode.window.showErrorMessage("Not in a xlf file.");
     }
   } catch (error) {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -84,6 +84,9 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand("nab.CopySourceToTarget", () => {
       NABfunctions.copySourceToTarget();
     }),
+    vscode.commands.registerCommand("nab.CopyAllSourceToTarget", () => {
+      NABfunctions.copyAllSourceToTarget();
+    }),
     vscode.commands.registerCommand("nab.SuggestToolTips", () => {
       NABfunctions.suggestToolTips();
     }),

--- a/extension/src/externalresources/ExternalResources.ts
+++ b/extension/src/externalresources/ExternalResources.ts
@@ -21,7 +21,7 @@ interface BlobContainerInterface {
 }
 
 interface BlobDownloadResult {
-  succeded: string[];
+  succeeded: string[];
   failed: string[];
 }
 
@@ -83,7 +83,7 @@ export class BlobContainer implements BlobContainerInterface {
   public async getBlobs(
     languageCodeFilter?: string[]
   ): Promise<BlobDownloadResult> {
-    const downloadResult: BlobDownloadResult = { succeded: [], failed: [] };
+    const downloadResult: BlobDownloadResult = { succeeded: [], failed: [] };
     if (!fs.existsSync(this.exportPath)) {
       throw new Error(`Directory does not exist: ${this.exportPath}`);
     }
@@ -145,7 +145,7 @@ export class BlobContainer implements BlobContainerInterface {
         fs.unlinkSync(writeStream.path);
         continue;
       }
-      downloadResult.succeded.push(blob.name);
+      downloadResult.succeeded.push(blob.name);
     }
     return downloadResult;
   }

--- a/extension/src/test/BaseAppTranslationFiles.test.ts
+++ b/extension/src/test/BaseAppTranslationFiles.test.ts
@@ -15,7 +15,7 @@ suite("Base App Translation Files Tests", function () {
     this.timeout(TIMEOUT);
     const result = await BaseAppTranslationFiles.baseAppTranslationFiles.getBlobs(); // Gets all the blobs, and I mean aaaall of them.
     assert.deepStrictEqual(
-      result.succeded.length,
+      result.succeeded.length,
       25,
       "Unexpected number of files downloaded"
     );
@@ -37,7 +37,7 @@ suite("Base App Translation Files Tests", function () {
     );
     const localTranslationFiles = BaseAppTranslationFiles.localBaseAppTranslationFiles();
     assert.deepStrictEqual(
-      result.succeded.length,
+      result.succeeded.length,
       1,
       "Unexpected number of files downloaded"
     );

--- a/extension/src/test/ExternalResources.test.ts
+++ b/extension/src/test/ExternalResources.test.ts
@@ -99,7 +99,7 @@ suite("External Resources Tests", function () {
     blobContainer.addBlob("sv-se.json");
     const result = await blobContainer.getBlobs();
     assert.deepStrictEqual(
-      result.succeded.length,
+      result.succeeded.length,
       1,
       "Unexpected number of files downloaded"
     );
@@ -145,7 +145,7 @@ suite("External Resources Tests", function () {
       langCode.pristine,
     ]);
     assert.deepStrictEqual(
-      result.succeded.length,
+      result.succeeded.length,
       1,
       "Unexpected number of files downloaded"
     );


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
Fixes #243.

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:
- Copies the content of the <source> element to the <target> element for all translation units that is untranslated. All copied targets are optionally marked for review.


Sorry about the unrelated diffs in the changelog. I activated prettier for .md files for a while, but the readme became a complete diff so I reverted that. But I missed that the changelog already was affected.

I'll activate prettier for .md and .js files in another PR after this is completed.