### PR TITLE
Refactor: Set TargetState from token

### DIFF
--- a/extension/src/Xliff/XLIFFDocument.ts
+++ b/extension/src/Xliff/XLIFFDocument.ts
@@ -705,15 +705,19 @@ export class TransUnit implements TransUnitInterface {
     const note = new Note(customNoteType, "general", 3, text);
     this.notes.unshift(note);
   }
+
   public removeCustomNote(customNoteType: CustomNoteType): void {
     this.notes = this.notes.filter((x) => x.from !== customNoteType);
   }
+
   public hasCustomNote(customNoteType: CustomNoteType): boolean {
     return this.customNote(customNoteType) !== undefined;
   }
+
   public customNote(customNoteType: CustomNoteType): Note {
     return this.notes.filter((x) => x.from === customNoteType)[0];
   }
+
   public customNoteContent(customNoteType: CustomNoteType): string {
     const note = this.customNote(customNoteType);
     return note ? note.textContent : "";

--- a/extension/src/Xliff/XLIFFDocument.ts
+++ b/extension/src/Xliff/XLIFFDocument.ts
@@ -760,6 +760,31 @@ export class TransUnit implements TransUnitInterface {
         targetStateActionNeededValues().includes(this.target.state))
     );
   }
+
+  public setTargetStateFromToken(): void {
+    if (this.target.state) {
+      return;
+    }
+    switch (this.target.translationToken) {
+      case TranslationToken.notTranslated:
+        this.target.state = TargetState.needsTranslation;
+        this.target.stateQualifier = undefined;
+        break;
+      case TranslationToken.review:
+        this.target.state = TargetState.needsReviewTranslation;
+        this.target.stateQualifier = undefined;
+        break;
+      case TranslationToken.suggestion:
+        this.target.state = TargetState.translated;
+        this.target.stateQualifier = StateQualifier.exactMatch;
+        break;
+      default:
+        this.target.state = TargetState.translated;
+        this.target.stateQualifier = undefined;
+        break;
+    }
+    this.target.translationToken = undefined;
+  }
 }
 
 export class Target implements TargetInterface {

--- a/extension/src/Xliff/XLIFFDocument.ts
+++ b/extension/src/Xliff/XLIFFDocument.ts
@@ -765,9 +765,9 @@ export class TransUnit implements TransUnitInterface {
     );
   }
 
-  public setTargetStateFromToken(): TransUnit {
+  public setTargetStateFromToken(): void {
     if (this.target.state) {
-      return this;
+      return;
     }
     switch (this.target.translationToken) {
       case TranslationToken.notTranslated:
@@ -788,7 +788,6 @@ export class TransUnit implements TransUnitInterface {
         break;
     }
     this.target.translationToken = undefined;
-    return this;
   }
 }
 

--- a/extension/src/Xliff/XLIFFDocument.ts
+++ b/extension/src/Xliff/XLIFFDocument.ts
@@ -765,9 +765,9 @@ export class TransUnit implements TransUnitInterface {
     );
   }
 
