### PR TITLE
feat: Troubleshooting commands

### DIFF
--- a/extension/.nycrc.json
+++ b/extension/.nycrc.json
@@ -21,6 +21,6 @@
   "report-dir": ".coverage",
   "statements": 82,
   "branches": 64,
-  "functions": 84,
+  "functions": 80,
   "lines": 82
 }

--- a/extension/package.json
+++ b/extension/package.json
@@ -258,6 +258,11 @@
       {
         "command": "nab.convertToPermissionSet",
         "title": "NAB: Convert to PermissionSet objects"
+      },
+      {
+        "command": "nab.troubleshootAlFileParsing",
+        "title": "NAB: Troubleshoot AL File parsing",
+        "enablement": "config.NAB.EnableTroubleshootingCommands"
       }
     ],
     "keybindings": [

--- a/extension/package.json
+++ b/extension/package.json
@@ -260,8 +260,13 @@
         "title": "NAB: Convert to PermissionSet objects"
       },
       {
-        "command": "nab.troubleshootAlFileParsing",
-        "title": "NAB: Troubleshoot AL File parsing",
+        "command": "nab.troubleshootParseCurrentFile",
+        "title": "NAB: Troubleshoot - Parse current file",
+        "enablement": "config.NAB.EnableTroubleshootingCommands"
+      },
+      {
+        "command": "nab.troubleshootParseAllFiles",
+        "title": "NAB: Troubleshoot - Parse current project",
         "enablement": "config.NAB.EnableTroubleshootingCommands"
       }
     ],

--- a/extension/package.json
+++ b/extension/package.json
@@ -603,7 +603,7 @@
         "NAB.EnableTroubleshootingCommands": {
           "type": "boolean",
           "default": false,
-          "description": "Specifies if troubleshooting commands for NAB AL Tools should be visible in the command palette. When you have enabled this setting, search for 'NAB: Troubleshooting' to find de enabled commands.",
+          "description": "Specifies if troubleshooting commands for NAB AL Tools should be visible in the command palette. When you have enabled this setting, search for 'NAB: Troubleshooting' to find the enabled commands.",
           "scope": "application"
         }
       }

--- a/extension/package.json
+++ b/extension/package.json
@@ -589,6 +589,12 @@
           "default": true,
           "description": "Specifies if anonymous telemetry can be sent to the developer. It is recommended to leave this on, so that the usage of this extension can be analyzed and the work effort can focus on the most used features. VSCode must be restarted to apply any changes to this setting.",
           "scope": "resource"
+        },
+        "NAB.EnableTroubleshootingCommands": {
+          "type": "boolean",
+          "default": false,
+          "description": "Specifies if troubleshooting commands for NAB AL Tools should be visible in the command palette. When you have enabled this setting, search for 'NAB: Troubleshooting' to find de enabled commands.",
+          "scope": "application"
         }
       }
     },

