### PR TITLE
External Docs improvements

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -37,8 +37,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
           - `<code lang="json">{code: "theCode"}</code>`
           - `<code language="al">Message('Hello World!');</code>`
       - If no language attribute is used, `al` will be used as the default language.
-        - To enable `al` in highlight.js, <https://github.com/microsoft/AL/blob/master/highlightjs_al/dist/al.min.js> can be used.
+        - To enable `al` in [highlight.js](https://highlightjs.org/), <https://github.com/microsoft/AL/blob/master/highlightjs_al/dist/al.min.js> can be used.
       - The language attribute is ignored for inline code.
+    - Fields and Sub Pages are printed on API pages and WebServices pages.
+    - The first line of the XmlComment `Summary` is now printed for table fields and page controls (Fields, Actions, Parts).
 - Changes:
   - A change has been made to the generated External Documentation (created from the `NAB: Generate External Documentation`):
     - The procedure signatures now gets the default language `al`. See above for info on highlight.js.

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -25,6 +25,23 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
       - etc.
     - After the PermissionSet objects has been created, the old Xml PermissionSet files are deleted.
     - An upgrade codeunit is created that maps the usage of the old Xml PermissionSet to the new PermissionSet object.
+  - A few additions has been made to the generated External Documentation (created from the `NAB: Generate External Documentation`):
+    - Inline code tags is now supported.
+      - The `<code>` element is considered an inline code if there is a non-whitespace character on the line before the `<code>` tag and the `<code>` and `</code>` are on the same line.
+        - `/// This is an <code>inline</code> code`
+      - The `<code>` element is considered an code block if the `<code>` tag is on the beginning of the line.
+        - `/// <code>This is a code block</code>`
+    - Code blocks in XmlComments now supports a language attribute
+      - Add the attribute `"language"` (or `"lang"` as a shorthand) to the `code` element
+        - Examples:
+          - `<code lang="json">{code: "theCode"}</code>`
+          - `<code language="al">Message('Hello World!');</code>`
+      - If no language attribute is used, `al` will be used as the default language.
+        - To enable `al` in highlight.js, <https://github.com/microsoft/AL/blob/master/highlightjs_al/dist/al.min.js> can be used.
+      - The language attribute is ignored for inline code.
+- Changes:
+  - A change has been made to the generated External Documentation (created from the `NAB: Generate External Documentation`):
+    - The procedure signatures now gets the default language `al`. See above for info on highlight.js.
 
 ## [1.10] - 2021-12-20
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -243,7 +243,7 @@ Generates documentation that is intended to be used as an external documentation
 
 The content is generated from the AL code and the [XML Comments](https://docs.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-xml-comments) that are written in the AL code.
 
-In the first release the following XML Comments are supported
+The following XML Comments are currently supported
 
 - `<summary>`
 - `<param>`
@@ -251,7 +251,7 @@ In the first release the following XML Comments are supported
 - `<remarks>`
 - `<example>`
 
-The following formatting tags are supported in the first release
+The following formatting tags are currently supported
 
 - `<para>`
 - `<b>`
@@ -259,11 +259,11 @@ The following formatting tags are supported in the first release
 - `<c>`
 - `<code>`
 
-The first line in the summary tag for object, procedure or event are used for all objects, procedures or events overview pages in the documentation.
+The first line in the summary tag for object, fields, actions, parts, procedure or event are used for all objects, procedures or events overview pages in the documentation.
 
 There are three types of files that are created with their own index page. The different index files will only be created if there are any objects of that type.
 
-- "Public Objects" - Objects that has either public procedures or public events. Can be Codeunits, Tables, Table Extensions, Pages, Page Extensions or Interfaces.
+- "Public Objects" - Objects that has either public procedures or public events. Can be Codeunits, Tables, Table Extensions, Pages, Page Extensions, Enums or Interfaces.
 - "API" - API Pages and API Queries
 - "Web Services" - Pages or Codeunits that are published as Web Services through a webservices.xml file
 

--- a/extension/src/ALObject/ALElementTypes.ts
+++ b/extension/src/ALObject/ALElementTypes.ts
@@ -365,6 +365,24 @@ export class ALControl extends ALElement {
       return arr;
     }
   }
+  public getProperty(
+    property: ALPropertyType,
+    defaultValue: boolean | string | number
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): any {
+    const prop = this.properties.filter((x) => x.type === property)[0];
+    if (!prop) {
+      return defaultValue;
+    }
+
+    if (isBoolean(defaultValue)) {
+      return prop.value.toLowerCase() === "true";
+    }
+    if (isNumber(defaultValue)) {
+      return parseInt(prop.value);
+    }
+    return prop.value;
+  }
 }
 
 export class ALProperty extends ALElement {
@@ -666,25 +684,6 @@ export class ALObject extends ALControl {
       );
     }
     return sourceObject;