-  public setTargetStateFromToken(): void {
+  public setTargetStateFromToken(): TransUnit {
     if (this.target.state) {
-      return;
+      return this;
     }
     switch (this.target.translationToken) {
       case TranslationToken.notTranslated:
@@ -788,6 +788,7 @@ export class TransUnit implements TransUnitInterface {
         break;
     }
     this.target.translationToken = undefined;
+    return this;
   }
 }
 

--- a/extension/src/XliffFunctions.ts
+++ b/extension/src/XliffFunctions.ts
@@ -438,10 +438,10 @@ export function formatTransUnitForTranslationMode(
 ): void {
   switch (translationMode) {
     case TranslationMode.external:
-      setTargetStateFromToken(transUnit);
+      transUnit.setTargetStateFromToken();
       break;
     case TranslationMode.dts:
-      setTargetStateFromToken(transUnit);
+      transUnit.setTargetStateFromToken();
       // Might want to include this later, keep for now...
       // transUnit.removeDeveloperNoteIfEmpty();
       // transUnit.sizeUnit = undefined;
@@ -472,31 +472,6 @@ export function formatTransUnitForTranslationMode(
       transUnit.target.stateQualifier = undefined;
       break;
   }
-}
-
-function setTargetStateFromToken(transUnit: TransUnit): void {
-  if (transUnit.target.state !== undefined && transUnit.target.state !== null) {
-    return;
-  }
-  switch (transUnit.target.translationToken) {
-    case TranslationToken.notTranslated:
-      transUnit.target.state = TargetState.needsTranslation;
-      transUnit.target.stateQualifier = undefined;
-      break;
-    case TranslationToken.review:
-      transUnit.target.state = TargetState.needsReviewTranslation;
-      transUnit.target.stateQualifier = undefined;
-      break;
-    case TranslationToken.suggestion:
-      transUnit.target.state = TargetState.translated;
-      transUnit.target.stateQualifier = StateQualifier.exactMatch;
-      break;
-    default:
-      transUnit.target.state = TargetState.translated;
-      transUnit.target.stateQualifier = undefined;
-      break;
-  }
-  transUnit.target.translationToken = undefined;
 }
 
 export async function createSuggestionMaps(

--- a/extension/src/test/XLIFFTypes.test.ts
+++ b/extension/src/test/XLIFFTypes.test.ts
@@ -549,6 +549,7 @@ suite("Xliff Types - Functions", function () {
       "Duplicate trans-units in result"
     );
   });
+
   test("TransUnit.sourceIsEmpty", function () {
     const transUnit = TransUnit.fromString(getTransUnitXml());
     assert.strictEqual(
@@ -563,6 +564,7 @@ suite("Xliff Types - Functions", function () {
       "Source should be considered empty."
     );
   });
+
   test("TransUnit.targetIsEmpty", function () {
     const transUnit = TransUnit.fromString(getTransUnitXml());
     assert.strictEqual(
@@ -577,6 +579,7 @@ suite("Xliff Types - Functions", function () {
       "target should be considered empty."
     );
   });
+
   test("TransUnit.targetMatchesSource", function () {
     const transUnit = TransUnit.fromString(getTransUnitXml());
     assert.strictEqual(

--- a/extension/src/test/XLIFFTypes.test.ts
+++ b/extension/src/test/XLIFFTypes.test.ts
@@ -12,6 +12,7 @@ import {
   CustomNoteType,
   StateQualifier,
   targetStateActionNeededAttributes,
+  TranslationToken,
 } from "../Xliff/XLIFFDocument";
 
 suite("Xliff Types - Deserialization", function () {
@@ -637,6 +638,70 @@ suite("Xliff Types - Functions", function () {
       ],
       "Unexpected contents of array"
     );
+  });
+
+  test("TransUnit.setTargetStateFromToken", function () {
+    const tu = TransUnit.fromString(getTransUnitXml());
+    tu.setTargetStateFromToken();
+    assert.strictEqual(
+      tu.target.translationToken,
+      undefined,
+      "Expected translationToken to be undefined."
+    );
+    assert.strictEqual(
+      tu.target.state,
+      TargetState.new,
+      `Expected state "${TargetState.new}".`
+    );
+    assert.strictEqual(
+      tu.target.stateQualifier,
+      undefined,
+      "Expected stateQualifier to be undefined."
+    );
+
+    tu.target.translationToken = TranslationToken.notTranslated;
+    tu.target.state = undefined;
+    tu.setTargetStateFromToken();
+    assert.strictEqual(
+      tu.target.state,
+      TargetState.needsTranslation,
+      `Expected token "${TranslationToken.notTranslated} to set state "${TargetState.needsTranslation}".`
+    );
+    assert.strictEqual(tu.target.stateQualifier, undefined);
+    assert.strictEqual(tu.target.translationToken, undefined);
+
+    tu.target.translationToken = TranslationToken.review;
+    tu.target.state = undefined;
+    tu.setTargetStateFromToken();
+    assert.strictEqual(
+      tu.target.state,
+      TargetState.needsReviewTranslation,
+      `Expected token "${TranslationToken.review} to set state "${TargetState.needsReviewTranslation}".`
+    );
+    assert.strictEqual(tu.target.stateQualifier, undefined);
+    assert.strictEqual(tu.target.translationToken, undefined);
+
+    tu.target.translationToken = TranslationToken.suggestion;
+    tu.target.state = undefined;
+    tu.setTargetStateFromToken();
+    assert.strictEqual(
+      tu.target.state,
+      TargetState.translated,
+      `Expected token "${TranslationToken.suggestion} to set state "${TargetState.translated}".`
+    );
+    assert.strictEqual(tu.target.stateQualifier, StateQualifier.exactMatch);
+
+    // Test switch default case
+    tu.target.translationToken = undefined;
+    tu.target.state = undefined;
+    tu.setTargetStateFromToken();
+    assert.strictEqual(
+      tu.target.state,
+      TargetState.translated,
+      `Expected no TranslationToget to set state as: "${TargetState.translated}".`
+    );
+    assert.strictEqual(tu.target.stateQualifier, undefined);
+    assert.strictEqual(tu.target.translationToken, undefined);
   });
 });
 

--- a/extension/src/test/XLIFFTypes.test.ts
+++ b/extension/src/test/XLIFFTypes.test.ts
@@ -640,38 +640,9 @@ suite("Xliff Types - Functions", function () {
     );
   });
 
-  test("TransUnit.setTargetStateFromToken", function () {
-    let tu = getTransUnit(TranslationToken.notTranslated);
-    tu.setTargetStateFromToken();
-    assert.strictEqual(
-      tu.target.state,
-      TargetState.needsTranslation,
-      `Expected token "${TranslationToken.notTranslated} to set state "${TargetState.needsTranslation}".`
-    );
-    assert.strictEqual(tu.target.stateQualifier, undefined);
-    assert.strictEqual(tu.target.translationToken, undefined);
-
-    tu = getTransUnit(TranslationToken.review);
-    tu.setTargetStateFromToken();
-    assert.strictEqual(
-      tu.target.state,
-      TargetState.needsReviewTranslation,
-      `Expected token "${TranslationToken.review} to set state "${TargetState.needsReviewTranslation}".`
-    );
-    assert.strictEqual(tu.target.stateQualifier, undefined);
-    assert.strictEqual(tu.target.translationToken, undefined);
-
-    tu = getTransUnit(TranslationToken.suggestion);
-    tu.setTargetStateFromToken();
-    assert.strictEqual(
-      tu.target.state,
-      TargetState.translated,
-      `Expected token "${TranslationToken.suggestion} to set state "${TargetState.translated}".`
-    );
-    assert.strictEqual(tu.target.stateQualifier, StateQualifier.exactMatch);
-
+  test("TransUnit.setTargetStateFromToken: default", function () {
     // Test switch default case
-    tu = getTransUnit();
+    const tu = getTransUnit();
     tu.setTargetStateFromToken();
     assert.strictEqual(
       tu.target.state,
@@ -680,6 +651,41 @@ suite("Xliff Types - Functions", function () {
     );
     assert.strictEqual(tu.target.stateQualifier, undefined);
     assert.strictEqual(tu.target.translationToken, undefined);
+  });
+
+  test("TransUnit.setTargetStateFromToken: notTranslated", function () {
+    const tu = getTransUnit(TranslationToken.notTranslated);
+    tu.setTargetStateFromToken();
+    assert.strictEqual(
+      tu.target.state,
+      TargetState.needsTranslation,
+      `Expected token "${TranslationToken.notTranslated} to set state "${TargetState.needsTranslation}".`
+    );
+    assert.strictEqual(tu.target.stateQualifier, undefined);
+    assert.strictEqual(tu.target.translationToken, undefined);
+  });
+
+  test("TransUnit.setTargetStateFromToken: review", function () {
+    const tu = getTransUnit(TranslationToken.review);
+    tu.setTargetStateFromToken();
+    assert.strictEqual(
+      tu.target.state,
+      TargetState.needsReviewTranslation,
+      `Expected token "${TranslationToken.review} to set state "${TargetState.needsReviewTranslation}".`
+    );
+    assert.strictEqual(tu.target.stateQualifier, undefined);
+    assert.strictEqual(tu.target.translationToken, undefined);
+  });
+
+  test("TransUnit.setTargetStateFromToken: suggestion", function () {
+    const tu = getTransUnit(TranslationToken.suggestion);
+    tu.setTargetStateFromToken();
+    assert.strictEqual(
+      tu.target.state,
+      TargetState.translated,
+      `Expected token "${TranslationToken.suggestion} to set state "${TargetState.translated}".`
+    );
+    assert.strictEqual(tu.target.stateQualifier, StateQualifier.exactMatch);
   });
 });
 

--- a/extension/src/test/XLIFFTypes.test.ts
+++ b/extension/src/test/XLIFFTypes.test.ts
@@ -641,9 +641,8 @@ suite("Xliff Types - Functions", function () {
   });
 
   test("TransUnit.setTargetStateFromToken", function () {
-    let tu = getTransUnit(
-      TranslationToken.notTranslated
-    ).setTargetStateFromToken();
+    let tu = getTransUnit(TranslationToken.notTranslated);
+    tu.setTargetStateFromToken();
     assert.strictEqual(
       tu.target.state,
       TargetState.needsTranslation,
@@ -652,7 +651,8 @@ suite("Xliff Types - Functions", function () {
     assert.strictEqual(tu.target.stateQualifier, undefined);
     assert.strictEqual(tu.target.translationToken, undefined);
 
-    tu = getTransUnit(TranslationToken.review).setTargetStateFromToken();
+    tu = getTransUnit(TranslationToken.review);
+    tu.setTargetStateFromToken();
     assert.strictEqual(
       tu.target.state,
       TargetState.needsReviewTranslation,
@@ -661,7 +661,8 @@ suite("Xliff Types - Functions", function () {
     assert.strictEqual(tu.target.stateQualifier, undefined);
     assert.strictEqual(tu.target.translationToken, undefined);
 
-    tu = getTransUnit(TranslationToken.suggestion).setTargetStateFromToken();
+    tu = getTransUnit(TranslationToken.suggestion);
+    tu.setTargetStateFromToken();
     assert.strictEqual(
       tu.target.state,
       TargetState.translated,
@@ -670,7 +671,8 @@ suite("Xliff Types - Functions", function () {
     assert.strictEqual(tu.target.stateQualifier, StateQualifier.exactMatch);
 
     // Test switch default case
-    tu = getTransUnit().setTargetStateFromToken();
+    tu = getTransUnit();
+    tu.setTargetStateFromToken();
     assert.strictEqual(
       tu.target.state,
       TargetState.translated,

--- a/extension/src/test/XLIFFTypes.test.ts
+++ b/extension/src/test/XLIFFTypes.test.ts
@@ -640,7 +640,7 @@ suite("Xliff Types - Functions", function () {
     );
   });
 
-  test.only("TransUnit.setTargetStateFromToken", function () {
+  test("TransUnit.setTargetStateFromToken", function () {
     let tu = getTransUnit(
       TranslationToken.notTranslated
     ).setTargetStateFromToken();

--- a/extension/src/test/XLIFFTypes.test.ts
+++ b/extension/src/test/XLIFFTypes.test.ts
@@ -686,6 +686,7 @@ suite("Xliff Types - Functions", function () {
       `Expected token "${TranslationToken.suggestion} to set state "${TargetState.translated}".`
     );
     assert.strictEqual(tu.target.stateQualifier, StateQualifier.exactMatch);
+    assert.strictEqual(tu.target.translationToken, undefined);
   });
 });
 

--- a/extension/src/test/XLIFFTypes.test.ts
+++ b/extension/src/test/XLIFFTypes.test.ts
@@ -640,28 +640,10 @@ suite("Xliff Types - Functions", function () {
     );
   });
 
-  test("TransUnit.setTargetStateFromToken", function () {
-    const tu = TransUnit.fromString(getTransUnitXml());
-    tu.setTargetStateFromToken();
-    assert.strictEqual(
-      tu.target.translationToken,
-      undefined,
-      "Expected translationToken to be undefined."
-    );
-    assert.strictEqual(
-      tu.target.state,
-      TargetState.new,
-      `Expected state "${TargetState.new}".`
-    );
-    assert.strictEqual(
-      tu.target.stateQualifier,
-      undefined,
-      "Expected stateQualifier to be undefined."
-    );
-
-    tu.target.translationToken = TranslationToken.notTranslated;
-    tu.target.state = undefined;
-    tu.setTargetStateFromToken();
+  test.only("TransUnit.setTargetStateFromToken", function () {
+    let tu = getTransUnit(
+      TranslationToken.notTranslated
+    ).setTargetStateFromToken();
     assert.strictEqual(
       tu.target.state,
       TargetState.needsTranslation,
@@ -670,9 +652,7 @@ suite("Xliff Types - Functions", function () {
     assert.strictEqual(tu.target.stateQualifier, undefined);
     assert.strictEqual(tu.target.translationToken, undefined);
 
-    tu.target.translationToken = TranslationToken.review;
-    tu.target.state = undefined;
-    tu.setTargetStateFromToken();
+    tu = getTransUnit(TranslationToken.review).setTargetStateFromToken();
     assert.strictEqual(
       tu.target.state,
       TargetState.needsReviewTranslation,
@@ -681,9 +661,7 @@ suite("Xliff Types - Functions", function () {
     assert.strictEqual(tu.target.stateQualifier, undefined);
     assert.strictEqual(tu.target.translationToken, undefined);
 
-    tu.target.translationToken = TranslationToken.suggestion;
-    tu.target.state = undefined;
-    tu.setTargetStateFromToken();
+    tu = getTransUnit(TranslationToken.suggestion).setTargetStateFromToken();
     assert.strictEqual(
       tu.target.state,
       TargetState.translated,
@@ -692,9 +670,7 @@ suite("Xliff Types - Functions", function () {
     assert.strictEqual(tu.target.stateQualifier, StateQualifier.exactMatch);
 
     // Test switch default case
-    tu.target.translationToken = undefined;
-    tu.target.state = undefined;
-    tu.setTargetStateFromToken();
+    tu = getTransUnit().setTargetStateFromToken();
     assert.strictEqual(
       tu.target.state,
       TargetState.translated,
@@ -704,6 +680,19 @@ suite("Xliff Types - Functions", function () {
     assert.strictEqual(tu.target.translationToken, undefined);
   });
 });
+
+function getTransUnit(translationToken?: TranslationToken): TransUnit {
+  const transUnit = new TransUnit(
+    "Table 12557645",
+    true,
+    "Test",
+    new Target("Test"),
+    SizeUnit.char,
+    "preserve"
+  );
+  transUnit.target.translationToken = translationToken;
+  return transUnit;
+}
 
 function getNoteXml(): string {
   return '<note from="Xliff Generator" annotates="general" priority="3">Table MyTable - Field MyFieldOption - Property Caption</note>';

--- a/extension/src/test/XliffFunctions.test.ts
+++ b/extension/src/test/XliffFunctions.test.ts
@@ -10,8 +10,7 @@ import {
 import * as XliffFunctions from "../XliffFunctions";
 
 suite("XliffFunctions Tests", function () {
-  test("formatTransUnitForTranslationMode - DTS", function () {
-    // DTS
+  test("formatTransUnitForTranslationMode: dts", function () {
     const tu = getTransUnit();
     tu.target.translationToken = TranslationToken.notTranslated;
     XliffFunctions.formatTransUnitForTranslationMode(TranslationMode.dts, tu);
@@ -24,8 +23,7 @@ suite("XliffFunctions Tests", function () {
     assert.strictEqual(tu.target.translationToken, undefined);
   });
 
-  test("formatTransUnitForTranslationMode - External", function () {
-    // External
+  test("formatTransUnitForTranslationMode: external", function () {
     const tu = getTransUnit();
     tu.target.translationToken = TranslationToken.notTranslated;
     XliffFunctions.formatTransUnitForTranslationMode(
@@ -41,27 +39,38 @@ suite("XliffFunctions Tests", function () {
     assert.strictEqual(tu.target.translationToken, undefined);
   });
 
-  test("formatTransUnitForTranslationMode - NAB Tags (default case)", function () {
-    // NAB Tags
-    const translationMode = TranslationMode.nabTags;
-    let tu = getTransUnit(TargetState.new);
-    XliffFunctions.formatTransUnitForTranslationMode(translationMode, tu);
+  test("formatTransUnitForTranslationMode: nabTags - new", function () {
+    const tu = getTransUnit(TargetState.new);
+    XliffFunctions.formatTransUnitForTranslationMode(
+      TranslationMode.nabTags,
+      tu
+    );
     assert.strictEqual(tu.target.state, undefined);
     assert.strictEqual(tu.target.stateQualifier, undefined);
     assert.strictEqual(
       tu.target.translationToken,
       TranslationToken.notTranslated
     );
+  });
 
-    tu = getTransUnit(TargetState.needsReviewTranslation);
-    XliffFunctions.formatTransUnitForTranslationMode(translationMode, tu);
+  test("formatTransUnitForTranslationMode: nabTags - needsReviewTranslation", function () {
+    const tu = getTransUnit(TargetState.needsReviewTranslation);
+    XliffFunctions.formatTransUnitForTranslationMode(
+      TranslationMode.nabTags,
+      tu
+    );
     assert.strictEqual(tu.target.state, undefined);
     assert.strictEqual(tu.target.stateQualifier, undefined);
     assert.strictEqual(tu.target.translationToken, TranslationToken.review);
+  });
 
-    // Test default case of inner switch
-    tu = getTransUnit(TargetState.final);
-    XliffFunctions.formatTransUnitForTranslationMode(translationMode, tu);
+  test("formatTransUnitForTranslationMode: nabTags - Final", function () {
+    // default case of inner switch
+    const tu = getTransUnit(TargetState.final);
+    XliffFunctions.formatTransUnitForTranslationMode(
+      TranslationMode.nabTags,
+      tu
+    );
     assert.strictEqual(tu.target.state, undefined);
     assert.strictEqual(tu.target.stateQualifier, undefined);
     assert.strictEqual(tu.target.translationToken, undefined);

--- a/extension/src/test/XliffFunctions.test.ts
+++ b/extension/src/test/XliffFunctions.test.ts
@@ -1,6 +1,8 @@
 import * as assert from "assert";
 import { TranslationMode } from "../Enums";
 import {
+  SizeUnit,
+  Target,
   TargetState,
   TranslationToken,
   TransUnit,
@@ -10,7 +12,8 @@ import * as XliffFunctions from "../XliffFunctions";
 suite("XliffFunctions Tests", function () {
   test("formatTransUnitForTranslationMode - DTS", function () {
     // DTS
-    const tu = getTransUnit(TranslationToken.notTranslated);
+    const tu = getTransUnit();
+    tu.target.translationToken = TranslationToken.notTranslated;
     XliffFunctions.formatTransUnitForTranslationMode(TranslationMode.dts, tu);
     assert.strictEqual(
       tu.target.state,
@@ -23,7 +26,8 @@ suite("XliffFunctions Tests", function () {
 
   test("formatTransUnitForTranslationMode - External", function () {
     // External
-    const tu = getTransUnit(TranslationToken.notTranslated);
+    const tu = getTransUnit();
+    tu.target.translationToken = TranslationToken.notTranslated;
     XliffFunctions.formatTransUnitForTranslationMode(
       TranslationMode.external,
       tu
@@ -40,7 +44,7 @@ suite("XliffFunctions Tests", function () {
   test("formatTransUnitForTranslationMode - NAB Tags (default case)", function () {
     // NAB Tags
     const translationMode = TranslationMode.nabTags;
-    let tu = getTransUnit(undefined, TargetState.new);
+    let tu = getTransUnit(TargetState.new);
     XliffFunctions.formatTransUnitForTranslationMode(translationMode, tu);
     assert.strictEqual(tu.target.state, undefined);
     assert.strictEqual(tu.target.stateQualifier, undefined);
@@ -49,14 +53,14 @@ suite("XliffFunctions Tests", function () {
       TranslationToken.notTranslated
     );
 
-    tu = getTransUnit(undefined, TargetState.needsReviewTranslation);
+    tu = getTransUnit(TargetState.needsReviewTranslation);
     XliffFunctions.formatTransUnitForTranslationMode(translationMode, tu);
     assert.strictEqual(tu.target.state, undefined);
     assert.strictEqual(tu.target.stateQualifier, undefined);
     assert.strictEqual(tu.target.translationToken, TranslationToken.review);
 
     // Test default case of inner switch
-    tu = getTransUnit(undefined, TargetState.final);
+    tu = getTransUnit(TargetState.final);
     XliffFunctions.formatTransUnitForTranslationMode(translationMode, tu);
     assert.strictEqual(tu.target.state, undefined);
     assert.strictEqual(tu.target.stateQualifier, undefined);
@@ -64,21 +68,15 @@ suite("XliffFunctions Tests", function () {
   });
 });
 
-function getTransUnit(
-  translationToken: TranslationToken | undefined,
-  targetState: TargetState | undefined = undefined
-): TransUnit {
-  const tu = TransUnit.fromString(getTransUnitXml());
-  tu.target.state = targetState;
-  tu.target.translationToken = translationToken;
-  return tu;
-}
-
-function getTransUnitXml(): string {
-  return `<trans-unit id="Table 2328808854 - NamedType 12557645" size-unit="char" translate="yes" xml:space="preserve">
-    <source>This is a test ERROR in table</source>
-    <target state="New">This is a test ERROR in table</target>
-    <note from="Developer" annotates="general" priority="2" />
-    <note from="Xliff Generator" annotates="general" priority="3">Table MyTable - NamedType TestErr</note>
-  </trans-unit>`;
+function getTransUnit(targetState?: TargetState): TransUnit {
+  const transUnit = new TransUnit(
+    "Table 12557645",
+    true,
+    "Test",
+    new Target("Test"),
+    SizeUnit.char,
+    "preserve"
+  );
+  transUnit.target.state = targetState;
+  return transUnit;
 }

--- a/extension/src/test/XliffFunctions.test.ts
+++ b/extension/src/test/XliffFunctions.test.ts
@@ -1,0 +1,84 @@
+import * as assert from "assert";
+import { TranslationMode } from "../Enums";
+import {
+  TargetState,
+  TranslationToken,
+  TransUnit,
+} from "../Xliff/XLIFFDocument";
+import * as XliffFunctions from "../XliffFunctions";
+
+suite("XliffFunctions Tests", function () {
+  test("formatTransUnitForTranslationMode - DTS", function () {
+    // DTS
+    const tu = getTransUnit(TranslationToken.notTranslated);
+    XliffFunctions.formatTransUnitForTranslationMode(TranslationMode.dts, tu);
+    assert.strictEqual(
+      tu.target.state,
+      TargetState.needsTranslation,
+      `Expected state "${TargetState.needsTranslation}".`
+    );
+    assert.strictEqual(tu.target.stateQualifier, undefined);
+    assert.strictEqual(tu.target.translationToken, undefined);
+  });
+
+  test("formatTransUnitForTranslationMode - External", function () {
+    // External
+    const tu = getTransUnit(TranslationToken.notTranslated);
+    XliffFunctions.formatTransUnitForTranslationMode(
+      TranslationMode.external,
+      tu
+    );
+    assert.strictEqual(
+      tu.target.state,
+      TargetState.needsTranslation,
+      `Expected state "${TargetState.needsTranslation}".`
+    );
+    assert.strictEqual(tu.target.stateQualifier, undefined);
+    assert.strictEqual(tu.target.translationToken, undefined);
+  });
+
+  test("formatTransUnitForTranslationMode - NAB Tags (default case)", function () {
+    // NAB Tags
+    const translationMode = TranslationMode.nabTags;
+    let tu = getTransUnit(undefined, TargetState.new);
+    XliffFunctions.formatTransUnitForTranslationMode(translationMode, tu);
+    assert.strictEqual(tu.target.state, undefined);
+    assert.strictEqual(tu.target.stateQualifier, undefined);
+    assert.strictEqual(
+      tu.target.translationToken,
+      TranslationToken.notTranslated
+    );
+
+    tu = getTransUnit(undefined, TargetState.needsReviewTranslation);
+    XliffFunctions.formatTransUnitForTranslationMode(translationMode, tu);
+    assert.strictEqual(tu.target.state, undefined);
+    assert.strictEqual(tu.target.stateQualifier, undefined);
+    assert.strictEqual(tu.target.translationToken, TranslationToken.review);
+
+    // Test default case of inner switch
+    tu = getTransUnit(undefined, TargetState.final);
+    XliffFunctions.formatTransUnitForTranslationMode(translationMode, tu);
+    assert.strictEqual(tu.target.state, undefined);
+    assert.strictEqual(tu.target.stateQualifier, undefined);
+    assert.strictEqual(tu.target.translationToken, undefined);
+  });
+});
+
+function getTransUnit(
+  translationToken: TranslationToken | undefined,
+  targetState: TargetState | undefined = undefined
+): TransUnit {
+  const tu = TransUnit.fromString(getTransUnitXml());
+  tu.target.state = targetState;
+  tu.target.translationToken = translationToken;
+  return tu;
+}
+
+function getTransUnitXml(): string {
+  return `<trans-unit id="Table 2328808854 - NamedType 12557645" size-unit="char" translate="yes" xml:space="preserve">
+    <source>This is a test ERROR in table</source>
+    <target state="New">This is a test ERROR in table</target>
+    <note from="Developer" annotates="general" priority="2" />
+    <note from="Xliff Generator" annotates="general" priority="3">Table MyTable - NamedType TestErr</note>
+  </trans-unit>`;
+}

--- a/nab-al-tools.code-workspace
+++ b/nab-al-tools.code-workspace
@@ -25,6 +25,9 @@
     "[typescript]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
+    "[javascript]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
     "[json]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode"
     },

--- a/nab-al-tools.code-workspace
+++ b/nab-al-tools.code-workspace
@@ -25,6 +25,15 @@
     "[typescript]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
+    "[json]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[jsonc]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[markdown]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
     "git.suggestSmartCommit": false,
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
@@ -32,9 +41,7 @@
     },
     "editor.formatOnPaste": true,
     "editor.formatOnType": true,
-    "[json]": {
-      "editor.defaultFormatter": "vscode.json-language-features"
-    },
+
     "todohighlight.exclude": [
       "**/.vscode-test/**",
       "out/**",
@@ -49,9 +56,7 @@
       "**/*.map",
       "**/.next/**"
     ],
-    "cSpell.words": [
-      "Codeunits"
-    ],
+    "cSpell.words": ["Codeunits"],
     "eslint.lintTask.enable": true,
     "typescript.tsdk": "extension\\node_modules\\typescript\\lib",
     "markdownlint.config": {


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
Closes #252.

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- Move `setTargetStateFromToken` to `TransUnit` class.
- Add tests for `formatTransUnitForTranslationMode` and `setTargetStateFromToken`. Some of the tests for `formatTransUnitForTranslationMode` are overlapping. It felt better to include the overlap (as an integration test perhaps :wink: )  since there still is a separation of logic.

Additional comments
Was a bit tired writing this up so any smart ideas I'll take into consideration :sweat_smile: 