--- a/extension/src/ALObject/ALElementTypes.ts
+++ b/extension/src/ALObject/ALElementTypes.ts
@@ -722,7 +722,7 @@ export class ALObject extends ALControl {
     const lineEnding = this.eol
       ? this.eol.lineEnding
       : EOL.eolToLineEnding(EndOfLine.crLf);
-    this.alCodeLines?.forEach((codeLine) => {
+    this.alCodeLines.forEach((codeLine) => {
       result += codeLine.code + lineEnding;
     });
     return result.trimEnd();

--- a/extension/src/ALObject/ALElementTypes.ts
+++ b/extension/src/ALObject/ALElementTypes.ts
@@ -22,10 +22,12 @@ export class ALElement {
   endLineIndex = -1;
   parent?: ALControl;
   level = 0;
-  alCodeLines: ALCodeLine[] | undefined = [];
+  alCodeLines: ALCodeLine[] = [];
 
-  prepareForJsonOutput(): void {
-    delete this.alCodeLines;
+  prepareForJsonOutput(keepCodeLines = false): void {
+    if (!keepCodeLines) {
+      this.alCodeLines = [];
+    }
     this.parent = undefined;
   }
 }
@@ -95,9 +97,6 @@ export class ALControl extends ALElement {
       );
       newToolTip.commentedOut = true;
       newToolTip.text = toolTipText;
-      if (!this.alCodeLines) {
-        this.alCodeLines = [];
-      }
       let insertBeforeLineNo = this.endLineIndex;
       const indentation = this.alCodeLines[this.startLineIndex].indentation + 1;
       const triggerLine = this.alCodeLines.filter(
@@ -390,8 +389,8 @@ export class ALControl extends ALElement {
     }
     return prop.value;
   }
-  prepareForJsonOutput(): void {
-    super.prepareForJsonOutput();
+  prepareForJsonOutput(keepCodeLines = false): void {
+    super.prepareForJsonOutput(keepCodeLines);
     this.properties.forEach((p) => (p.parent = undefined));
     for (const mlObj of this.multiLanguageObjects) {
       mlObj.prepareForJsonOutput();
@@ -736,9 +735,6 @@ export class ALObject extends ALControl {
   ): void {
     code = `${"".padEnd(indentation * 4)}${code}`;
     const alCodeLine = new ALCodeLine(code, insertBeforeLineNo, indentation);
-    if (!this.alCodeLines) {
-      this.alCodeLines = [];
-    }
     this.alCodeLines
       .filter((x) => x.lineNo >= insertBeforeLineNo)
       .forEach((x) => x.lineNo++);
@@ -763,6 +759,10 @@ export class ALObject extends ALControl {
         }
         x.endLineIndex++;
       });
+  }
+  prepareForJsonOutput(): void {
+    super.prepareForJsonOutput(true);
+    this.alObjects = [];
   }
 }
 

--- a/extension/src/Common.ts
+++ b/extension/src/Common.ts
@@ -38,3 +38,27 @@ export function formatDate(date = new Date()): string {
 
   return `${year}-${month}-${day}`;
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function sortObjByKey(value: any): any {
+  return typeof value === "object"
+    ? Array.isArray(value)
+      ? value.map(sortObjByKey)
+      : Object.keys(value)
+          .sort()
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .reduce((o: any, key) => {
+            const v = value[key];
+            o[key] = sortObjByKey(v);
+            return o;
+          }, {})
+    : value;
+}
+
+export function orderedJsonStringify(
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+  obj: any,
+  space?: string | number | undefined
+): string {
+  return JSON.stringify(sortObjByKey(obj), undefined, space);
+}

--- a/extension/src/Logging/ConsoleLogger.ts
+++ b/extension/src/Logging/ConsoleLogger.ts
@@ -25,4 +25,7 @@ export class ConsoleLogger implements ILogger {
       console.error(appendTimestamp(message), optionalParams);
     }
   }
+  show(): void {
+    // Do nothing
+  }
 }

--- a/extension/src/Logging/ILogger.ts
+++ b/extension/src/Logging/ILogger.ts
@@ -1,4 +1,5 @@
 export interface ILogger {
   log(message?: string, ...optionalParams: string[]): void;
   error(message?: string, ...optionalParams: string[]): void;
+  show(): void;
 }

--- a/extension/src/Logging/NullLogger.ts
+++ b/extension/src/Logging/NullLogger.ts
@@ -8,4 +8,7 @@ export class NullLogger implements ILogger {
   error(_message?: string, ..._optionalParams: string[]): void {
     // Do nothing
   }
+  show(): void {
+    // Do nothing
+  }
 }

--- a/extension/src/Logging/OutputLogger.ts
+++ b/extension/src/Logging/OutputLogger.ts
@@ -37,4 +37,7 @@ export class OutputLogger implements ILogger {
       this.channel.appendLine("");
     }
   }
+  show(): void {
+    this.channel.show();
+  }
 }

--- a/extension/src/Logging/OutputLogger.ts
+++ b/extension/src/Logging/OutputLogger.ts
@@ -5,7 +5,7 @@ import { appendTimestamp } from "./LogHelper";
 export class OutputLogger implements ILogger {
   private static instance: OutputLogger;
   private channel: OutputChannel;
-  private static readonly channelName: string = "NAB AL Tools";
+  public static readonly channelName: string = "NAB AL Tools";
 
   static getInstance(): OutputLogger {
     if (!this.instance) {

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -1420,22 +1420,23 @@ export function troubleshootAlFileParsing(): void {
     logger.log();
     logger.log("Controls:");
     alObj.getAllControls().forEach((c) => logger.log(`${c.type}: ${c.name}`));
+    logger.log();
+
+    alObj.prepareForJsonOutput();
+    vscode.workspace
+      .openTextDocument({
+        language: "json",
+        content: JSON.stringify(alObj, undefined, 4),
+      })
+      .then((doc) => vscode.window.showTextDocument(doc));
     vscode.window.showInformationMessage(
-      `The .al file was successfully parsed. Open the Output channel ${OutputLogger.channelName} for details. `
+      `The .al file was successfully parsed. Open the Output channel '${OutputLogger.channelName}' for details. Review the opened json file for the parsed object structure.`
     );
-    alObj.alCodeLines = [];
-    alObj.getAllMultiLanguageObjects().forEach((o) => (o.parent = undefined));
-    alObj.getAllControls().forEach((o) => {
-      o.parent = undefined;
-      o.alCodeLines = [];
-      o.properties.forEach((p) => (p.parent = undefined));
-      o.multiLanguageObjects.forEach((m) => (m.parent = undefined));
-    });
-    logger.log(JSON.stringify(alObj));
   } catch (error) {
     showErrorAndLog(
       "Parsing of current AL Object failed with error:",
       error as Error
     );
   }
+  logger.show();
 }

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -1459,6 +1459,11 @@ export async function troubleshootParseAllFiles(): Promise<void> {
         content: Common.orderedJsonStringify(objects, 4),
       })
       .then((doc) => vscode.window.showTextDocument(doc));
+    logger.log();
+    logger.log("Objects:");
+    objects.forEach((obj) =>
+      logger.log(`${obj.objectType} ${obj.objectId} ${obj.objectName}`)
+    );
     vscode.window.showInformationMessage(
       `All .al file was successfully parsed. Review the opened json file for the parsed object structure. Any missing object could not be identified as an AL object, please report as an issue on GitHub (https://github.com/jwikman/nab-al-tools/issues)`
     );
@@ -1468,4 +1473,5 @@ export async function troubleshootParseAllFiles(): Promise<void> {
       error as Error
     );
   }
+  logger.show();
 }

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -1381,9 +1381,9 @@ function appendActiveDocument(filesToSearch: string[]): string[] {
   }
   return filesToSearch;
 }
