### PR TITLE
ci(telemetry): add new env variable for telemetry

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       working-directory: ./extension/
+      NAB_DISABLE_TELEMETRY: true
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/extension/.vscode/launch.json
+++ b/extension/.vscode/launch.json
@@ -31,6 +31,9 @@
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
+            "env": {
+                "NAB_DISABLE_TELEMETRY": "true" // Set to null to enable testing with telemetry
+            },
             "args": [
                 "${workspaceFolder}/../test-app/TestApp.code-workspace",
                 "--extensionDevelopmentPath=${workspaceFolder}",

--- a/extension/src/Telemetry.ts
+++ b/extension/src/Telemetry.ts
@@ -16,7 +16,8 @@ export function startTelemetry(
   extensionPackage: IExtensionPackage
 ): void {
   if (!initiated) {
-    enableTelemetry = settings.enableTelemetry && !process.env.GITHUB_ACTION;
+    enableTelemetry =
+      settings.enableTelemetry && !process.env.NAB_DISABLE_TELEMETRY;
     initiated = true;
   }
   if (!enableTelemetry) {

--- a/extension/src/test/suite/index-coverage.ts
+++ b/extension/src/test/suite/index-coverage.ts
@@ -26,6 +26,11 @@ function setupNyc(): any {
 }
 
 export function run(): Promise<void> {
+  if (process.env.NAB_DISABLE_TELEMETRY) {
+    console.log(
+      `[NAB]: Running with NAB_DISABLE_TELEMETRY=${process.env.NAB_DISABLE_TELEMETRY}`
+    );
+  }
   const nyc = setupNyc();
 
   // Create the mocha test

--- a/extension/src/test/suite/index.ts
+++ b/extension/src/test/suite/index.ts
@@ -3,6 +3,11 @@ import * as Mocha from "mocha";
 import * as glob from "glob";
 
 export function run(): Promise<void> {
+  if (process.env.NAB_DISABLE_TELEMETRY) {
+    console.log(
+      `[NAB]: Running with NAB_DISABLE_TELEMETRY=${process.env.NAB_DISABLE_TELEMETRY}`
+    );
+  }
   // Create the mocha test
   const mocha = new Mocha({
     ui: "tdd",


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
Continuation of #266. As I went to bed last night I realized that I had merged to soon.

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- Adds new env variable `NAB_DISABLE_TELEMETRY` to toggle telemetry independently.
- Disables telemetry in `launch.json` when running "Automatic Tests". This is very much up for discussion.
- Adds a smal log in `test/suite/index.ts` and `test/suite/index-coverage.ts` to confirm env var is set.
