### PR TITLE
ci(telemetry): disable telemetry if running in workflow

### DIFF
--- a/extension/.vscode/launch.json
+++ b/extension/.vscode/launch.json
@@ -43,6 +43,25 @@
             "internalConsoleOptions": "openOnSessionStart"
         },
         {
+            "name": "All Automatic Tests",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "env": {
+                "GITHUB_ACTION": "Truthy"
+            },
+            "args": [
+                "${workspaceFolder}/../test-app/TestApp.code-workspace",
+                "--extensionDevelopmentPath=${workspaceFolder}",
+                "--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
+            ],
+            "outFiles": [
+                "${workspaceFolder}/out/test/**/*.js"
+            ],
+            "preLaunchTask": "npm: test-watch",
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
             "name": "Tests any workspace",
             "type": "extensionHost",
             "request": "launch",

--- a/extension/src/Telemetry.ts
+++ b/extension/src/Telemetry.ts
@@ -16,10 +16,10 @@ export function startTelemetry(
   extensionPackage: IExtensionPackage
 ): void {
   if (!initiated) {
-    enableTelemetry = settings.enableTelemetry;
+    enableTelemetry = settings.enableTelemetry && !process.env.GITHUB_ACTION;
     initiated = true;
   }
-  if (!enableTelemetry || process.env.GITHUB_ACTION) {
+  if (!enableTelemetry) {
     return;
   }
 

--- a/extension/src/Telemetry.ts
+++ b/extension/src/Telemetry.ts
@@ -19,7 +19,7 @@ export function startTelemetry(
     enableTelemetry = settings.enableTelemetry;
     initiated = true;
   }
-  if (!enableTelemetry) {
+  if (!enableTelemetry || process.env.GITHUB_ACTION) {
     return;
   }
 


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
Fixes #266 .

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- Disable telemetry if running in workflow
- Adds configuration "All Automatic Tests" in `launch.json` to enable running workflow tests locally.