-export function troubleshootAlFileParsing(): void {
-  logger.log("Running: troubleshootAlFileParsing");
-  Telemetry.trackEvent("troubleshootAlFileParsing");
+export function troubleshootParseCurrentFile(): void {
+  logger.log("Running: troubleshootParseCurrentFile");
+  Telemetry.trackEvent("troubleshootParseCurrentFile");
   try {
     const currDocument = vscode.window.activeTextEditor?.document;
     if (!currDocument) {

--- a/extension/src/Settings/Settings.ts
+++ b/extension/src/Settings/Settings.ts
@@ -57,6 +57,7 @@ export class Settings {
   public refreshXlfAfterFindNextUntranslated = true;
   public enableTranslationsOnHover = true;
   public enableTelemetry = true;
+  public enableTroubleshootingCommands = true;
   public useDictionaryInDTSImport = true;
 
   constructor(workspaceFolderPath: string) {

--- a/extension/src/Settings/SettingsMap.ts
+++ b/extension/src/Settings/SettingsMap.ts
@@ -52,4 +52,5 @@ export const settingsMap = new Map<string, keyof Settings>([
   ],
   ["NAB.EnableTranslationsOnHover", "enableTranslationsOnHover"],
   ["NAB.EnableTelemetry", "enableTelemetry"],
+  ["NAB.EnableTroubleshootingCommands", "enableTroubleshootingCommands"],
 ]);

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -149,8 +149,8 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand("nab.convertToPermissionSet", () => {
       NABfunctions.convertToPermissionSet(context.extensionUri);
     }),
-    vscode.commands.registerCommand("nab.troubleshootAlFileParsing", () => {
-      NABfunctions.troubleshootAlFileParsing();
+    vscode.commands.registerCommand("nab.troubleshootParseCurrentFile", () => {
+      NABfunctions.troubleshootParseCurrentFile();
     }),
     vscode.commands.registerTextEditorCommand(
       "nab.AddXmlCommentBold",

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -149,6 +149,9 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand("nab.convertToPermissionSet", () => {
       NABfunctions.convertToPermissionSet(context.extensionUri);
     }),
+    vscode.commands.registerCommand("nab.troubleshootAlFileParsing", () => {
+      NABfunctions.troubleshootAlFileParsing();
+    }),
     vscode.commands.registerTextEditorCommand(
       "nab.AddXmlCommentBold",
       (textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit) => {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -152,6 +152,9 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand("nab.troubleshootParseCurrentFile", () => {
       NABfunctions.troubleshootParseCurrentFile();
     }),
+    vscode.commands.registerCommand("nab.troubleshootParseAllFiles", () => {
+      NABfunctions.troubleshootParseAllFiles();
+    }),
     vscode.commands.registerTextEditorCommand(
       "nab.AddXmlCommentBold",
       (textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit) => {

--- a/extension/src/test/Common.test.ts
+++ b/extension/src/test/Common.test.ts
@@ -16,7 +16,7 @@ suite("Common", function () {
       "Incorrect date string returned"
     );
   });
-  test.only("orderedJsonStringify", function () {
+  test("orderedJsonStringify", function () {
     const obj = { b: 1, a: 2, c: 1 };
     const json = Common.orderedJsonStringify(obj, 4);
     assert.strictEqual(

--- a/extension/src/test/Common.test.ts
+++ b/extension/src/test/Common.test.ts
@@ -16,4 +16,17 @@ suite("Common", function () {
       "Incorrect date string returned"
     );
   });
+  test.only("orderedJsonStringify", function () {
+    const obj = { b: 1, a: 2, c: 1 };
+    const json = Common.orderedJsonStringify(obj, 4);
+    assert.strictEqual(
+      json,
+      `{
+    "a": 2,
+    "b": 1,
+    "c": 1
+}`,
+      "Unexpected output of sorting object"
+    );
+  });
 });


### PR DESCRIPTION
Changes proposed in this pull request:
- Adds a new setting, `NAB.EnableTroubleshootingCommands`, to enable Troubleshooting commands 
- Adds two new commands:
  - NAB: Troubleshoot - Parse current file
  - NAB: Troubleshoot - Parse current project
- The above commands tries to parse files as ALObjects.
  - If successful, the object(s) is serialized to json and opened in a new TextEditor.
  - Some properties are cleared to avoid circular reference in json
  - Code lines are only output once per object
  - Properties in json are sorted by name
- Improves the cli test when running locally