-  }
-
-  public getProperty(
-    property: ALPropertyType,
-    defaultValue: boolean | string | number
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ): any {
-    const prop = this.properties.filter((x) => x.type === property)[0];
-    if (!prop) {
-      return defaultValue;
-    }
-
-    if (isBoolean(defaultValue)) {
-      return prop.value.toLowerCase() === "true";
-    }
-    if (isNumber(defaultValue)) {
-      return parseInt(prop.value);
-    }
-    return prop.value;
   }
 
   public getDocsFolderName(docsType: DocsType): string {

--- a/extension/src/ALObject/ALPageField.ts
+++ b/extension/src/ALObject/ALPageField.ts
@@ -1,5 +1,6 @@
 import { ALPageControl } from "./ALPageControl";
-import { ALControlType } from "./Enums";
+import { ALTableField } from "./ALTableField";
+import { ALControlType, ALPropertyType } from "./Enums";
 
 export class ALPageField extends ALPageControl {
   public get caption(): string {
@@ -9,14 +10,27 @@ export class ALPageField extends ALPageControl {
     }
 
     // Check table for caption
-    const objects = this.getAllObjects(true);
-    if (objects === undefined) {
-      return "";
+    const field = this.getSourceTableField();
+    return field ? field.caption : "";
+  }
+
+  public get readOnly(): boolean {
+    if (!this.getProperty(ALPropertyType.editable, true)) {
+      return true;
+    }
+    if (this.getObject()?.readOnly) {
+      return true;
     }
 
+    // Check table field
+    const field = this.getSourceTableField();
+    return field ? !field.getProperty(ALPropertyType.editable, true) : false;
+  }
+
+  private getSourceTableField(): ALTableField | undefined {
     const sourceObject = this.getObject().getSourceObject();
     if (sourceObject === undefined) {
-      return "";
+      return undefined;
     }
 
     const allControls = sourceObject.getAllControls();
@@ -24,6 +38,6 @@ export class ALPageField extends ALPageControl {
       (x) => x.type === ALControlType.tableField
     );
     const field = fields.find((x) => x.name === this.value);
-    return field ? field.caption : "";
+    return field as ALTableField;
   }
 }

--- a/extension/src/ALObject/ALPagePart.ts
+++ b/extension/src/ALObject/ALPagePart.ts
@@ -1,6 +1,6 @@
 import { ALObject } from "./ALElementTypes";
 import { ALPageControl } from "./ALPageControl";
-import { ALControlType, ALObjectType } from "./Enums";
+import { ALControlType, ALObjectType, ALPropertyType } from "./Enums";
 
 export class ALPagePart extends ALPageControl {
   constructor(type: ALControlType, name: string, value: string) {
@@ -20,6 +20,19 @@ export class ALPagePart extends ALPageControl {
     }
     const relatedObj = this.relatedObject();
     return relatedObj ? relatedObj.caption : "";
+  }
+
+  public get readOnly(): boolean {
+    if (!this.getProperty(ALPropertyType.editable, true)) {
+      return true;
+    }
+    if (this.getObject().readOnly) {
+      return true;
+    }
+
+    // Check related page
+    const relatedPage = this.relatedObject(true);
+    return relatedPage ? relatedPage.readOnly : false;
   }
 
   public relatedObject(includeSymbolObjects = false): ALObject | undefined {

--- a/extension/src/ALObject/ALXmlComment.ts
+++ b/extension/src/ALObject/ALXmlComment.ts
@@ -92,10 +92,21 @@ export class ALXmlComment {
     } else {
       // Paragraph
       text = text.replace(/<para>\s*(.*?)\s*<\/para>/gi, "\n\n$1\n\n"); // .*? = non-greedy match all
-      // Code block
+      // Code
+      // Inline comments. Something else than whitespace before <code>. Ignores language attribute
       text = text.replace(
-        /<code>\s*(.*?)\s*<\/code>/gis,
-        "\n```javascript\n$1\n```"
+        /^(?<preText>.*?[\S]+.*?)<code( lang(uage)?="(?<language>[\w-]+)")?>(?<code>[^<]*)<\/code>(?<postText>.*)/gim,
+        "$<preText>`$<code>`$<postText>"
+      );
+      // Code block without language attribute
+      text = text.replace(
+        /<code>[\r\n]*(?<code>[^<]*?)\s*<\/code>/gis,
+        "```al\n$<code>\n```"
+      );
+      // Code block with language/lang attribute
+      text = text.replace(
+        /<code lang(uage)?="(?<language>[\w-]+)">[\r\n]*(?<code>[^<]*?)\s*<\/code>/gis,
+        "```$<language>\n$<code>\n```"
       );
       // Parameter ref.
       text = text.replace(

--- a/extension/src/ALObject/ALXmlComment.ts
+++ b/extension/src/ALObject/ALXmlComment.ts
@@ -9,7 +9,7 @@ export class ALXmlComment {
   remarks: string | undefined = undefined;
 
   public get summaryShort(): string {
-    let summary = this.summary ? this.summary : "";
+    let summary = this.summary ?? "";
     const summaryArr = summary.split("\n");
     summary = summaryArr[0];
     summary = summary.replace(/<paramref\s*name\s*=\s*"(.*?)"\s*\/>/gi, "$1");

--- a/extension/src/Documentation.ts
+++ b/extension/src/Documentation.ts
@@ -28,6 +28,7 @@ import { ALPagePart } from "./ALObject/ALPagePart";
 import { ALTableField } from "./ALObject/ALTableField";
 import { AppManifest, Settings } from "./Settings/Settings";
 import { ALEnumValue } from "./ALObject/ALEnumValue";
+import { ALPageField } from "./ALObject/ALPageField";
 
 const extensionPackage = SettingsLoader.getExtensionPackage();
 const extensionVersion = extensionPackage.version;
@@ -1026,10 +1027,13 @@ export async function generateExternalDocumentation(
           controls.find((x) => x.xmlComment?.summary !== undefined) !==
           undefined;
         controls.forEach((control) => {
-          const controlCaption = control.caption.trim();
+          const readOnly =
+            control.type === ALControlType.part
+              ? (control as ALPagePart).readOnly
+              : (control as ALPageField).readOnly;
           controlsContent += `| ${controlTypeToText(control)} | ${
             control.name
-          } | ${controlCaption} |${
+          } | ${readOnly ? "yes" : ""} |${
             printSummary
               ? ` ${
                   control.xmlComment?.summary
@@ -1044,7 +1048,7 @@ export async function generateExternalDocumentation(
         });
         if (controlsContent !== "") {
           objectIndexContent += `## Controls\n\n`;
-          objectIndexContent += `| Type | Name | Caption |${
+          objectIndexContent += `| Type | Name | Read-only |${
             printSummary ? " Documentation |" : ""
           }\n`;
           objectIndexContent += `| ---- | ------- | ----------- |${
@@ -1076,9 +1080,14 @@ export async function generateExternalDocumentation(
           controls.find((x) => x.xmlComment?.summary !== undefined) !==
           undefined;
         controls.forEach((control) => {
+          const readOnly =
+            control.type === ALControlType.part
+              ? (control as ALPagePart).readOnly
+              : (control as ALPageField).readOnly;
+
           controlsContent += `| ${controlTypeToText(control)} | ${
             control.name
-          } |${
+          } | ${readOnly ? "yes" : ""} |${
             printSummary
               ? ` ${
                   control.xmlComment?.summary
@@ -1093,10 +1102,10 @@ export async function generateExternalDocumentation(
         });
         if (controlsContent !== "") {
           objectIndexContent += `## Controls\n\n`;
-          objectIndexContent += `| Type | Name |${
+          objectIndexContent += `| Type | Name | Read-only |${
             printSummary ? " Documentation |" : ""
           }\n`;
-          objectIndexContent += `| ---- | ------- |${
+          objectIndexContent += `| ---- | ------- | ------- |${
             printSummary ? " ------------- |" : ""
           }\n`;
           objectIndexContent += controlsContent;

--- a/extension/src/Documentation.ts
+++ b/extension/src/Documentation.ts
@@ -912,11 +912,20 @@ export async function generateExternalDocumentation(
         (o) => !o.isObsoletePending() && !o.isObsolete()
       );
       if (fields.length > 0) {
+        const printSummary =
+          fields.find((x) => x.xmlComment !== undefined) !== undefined;
+
         objectIndexContent += `## Fields\n\n`;
-        objectIndexContent += "| Number | Name | Type |\n";
-        objectIndexContent += "| ---- | ------- | ----------- |\n";
+        objectIndexContent += `| Number | Name | Type |${
+          printSummary ? " Documentation |" : ""
+        }\n`;
+        objectIndexContent += `| ---- | ------- | ----------- |${
+          printSummary ? " ------------- |" : ""
+        }\n`;
         fields.forEach((field) => {
-          objectIndexContent += `| ${field.id} | ${field.name} | ${field.dataType} |\n`;
+          objectIndexContent += `| ${field.id} | ${field.name} | ${
+            field.dataType
+          } |${printSummary ? ` ${field.xmlComment?.summaryShort} |` : ""}\n`;
         });
         objectIndexContent += "\n";
       }
@@ -931,6 +940,8 @@ export async function generateExternalDocumentation(
 
       if (controls.length > 0) {
         let controlsContent = "";
+        const printSummary =
+          controls.find((x) => x.xmlComment !== undefined) !== undefined;
         controls.forEach((control) => {
           const toolTipText = control.toolTip;
           const controlCaption = control.caption.trim();
@@ -942,18 +953,25 @@ export async function generateExternalDocumentation(
                 settings,
                 control as ALPagePart,
                 true
-              )} |\n`;
+              )} |`;
             }
           } else {
             controlsContent += `| ${controlTypeToText(
               control
-            )} | ${controlCaption} | ${toolTipText} |\n`;
+            )} | ${controlCaption} | ${toolTipText} |`;
           }
+          controlsContent += `${
+            printSummary ? ` ${control.xmlComment?.summaryShort} |` : ""
+          }\n`;
         });
         if (controlsContent !== "") {
           objectIndexContent += `## Controls\n\n`;
-          objectIndexContent += "| Type | Caption | Description |\n";
-          objectIndexContent += "| ---- | ------- | ----------- |\n";
+          objectIndexContent += `| Type | Caption | Description |${
+            printSummary ? " Documentation |" : ""
+          }\n`;
+          objectIndexContent += `| ---- | ------- | ----------- |${
+            printSummary ? " ------------- |" : ""
+          }\n`;
           objectIndexContent += controlsContent;
           objectIndexContent += "\n";
         }

--- a/extension/src/Documentation.ts
+++ b/extension/src/Documentation.ts
@@ -1298,7 +1298,7 @@ function removePrefix(
 }
 
 function codeBlock(code: string): string {
-  let result = "```javascript\n";
+  let result = "```al\n";
   result += code;
   result += "\n```\n\n";
   return result;

--- a/extension/src/Documentation.ts
+++ b/extension/src/Documentation.ts
@@ -918,7 +918,7 @@ export async function generateExternalDocumentation(
 
         objectIndexContent += `## Fields\n\n`;
         objectIndexContent += `| Number | Name | Type |${
-          printSummary ? " Documentation |" : ""
+          printSummary ? " Description |" : ""
         }\n`;
         objectIndexContent += `| ---- | ------- | ----------- |${
           printSummary ? " ------------- |" : ""
@@ -994,8 +994,8 @@ export async function generateExternalDocumentation(
         });
         if (controlsContent !== "") {
           objectIndexContent += `## Controls\n\n`;
-          objectIndexContent += `| Type | Caption | Description |${
-            printSummary ? " Documentation |" : ""
+          objectIndexContent += `| Type | Caption | ToolTip |${
+            printSummary ? " Description |" : ""
           }\n`;
           objectIndexContent += `| ---- | ------- | ----------- |${
             printSummary ? " ------------- |" : ""
@@ -1049,7 +1049,7 @@ export async function generateExternalDocumentation(
         if (controlsContent !== "") {
           objectIndexContent += `## Controls\n\n`;
           objectIndexContent += `| Type | Name | Read-only |${
-            printSummary ? " Documentation |" : ""
+            printSummary ? " Description |" : ""
           }\n`;
           objectIndexContent += `| ---- | ------- | ----------- |${
             printSummary ? " ------------- |" : ""
@@ -1103,7 +1103,7 @@ export async function generateExternalDocumentation(
         if (controlsContent !== "") {
           objectIndexContent += `## Controls\n\n`;
           objectIndexContent += `| Type | Name | Read-only |${
-            printSummary ? " Documentation |" : ""
+            printSummary ? " Description |" : ""
           }\n`;
           objectIndexContent += `| ---- | ------- | ------- |${
             printSummary ? " ------------- |" : ""

--- a/extension/src/Documentation.ts
+++ b/extension/src/Documentation.ts
@@ -907,103 +907,20 @@ export async function generateExternalDocumentation(
         object.objectType
       )
     ) {
-      const fields = (object.controls.filter(
-        (o) => o.type === ALControlType.tableField
-      ) as ALTableField[]).filter(
-        (o) => !o.isObsoletePending() && !o.isObsolete()
-      );
-      if (fields.length > 0) {
-        const printSummary =
-          fields.find((x) => x.xmlComment?.summary !== undefined) !== undefined;
-
-        objectIndexContent += `## Fields\n\n`;
-        objectIndexContent += `| Number | Name | Type |${
-          printSummary ? " Description |" : ""
-        }\n`;
-        objectIndexContent += `| ---- | ------- | ----------- |${
-          printSummary ? " ------------- |" : ""
-        }\n`;
-        fields.forEach((field) => {
-          objectIndexContent += `| ${field.id} | ${field.name} | ${
-            field.dataType
-          } |${
-            printSummary
-              ? ` ${
-                  field.xmlComment?.summary
-                    ? ALXmlComment.formatMarkDown({
-                        text: field.xmlComment.summary,
-                        inTableCell: true,
-                      })
-                    : ""
-                } |`
-              : ""
-          }\n`;
-        });
-        objectIndexContent += "\n";
-      }
+      objectIndexContent += getTableFieldsTable(object);
     }
+
     if (
       [ALObjectType.page, ALObjectType.pageExtension].includes(
         object.objectType
       ) &&
       pageType === DocsType.public
     ) {
-      let controls = getAlControlsToPrint(object, ignoreTransUnitsSetting);
-      controls = controls.filter((c) => !c.isObsoletePending(false));
-
-      if (controls.length > 0) {
-        let controlsContent = "";
-        const printSummary =
-          controls.find((x) => x.xmlComment?.summary !== undefined) !==
-          undefined;
-        controls.forEach((control) => {
-          const toolTipText = control.toolTip;
-          const controlCaption = control.caption.trim();
-          let addedContent = false;
-          if (control.type === ALControlType.part) {
-            if (getPagePartText(settings, control as ALPagePart, true) !== "") {
-              addedContent = true;
-              controlsContent += `| ${controlTypeToText(
-                control
-              )} | ${controlCaption} | ${getPagePartText(
-                settings,
-                control as ALPagePart,
-                true
-              )} |`;
-            }
-          } else {
-            addedContent = true;
-            controlsContent += `| ${controlTypeToText(
-              control
-            )} | ${controlCaption} | ${toolTipText} |`;
-          }
-          if (addedContent) {
-            controlsContent += `${
-              printSummary
-                ? ` ${
-                    control.xmlComment?.summary
-                      ? ALXmlComment.formatMarkDown({
-                          text: control.xmlComment.summary,
-                          inTableCell: true,
-                        })
-                      : ""
-                  } |`
-                : ""
-            }\n`;
-          }
-        });
-        if (controlsContent !== "") {
-          objectIndexContent += `## Controls\n\n`;
-          objectIndexContent += `| Type | Caption | ToolTip |${
-            printSummary ? " Description |" : ""
-          }\n`;
-          objectIndexContent += `| ---- | ------- | ----------- |${
-            printSummary ? " ------------- |" : ""
-          }\n`;
-          objectIndexContent += controlsContent;
-          objectIndexContent += "\n";
-        }
-      }
+      objectIndexContent += getPageFieldsTable(
+        object,
+        ignoreTransUnitsSetting,
+        settings
+      );
     }
 
     if (
@@ -1012,153 +929,24 @@ export async function generateExternalDocumentation(
       ) &&
       pageType === DocsType.api
     ) {
-      const allControls = object.getAllControls();
-      let controls = allControls.filter(
-        (control) =>
-          control.type === ALControlType.pageField ||
-          control.type === ALControlType.part
-      );
-
-      controls = controls.filter((c) => !c.isObsoletePending(false));
-
-      if (controls.length > 0) {
-        let controlsContent = "";
-        const printSummary =
-          controls.find((x) => x.xmlComment?.summary !== undefined) !==
-          undefined;
-        controls.forEach((control) => {
-          const readOnly =
-            control.type === ALControlType.part
-              ? (control as ALPagePart).readOnly
-              : (control as ALPageField).readOnly;
-          controlsContent += `| ${controlTypeToText(control)} | ${
-            control.name
-          } | ${readOnly ? "yes" : ""} |${
-            printSummary
-              ? ` ${
-                  control.xmlComment?.summary
-                    ? ALXmlComment.formatMarkDown({
-                        text: control.xmlComment.summary,
-                        inTableCell: true,
-                      })
-                    : ""
-                } |`
-              : ""
-          }\n`;
-        });
-        if (controlsContent !== "") {
-          objectIndexContent += `## Controls\n\n`;
-          objectIndexContent += `| Type | Name | Read-only |${
-            printSummary ? " Description |" : ""
-          }\n`;
-          objectIndexContent += `| ---- | ------- | ----------- |${
-            printSummary ? " ------------- |" : ""
-          }\n`;
-          objectIndexContent += controlsContent;
-          objectIndexContent += "\n";
-        }
-      }
+      objectIndexContent += getApiPageFieldsTable(object);
     }
+
     if (
       [ALObjectType.page, ALObjectType.pageExtension].includes(
         object.objectType
       ) &&
       pageType === DocsType.ws
     ) {
-      const allControls = object.getAllControls();
-      let controls = allControls.filter(
-        (control) =>
-          control.type === ALControlType.pageField ||
-          control.type === ALControlType.part
-      );
-
-      controls = controls.filter((c) => !c.isObsoletePending(false));
-
-      if (controls.length > 0) {
-        let controlsContent = "";
-        const printSummary =
-          controls.find((x) => x.xmlComment?.summary !== undefined) !==
-          undefined;
-        controls.forEach((control) => {
-          const readOnly =
-            control.type === ALControlType.part
-              ? (control as ALPagePart).readOnly
-              : (control as ALPageField).readOnly;
-
-          controlsContent += `| ${controlTypeToText(control)} | ${
-            control.name
-          } | ${readOnly ? "yes" : ""} |${
-            printSummary
-              ? ` ${
-                  control.xmlComment?.summary
-                    ? ALXmlComment.formatMarkDown({
-                        text: control.xmlComment.summary,
-                        inTableCell: true,
-                      })
-                    : ""
-                } |`
-              : ""
-          }\n`;
-        });
-        if (controlsContent !== "") {
-          objectIndexContent += `## Controls\n\n`;
-          objectIndexContent += `| Type | Name | Read-only |${
-            printSummary ? " Description |" : ""
-          }\n`;
-          objectIndexContent += `| ---- | ------- | ------- |${
-            printSummary ? " ------------- |" : ""
-          }\n`;
-          objectIndexContent += controlsContent;
-          objectIndexContent += "\n";
-        }
-      }
+      objectIndexContent += getWsPageFieldsTable(object);
     }
 
     if (object.objectType === ALObjectType.enum) {
-      const values = (object.controls.filter(
-        (o) => o.type === ALControlType.enumValue
-      ) as ALEnumValue[]).filter(
-        (o) => !o.isObsoletePending() && !o.isObsolete()
-      );
-      if (values.length > 0) {
-        objectIndexContent += `## Values\n\n`;
-        objectIndexContent += "| Number | Name | Description |\n";
-        objectIndexContent += "| ---- | ------- | ----------- |\n";
-        values.forEach((value) => {
-          objectIndexContent += `| ${value.id} | ${value.name} | ${
-            value.xmlComment?.summary
-              ? ALXmlComment.formatMarkDown({
-                  text: value.xmlComment.summary,
-                  inTableCell: true,
-                })
-              : ""
-          } |\n`;
-        });
-        objectIndexContent += "\n";
-      }
+      objectIndexContent += getEnumTable(object);
     }
 
     if (!obsoletePendingInfo) {
-      const allControls = object.getAllControls();
-      const obsoleteControls = allControls.filter(
-        (x) => x.isObsoletePending(false) && x.type !== ALControlType.procedure
-      );
-      if (obsoleteControls.length > 0) {
-        objectIndexContent += `## Deprecated Controls\n\n`;
-        objectIndexContent += `| Type | Name | Reason | Deprecated since |\n`;
-        objectIndexContent += `| ---- | ---- | ------ | ---------------- |\n`;
-        obsoleteControls.forEach((control) => {
-          const obsoleteInfo = control.getObsoletePendingInfo();
-          if (obsoleteInfo) {
-            objectIndexContent += `| ${controlTypeToText(control)} | ${
-              control.name
-            } | ${obsoleteInfo.obsoleteReason} | ${
-              obsoleteInfo.obsoleteTag
-            } |\n`;
-          }
-        });
-      }
-      objectIndexContent += "\n";
+      objectIndexContent += getObsoletePendingTable(object);
     }
 
     saveContentToFile(
@@ -1398,6 +1186,264 @@ export async function generateExternalDocumentation(
         saveContentToFile(tocFilepath, tocContent);
       }
     }
+
+    function getTableFieldsTable(object: ALObject): string {
+      let objectIndexContent = "";
+      const fields = (object.controls.filter(
+        (o) => o.type === ALControlType.tableField
+      ) as ALTableField[]).filter(
+        (o) => !o.isObsoletePending() && !o.isObsolete()
+      );
+      if (fields.length > 0) {
+        const printSummary =
+          fields.find((x) => x.xmlComment?.summary !== undefined) !== undefined;
+
+        objectIndexContent += `## Fields\n\n`;
+        objectIndexContent += `| Number | Name | Type |${
+          printSummary ? " Description |" : ""
+        }\n`;
+        objectIndexContent += `| ---- | ------- | ----------- |${
+          printSummary ? " ------------- |" : ""
+        }\n`;
+        fields.forEach((field) => {
+          objectIndexContent += `| ${field.id} | ${field.name} | ${
+            field.dataType
+          } |${
+            printSummary
+              ? ` ${
+                  field.xmlComment?.summary
+                    ? ALXmlComment.formatMarkDown({
+                        text: field.xmlComment.summary,
+                        inTableCell: true,
+                      })
+                    : ""
+                } |`
+              : ""
+          }\n`;
+        });
+        objectIndexContent += "\n";
+      }
+      return objectIndexContent;
+    }
+
+    function getPageFieldsTable(
+      object: ALObject,
+      ignoreTransUnitsSetting: string[],
+      settings: Settings
+    ): string {
+      let objectIndexContent = "";
+      let controls = getAlControlsToPrint(object, ignoreTransUnitsSetting);
+      controls = controls.filter((c) => !c.isObsoletePending(false));
+
+      if (controls.length > 0) {
+        let controlsContent = "";
+        const printSummary =
+          controls.find((x) => x.xmlComment?.summary !== undefined) !==
+          undefined;
+        controls.forEach((control) => {
+          const toolTipText = control.toolTip;
+          const controlCaption = control.caption.trim();
+          let addedContent = false;
+          if (control.type === ALControlType.part) {
+            if (getPagePartText(settings, control as ALPagePart, true) !== "") {
+              addedContent = true;
+              controlsContent += `| ${controlTypeToText(
+                control
+              )} | ${controlCaption} | ${getPagePartText(
+                settings,
+                control as ALPagePart,
+                true
+              )} |`;
+            }
+          } else {
+            addedContent = true;
+            controlsContent += `| ${controlTypeToText(
+              control
+            )} | ${controlCaption} | ${toolTipText} |`;
+          }
+          if (addedContent) {
+            controlsContent += `${
+              printSummary
+                ? ` ${
+                    control.xmlComment?.summary
+                      ? ALXmlComment.formatMarkDown({
+                          text: control.xmlComment.summary,
+                          inTableCell: true,
+                        })
+                      : ""
+                  } |`
+                : ""
+            }\n`;
+          }
+        });
+        if (controlsContent !== "") {
+          objectIndexContent += `## Controls\n\n`;
+          objectIndexContent += `| Type | Caption | ToolTip |${
+            printSummary ? " Description |" : ""
+          }\n`;
+          objectIndexContent += `| ---- | ------- | ----------- |${
+            printSummary ? " ------------- |" : ""
+          }\n`;
+          objectIndexContent += controlsContent;
+          objectIndexContent += "\n";
+        }
+      }
+      return objectIndexContent;
+    }
+
+    function getApiPageFieldsTable(object: ALObject): string {
+      let objectIndexContent = "";
+      const allControls = object.getAllControls();
+      let controls = allControls.filter(
+        (control) =>
+          control.type === ALControlType.pageField ||
+          control.type === ALControlType.part
+      );
+
+      controls = controls.filter((c) => !c.isObsoletePending(false));
+
+      if (controls.length > 0) {
+        let controlsContent = "";
+        const printSummary =
+          controls.find((x) => x.xmlComment?.summary !== undefined) !==
+          undefined;
+        controls.forEach((control) => {
+          const readOnly =
+            control.type === ALControlType.part
+              ? (control as ALPagePart).readOnly
+              : (control as ALPageField).readOnly;
+          controlsContent += `| ${controlTypeToText(control)} | ${
+            control.name
+          } | ${readOnly ? "yes" : ""} |${
+            printSummary
+              ? ` ${
+                  control.xmlComment?.summary
+                    ? ALXmlComment.formatMarkDown({
+                        text: control.xmlComment.summary,
+                        inTableCell: true,
+                      })
+                    : ""
+                } |`
+              : ""
+          }\n`;
+        });
+        if (controlsContent !== "") {
+          objectIndexContent += `## Controls\n\n`;
+          objectIndexContent += `| Type | Name | Read-only |${
+            printSummary ? " Description |" : ""
+          }\n`;
+          objectIndexContent += `| ---- | ------- | ----------- |${
+            printSummary ? " ------------- |" : ""
+          }\n`;
+          objectIndexContent += controlsContent;
+          objectIndexContent += "\n";
+        }
+      }
+      return objectIndexContent;
+    }
+
+    function getWsPageFieldsTable(object: ALObject): string {
+      let objectIndexContent = "";
+      const allControls = object.getAllControls();
+      let controls = allControls.filter(
+        (control) =>
+          control.type === ALControlType.pageField ||
+          control.type === ALControlType.part
+      );
+
+      controls = controls.filter((c) => !c.isObsoletePending(false));
+
+      if (controls.length > 0) {
+        let controlsContent = "";
+        const printSummary =
+          controls.find((x) => x.xmlComment?.summary !== undefined) !==
+          undefined;
+        controls.forEach((control) => {
+          const readOnly =
+            control.type === ALControlType.part
+              ? (control as ALPagePart).readOnly
+              : (control as ALPageField).readOnly;
+
+          controlsContent += `| ${controlTypeToText(control)} | ${
+            control.name
+          } | ${readOnly ? "yes" : ""} |${
+            printSummary
+              ? ` ${
+                  control.xmlComment?.summary
+                    ? ALXmlComment.formatMarkDown({
+                        text: control.xmlComment.summary,
+                        inTableCell: true,
+                      })
+                    : ""
+                } |`
+              : ""
+          }\n`;
+        });
+        if (controlsContent !== "") {
+          objectIndexContent += `## Controls\n\n`;
+          objectIndexContent += `| Type | Name | Read-only |${
+            printSummary ? " Description |" : ""
+          }\n`;
+          objectIndexContent += `| ---- | ------- | ------- |${
+            printSummary ? " ------------- |" : ""
+          }\n`;
+          objectIndexContent += controlsContent;
+          objectIndexContent += "\n";
+        }
+      }
+      return objectIndexContent;
+    }
+
+    function getEnumTable(object: ALObject): string {
+      let objectIndexContent = "";
+      const values = (object.controls.filter(
+        (o) => o.type === ALControlType.enumValue
+      ) as ALEnumValue[]).filter(
+        (o) => !o.isObsoletePending() && !o.isObsolete()
+      );
+      if (values.length > 0) {
+        objectIndexContent += `## Values\n\n`;
+        objectIndexContent += "| Number | Name | Description |\n";
+        objectIndexContent += "| ---- | ------- | ----------- |\n";
+        values.forEach((value) => {
+          objectIndexContent += `| ${value.id} | ${value.name} | ${
+            value.xmlComment?.summary
+              ? ALXmlComment.formatMarkDown({
+                  text: value.xmlComment.summary,
+                  inTableCell: true,
+                })
+              : ""
+          } |\n`;
+        });
+        objectIndexContent += "\n";
+      }
+      return objectIndexContent;
+    }
+
+    function getObsoletePendingTable(object: ALObject): string {
+      let objectIndexContent = "";
+      const allControls = object.getAllControls();
+      const obsoleteControls = allControls.filter(
+        (x) => x.isObsoletePending(false) && x.type !== ALControlType.procedure
+      );
+      if (obsoleteControls.length > 0) {
+        objectIndexContent += `## Deprecated Controls\n\n`;
+        objectIndexContent += `| Type | Name | Reason | Deprecated since |\n`;
+        objectIndexContent += `| ---- | ---- | ------ | ---------------- |\n`;
+        obsoleteControls.forEach((control) => {
+          const obsoleteInfo = control.getObsoletePendingInfo();
+          if (obsoleteInfo) {
+            objectIndexContent += `| ${controlTypeToText(control)} | ${
+              control.name
+            } | ${obsoleteInfo.obsoleteReason} | ${
+              obsoleteInfo.obsoleteTag
+            } |\n`;
+          }
+        });
+      }
+      objectIndexContent += "\n";
+      return objectIndexContent;
+    }
   }
 
   function saveContentToFile(
@@ -1433,6 +1479,7 @@ export async function generateExternalDocumentation(
     fs.writeFileSync(filePath, fileContent);
   }
 }
+
 function boolToText(bool: boolean): string {
   return bool ? "Yes" : "";
 }

--- a/extension/src/test/ALXmlComment.test.ts
+++ b/extension/src/test/ALXmlComment.test.ts
@@ -98,14 +98,12 @@ sadf
 asdf`,
       }),
       `asfd 
-
-\`\`\`javascript
+\`\`\`al
 code block 1
 asdf afd
 \`\`\`
 sadf
-
-\`\`\`javascript
+\`\`\`al
 code block 2
 \`\`\`
 asdf`,

--- a/extension/src/test/ALXmlComment.test.ts
+++ b/extension/src/test/ALXmlComment.test.ts
@@ -5,7 +5,7 @@ import { ALProcedure } from "../ALObject/ALProcedure";
 import * as ALObjectTestLibrary from "./ALObjectTestLibrary";
 suite("Classes.AL Functions Tests", function () {
   test("XML Comments No Line Breaks formatting", function () {
-    assert.equal(
+    assert.strictEqual(
       ALXmlComment.formatMarkDown({
         text: "asfd <para>bold 1</para> sadf <para>bold 2</para> asdf",
         inTableCell: true,
@@ -13,7 +13,7 @@ suite("Classes.AL Functions Tests", function () {
       `asfd   bold 1   sadf   bold 2   asdf`,
       "Unexpected paragraph"
     );
-    assert.equal(
+    assert.strictEqual(
       ALXmlComment.formatMarkDown({
         text: "asfd <b>bold 1</b> sadf <b>bold 2</b> asdf",
         inTableCell: true,
@@ -21,7 +21,7 @@ suite("Classes.AL Functions Tests", function () {
       "asfd **bold 1** sadf **bold 2** asdf",
       "Unexpected bold"
     );
-    assert.equal(
+    assert.strictEqual(
       ALXmlComment.formatMarkDown({
         text: "asfd <i>italic 1</i> sadf <i>italic 2</i> asdf",
         inTableCell: true,
@@ -29,7 +29,7 @@ suite("Classes.AL Functions Tests", function () {
       "asfd *italic 1* sadf *italic 2* asdf",
       "Unexpected italic"
     );
-    assert.equal(
+    assert.strictEqual(
       ALXmlComment.formatMarkDown({
         text: "asfd <c>code 1</c> sadf <c>code 2</c> asdf",
         inTableCell: true,
@@ -37,7 +37,7 @@ suite("Classes.AL Functions Tests", function () {
       "asfd `code 1` sadf `code 2` asdf",
       "Unexpected code"
     );
-    assert.equal(
+    assert.strictEqual(
       ALXmlComment.formatMarkDown({
         text: `asfd <code>code block 1
 asdf afd</code>
@@ -52,7 +52,7 @@ asdf`,
   });
 
   test("XML Comments formatting", function () {
-    assert.equal(
+    assert.strictEqual(
       ALXmlComment.formatMarkDown({
         text: "asfd <para>bold 1</para> sadf <para>bold 2</para> asdf",
       }),
@@ -67,28 +67,28 @@ bold 2
  asdf`,
       "Unexpected paragraph"
     );
-    assert.equal(
+    assert.strictEqual(
       ALXmlComment.formatMarkDown({
         text: "asfd <b>bold 1</b> sadf <b>bold 2</b> asdf",
       }),
       "asfd **bold 1** sadf **bold 2** asdf",
       "Unexpected bold"
     );
-    assert.equal(
+    assert.strictEqual(
       ALXmlComment.formatMarkDown({
         text: "asfd <i>italic 1</i> sadf <i>italic 2</i> asdf",
       }),
       "asfd *italic 1* sadf *italic 2* asdf",
       "Unexpected italic"
     );
-    assert.equal(
+    assert.strictEqual(
       ALXmlComment.formatMarkDown({
         text: "asfd <c>code 1</c> sadf <c>code 2</c> asdf",
       }),
       "asfd `code 1` sadf `code 2` asdf",
       "Unexpected code"
     );
-    assert.equal(
+    assert.strictEqual(
       ALXmlComment.formatMarkDown({
         text: `asfd 
 <code>code block 1
@@ -121,82 +121,94 @@ asdf`,
     }
     let proc: ALProcedure;
     proc = <ALProcedure>alObj.controls[0];
-    assert.equal(alObj.controls.length, 3, "Unexpected number of procedures");
-    assert.equal(
+    assert.strictEqual(
+      alObj.controls.length,
+      3,
+      "Unexpected number of procedures"
+    );
+    assert.strictEqual(
       alObj.xmlComment?.summary,
       "The Summary",
       "Unexpected summary_"
     );
-    assert.equal(
+    assert.strictEqual(
       proc.xmlComment?.summary,
       "The Function Summary",
       "Unexpected function summary"
     );
-    assert.equal(
+    assert.strictEqual(
       proc.xmlComment?.parameters[0].name,
       "Parameter",
       "Unexpected parameter name"
     );
-    assert.equal(
+    assert.strictEqual(
       proc.xmlComment?.parameters[0].description,
       "The first parameter",
       "Unexpected description"
     );
-    assert.equal(
+    assert.strictEqual(
       proc.xmlComment?.parameters[1].name,
       "pvRecRef",
       "Unexpected parameter name 2"
     );
-    assert.equal(
+    assert.strictEqual(
       proc.xmlComment?.parameters[1].description,
       "The second parameter",
       "Unexpected description 2"
     );
     proc = <ALProcedure>alObj.controls[1];
-    assert.equal(
+    assert.strictEqual(
       proc.xmlComment?.summary,
       "The 2nd Summary",
       "Unexpected function summary 2"
     );
-    assert.equal(proc.name, "TheProcedure2", "Unexpected function name 2");
-    assert.equal(
+    assert.strictEqual(
+      proc.name,
+      "TheProcedure2",
+      "Unexpected function name 2"
+    );
+    assert.strictEqual(
       proc.parameters[0].name,
       "Parameter",
       "Unexpected function parameter 2"
     );
-    assert.equal(
+    assert.strictEqual(
       proc.parameters[1].name,
       "pvRecRef",
       "Unexpected function parameter 3"
     );
-    assert.equal(
+    assert.strictEqual(
       proc.parameters[1].datatype,
       "RecordRef",
       "Unexpected function parameter datatype 3"
     );
-    assert.equal(
+    assert.strictEqual(
       proc.parameters[2].name,
       "pvParameter",
       "Unexpected function parameter 4"
     );
-    assert.equal(
+    assert.strictEqual(
       proc.parameters[2].fullDataType,
       'Record "Table" temporary',
       "Unexpected function parameter datatype 4"
     );
     proc = <ALProcedure>alObj.controls[2];
-    assert.equal(
+    assert.strictEqual(
       proc.xmlComment?.summary,
       "The 3rd Summary",
       "Unexpected function summary 3"
     );
-    assert.equal(proc.name, "TheProcedure2", "Unexpected function name 3");
-    assert.equal(
+    assert.strictEqual(
+      proc.name,
+      "TheProcedure2",
+      "Unexpected function name 3"
+    );
+    assert.strictEqual(
       proc.parameters[0].name,
       "pvParameter",
       "Unexpected function parameter 3.1"
     );
-    assert.equal(
+    assert.strictEqual(
       proc.parameters[0].fullDataType,
       'Record "Table" temporary',
       "Unexpected function parameter datatype 2.1"
@@ -211,64 +223,68 @@ asdf`,
     if (!alObj) {
       assert.fail("Could not find object");
     }
-    assert.equal(
+    assert.strictEqual(
       alObj.xmlComment?.summary,
       "The Summary",
       "Unexpected summary_"
     );
-    assert.equal(
+    assert.strictEqual(
       alObj.controls[0].xmlComment?.summary,
       "The Function Summary",
       "Unexpected function summary"
     );
-    assert.equal(
+    assert.strictEqual(
       alObj.controls[0].xmlComment?.parameters[0].name,
       "Parameter",
       "Unexpected parameter name"
     );
-    assert.equal(
+    assert.strictEqual(
       alObj.controls[0].xmlComment?.parameters[0].description,
       "The <c>first</c> parameter",
       "Unexpected description"
     );
-    assert.equal(
+    assert.strictEqual(
       alObj.controls[0].xmlComment?.parameters[1].name,
       "pvRecRef",
       "Unexpected parameter name 2"
     );
-    assert.equal(
+    assert.strictEqual(
       alObj.controls[0].xmlComment?.parameters[1].description,
       "The second parameter",
       "Unexpected description 2"
     );
-    assert.equal(
+    assert.strictEqual(
       alObj.controls[1].xmlComment?.summary,
       "The 2nd Summary",
       "Unexpected function summary 2"
     );
     const proc: ALProcedure = <ALProcedure>alObj.controls[1];
-    assert.equal(proc.name, "TheProcedure2", "Unexpected function name 2");
-    assert.equal(
+    assert.strictEqual(
+      proc.name,
+      "TheProcedure2",
+      "Unexpected function name 2"
+    );
+    assert.strictEqual(
       proc.parameters[0].name,
       "Parameter",
       "Unexpected function parameter 2"
     );
-    assert.equal(
+    assert.strictEqual(
       proc.parameters[1].name,
       "pvRecRef",
       "Unexpected function parameter 3"
     );
-    assert.equal(
+    assert.strictEqual(
       proc.parameters[1].datatype,
       "RecordRef",
       "Unexpected function parameter datatype 3"
     );
-    assert.equal(
+    assert.strictEqual(
       proc.parameters[2].name,
       "pvParameter",
       "Unexpected function parameter 4"
     );
-    assert.equal(
+    assert.strictEqual(
       proc.parameters[2].fullDataType,
       'Record "Table" temporary',
       "Unexpected function parameter datatype 4"


### PR DESCRIPTION
<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

A few additions has been made to the generated External Documentation (created from the `NAB: Generate External Documentation`):
  - Inline code tags is now supported.
    - The `<code>` element is considered an inline code if there is a non-whitespace character on the line before the `<code>` tag and the `<code>` and `</code>` are on the same line.
      - `/// This is an <code>inline</code> code`
    - The `<code>` element is considered an code block if the `<code>` tag is on the beginning of the line.
      - `/// <code>This is a code block</code>`
  - Code blocks in XmlComments now supports a language attribute
    - Add the attribute `"language"` (or `"lang"` as a shorthand) to the `code` element
      - Examples:
        - `<code lang="json">{code: "theCode"}</code>`
        - `<code language="al">Message('Hello World!');</code>`
    - If no language attribute is used, `al` will be used as the default language.
      - To enable `al` in [highlight.js](https://highlightjs.org/), <https://github.com/microsoft/AL/blob/master/highlightjs_al/dist/al.min.js> can be used.
    - The language attribute is ignored for inline code.
  - Fields and Sub Pages are printed on API pages and WebServices pages.
  - The first line of the XmlComment `Summary` is now printed for table fields and page controls (Fields, Actions, Parts).
- A change has been made to the generated External Documentation (created from the `NAB: Generate External Documentation`):
  - The procedure signatures now gets the default language `al`. See above for info on highlight.js.