### PR TITLE
Double quotes in control names

### DIFF
--- a/extension/src/ALObject/ALElementTypes.ts
+++ b/extension/src/ALObject/ALElementTypes.ts
@@ -39,7 +39,7 @@ export class ALControl extends ALElement {
     super();
     this.type = type;
     if (name) {
-      this.name = name;
+      this.name = name.replace(/""/g, '"');
     }
   }
 

--- a/extension/src/ALObject/ALParser.ts
+++ b/extension/src/ALObject/ALParser.ts
@@ -205,7 +205,7 @@ function parseXmlComments(
   }
 }
 
-function matchALControl(
+export function matchALControl(
   parent: ALControl,
   lineIndex: number,
   codeLine: ALCodeLine

--- a/extension/src/test/ALParser.test.ts
+++ b/extension/src/test/ALParser.test.ts
@@ -343,6 +343,7 @@ suite("Classes.AL Functions Tests", function () {
       "2. Groups not removed"
     );
   });
+
   test("ALControl parsing", function () {
     testAlControlParsing(
       'field("IOGRec.""Location Code"""; IOGRec."Location Code")',
@@ -433,6 +434,8 @@ suite("Classes.AL Functions Tests", function () {
             `Unexpected value from line '${codeLine}'`
           );
           break;
+        default:
+          assert.fail(`ALControlType ${alControlType} is not supported`);
       }
     }
   }

--- a/extension/src/test/ALParser.test.ts
+++ b/extension/src/test/ALParser.test.ts
@@ -5,14 +5,18 @@ import * as ALObjectTestLibrary from "./ALObjectTestLibrary";
 import {
   ALAccessModifier,
   ALControlType,
+  ALObjectType,
   ALPropertyType,
   MultiLanguageType,
 } from "../ALObject/Enums";
 import { ALVariable } from "../ALObject/ALVariable";
 import { removeGroupNamesFromRegex } from "../constants";
 import * as ALParser from "../ALObject/ALParser";
-import { ALControl } from "../ALObject/ALElementTypes";
+import { ALObject, ALControl } from "../ALObject/ALElementTypes";
 import { ALCodeLine } from "../ALObject/ALCodeLine";
+import { ALPageField } from "../ALObject/ALPageField";
+import { ALTableField } from "../ALObject/ALTableField";
+import { ALPagePart } from "../ALObject/ALPagePart";
 
 suite("Classes.AL Functions Tests", function () {
   test("SpecialCharacters XLIFF", function () {
@@ -339,6 +343,101 @@ suite("Classes.AL Functions Tests", function () {
       "2. Groups not removed"
     );
   });
+  test("ALControl parsing", function () {
+    testAlControlParsing(
+      'field("IOGRec.""Location Code"""; IOGRec."Location Code")',
+      ALObjectType.page,
+      ALControlType.pageField,
+      'IOGRec."Location Code"',
+      'IOGRec."Location Code"'
+    );
+
+    testAlControlParsing(
+      'field("gGLAccount.""No.""";gGLAccount."No.")',
+      ALObjectType.page,
+      ALControlType.pageField,
+      'gGLAccount."No."',
+      'gGLAccount."No."'
+    );
+
+    testAlControlParsing(
+      'part("Table Setup"; "QWESR External System Subp.")',
+      ALObjectType.page,
+      ALControlType.part,
+      "Table Setup",
+      "QWESR External System Subp."
+    );
+
+    testAlControlParsing(
+      'dataitem(ExtSystemSyncHistoryLine; "QWESR Ext. Sys. Sync Hist. Lne")',
+      ALObjectType.report,
+      ALControlType.dataItem,
+      "ExtSystemSyncHistoryLine"
+    );
+
+    testAlControlParsing(
+      'field(11; "Change Type"; Enum "QWESR Ext. Sys. Change Type")',
+      ALObjectType.table,
+      ALControlType.tableField,
+      "Change Type",
+      'Enum "QWESR Ext. Sys. Change Type"'
+    );
+  });
+
+  function testAlControlParsing(
+    codeLine: string,
+    objectType: ALObjectType,
+    alControlType: ALControlType,
+    name: string,
+    value?: string
+  ): void {
+    const alControl = ALParser.matchALControl(
+      new ALObject([], objectType, 0, "DUMMY"),
+      0,
+      new ALCodeLine(codeLine, 0)
+    );
+    assert.ok(
+      alControl,
+      `Line '${codeLine}' could not be parsed as an ALControl`
+    );
+    assert.strictEqual(
+      alControl.name,
+      name,
+      `Unexpected name from line '${codeLine}'`
+    );
+    assert.strictEqual(
+      alControl.type,
+      alControlType,
+      `Unexpected type from line '${codeLine}'`
+    );
+    if (value) {
+      switch (alControlType) {
+        case ALControlType.pageField:
+          assert.strictEqual(
+            (alControl as ALPageField).value,
+            value,
+            `Unexpected value from line '${codeLine}'`
+          );
+          break;
+        case ALControlType.part:
+          assert.strictEqual(
+            (alControl as ALPagePart).value,
+            value,
+            `Unexpected value from line '${codeLine}'`
+          );
+          break;
+        case ALControlType.tableField:
+          assert.strictEqual(
+            (alControl as ALTableField).dataType,
+            value,
+            `Unexpected value from line '${codeLine}'`
+          );
+          break;
+        default:
+          break;
+      }
+    }
+  }
 
   test("Procedure parsing", function () {
     testProcedure(

--- a/extension/src/test/ALParser.test.ts
+++ b/extension/src/test/ALParser.test.ts
@@ -433,8 +433,6 @@ suite("Classes.AL Functions Tests", function () {
             `Unexpected value from line '${codeLine}'`
           );
           break;
-        default:
-          break;
       }
     }
   }

--- a/extension/src/test/AlFunctions.test.ts
+++ b/extension/src/test/AlFunctions.test.ts
@@ -7,35 +7,56 @@ import * as ALParser from "../ALObject/ALParser";
 
 suite("Classes.AL Functions Tests", function () {
   test("AL Fnv", function () {
-    assert.equal(AlFunctions.alFnv("MyPage"), 2931038265, "Value: MyPage");
-    assert.equal(
+    assert.strictEqual(
+      AlFunctions.alFnv("MyPage"),
+      2931038265,
+      "Value: MyPage"
+    );
+    assert.strictEqual(
       AlFunctions.alFnv("ActionName"),
       1692444235,
       "Value: ActionName"
     );
-    assert.equal(AlFunctions.alFnv("OnAction"), 1377591017, "Value: OnAction");
-    assert.equal(
+    assert.strictEqual(
+      AlFunctions.alFnv("OnAction"),
+      1377591017,
+      "Value: OnAction"
+    );
+    assert.strictEqual(
       AlFunctions.alFnv("TestOnActionErr"),
       2384180296,
       "Value: TestOnActionErr"
     );
-    assert.equal(
+    assert.strictEqual(
       AlFunctions.alFnv("TestProcLocal"),
       1531128287,
       "Value: TestProcLocal"
     );
-    assert.equal(
+    assert.strictEqual(
       AlFunctions.alFnv("MyFieldOption"),
       2443090863,
       "Value: MyFieldOption"
     );
-    assert.equal(
+    assert.strictEqual(
       AlFunctions.alFnv("OptionCaption"),
       62802879,
       "Value: OptionCaption"
     );
-    assert.equal(AlFunctions.alFnv("MyTable"), 2328808854, "Value: MyTable");
-    assert.equal(AlFunctions.alFnv("MyField"), 1296262074, "Value: MyField");
+    assert.strictEqual(
+      AlFunctions.alFnv("MyTable"),
+      2328808854,
+      "Value: MyTable"
+    );
+    assert.strictEqual(
+      AlFunctions.alFnv("MyField"),
+      1296262074,
+      "Value: MyField"
+    );
+    assert.strictEqual(
+      AlFunctions.alFnv('IOGRec."Location Code"'),
+      1570783645,
+      'Value: IOGRec."Location Code"'
+    );
     // assert.equal(, AlFunctions.AlFnv(''),'Value: ');
   });
 


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
Fixes #248.

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- Replace "double double quotes" in control names
- Added tests for parsing control names
