### PR TITLE
refactor: symbol reference reader / cache

### DIFF
--- a/extension/src/FileFunctions.ts
+++ b/extension/src/FileFunctions.ts
@@ -115,9 +115,7 @@ export function getZipEntryContentOrEmpty(
   fileName: string,
   encoding = "utf8"
 ): string {
-  const zipEntry = zipEntries.filter(
-    (zipEntry) => zipEntry.name === fileName
-  )[0];
+  const zipEntry = zipEntries.find((zipEntry) => zipEntry.name === fileName);
   if (zipEntry === undefined) {
     return "";
   }

--- a/extension/src/FileFunctions.ts
+++ b/extension/src/FileFunctions.ts
@@ -116,13 +116,8 @@ export function getZipEntryContentOrEmpty(
   encoding = "utf8"
 ): string {
   const zipEntry = zipEntries.find((zipEntry) => zipEntry.name === fileName);
-  if (zipEntry === undefined) {
-    return "";
-  }
-  let fileContent = zipEntry.getData().toString(encoding);
-  if (fileContent.charCodeAt(0) === 0xfeff) {
-    // Remove BOM
-    fileContent = fileContent.slice(1);
-  }
-  return fileContent;
+  const fileContent = zipEntry ? zipEntry.getData().toString(encoding) : "";
+  return fileContent.charCodeAt(0) === 0xfeff
+    ? fileContent.slice(1) // Remove BOM
+    : fileContent;
 }

--- a/extension/src/FileFunctions.ts
+++ b/extension/src/FileFunctions.ts
@@ -109,3 +109,22 @@ export function createFolderIfNotExist(folderPath: string): void {
     mkDirByPathSync(folderPath);
   }
 }
+
+export function getZipEntryContentOrEmpty(
+  zipEntries: AdmZip.IZipEntry[],
+  fileName: string,
+  encoding = "utf8"
+): string {
+  const zipEntry = zipEntries.filter(
+    (zipEntry) => zipEntry.name === fileName
+  )[0];
+  if (zipEntry === undefined) {
+    return "";
+  }
+  let fileContent = zipEntry.getData().toString(encoding);
+  if (fileContent.charCodeAt(0) === 0xfeff) {
+    // Remove BOM
+    fileContent = fileContent.slice(1);
+  }
+  return fileContent;
+}

--- a/extension/src/SymbolReference/SymbolReferenceCache.ts
+++ b/extension/src/SymbolReference/SymbolReferenceCache.ts
@@ -28,7 +28,7 @@ export class SymbolReferenceCache {
   }
 
   isCached(appId: AppIdentifier): boolean {
-    return this.cache.get(SymbolReferenceCache.key(appId)) !== undefined;
+    return this.cache.has(SymbolReferenceCache.key(appId));
   }
 
   delete(appId: AppIdentifier): boolean {

--- a/extension/src/SymbolReference/SymbolReferenceCache.ts
+++ b/extension/src/SymbolReference/SymbolReferenceCache.ts
@@ -19,8 +19,7 @@ export class SymbolReferenceCache {
     if (this.isCached(appPackage)) {
       return;
     }
-    const appToCache = appPackage;
-    //TODO: Test if objects share reference
+    const appToCache: AppPackage = Object.assign({}, appPackage);
     appToCache.symbolReference = undefined; // Free up unnecessary memory allocation
     this.cache.set(appToCache, appToCache);
   }

--- a/extension/src/SymbolReference/SymbolReferenceCache.ts
+++ b/extension/src/SymbolReference/SymbolReferenceCache.ts
@@ -1,7 +1,7 @@
 import { AppPackage, AppIdentifier } from "./types/AppPackage";
 
 export class SymbolReferenceCache {
-  private cache: Map<string, AppPackage>;
+  private cache: Map<AppIdentifier, AppPackage>;
 
   public get size(): number {
     return this.cache.size;
@@ -11,12 +11,8 @@ export class SymbolReferenceCache {
     this.cache = new Map();
   }
 
-  private id(app: AppIdentifier): string {
-    return `${app.name}-${app.publisher}-${app.version}`;
-  }
-
   get(app: AppIdentifier): AppPackage | undefined {
-    return this.cache.get(this.id(app));
+    return this.cache.get(app);
   }
 
   set(appPackage: AppPackage): void {
@@ -26,15 +22,15 @@ export class SymbolReferenceCache {
     const appToCache = appPackage;
     //TODO: Test if objects share reference
     appToCache.symbolReference = undefined; // Free up unnecessary memory allocation
-    this.cache.set(this.id(appToCache), appToCache);
+    this.cache.set(appToCache, appToCache);
   }
 
   isCached(app: AppIdentifier): boolean {
-    return this.cache.get(this.id(app)) !== undefined;
+    return this.cache.get(app) !== undefined;
   }
 
   delete(app: AppPackage): boolean {
-    return this.cache.delete(this.id(app));
+    return this.cache.delete(app);
   }
 
   clear(): void {

--- a/extension/src/SymbolReference/SymbolReferenceCache.ts
+++ b/extension/src/SymbolReference/SymbolReferenceCache.ts
@@ -1,6 +1,6 @@
 import { AppPackage, AppPackageMeta } from "./types/AppPackage";
 
-class SymbolReferenceCache {
+export class SymbolReferenceCache {
   private cache: Map<string, AppPackage>;
 
   public get size(): number {
@@ -19,17 +19,10 @@ class SymbolReferenceCache {
     return this.cache.get(this.id(app));
   }
 
-  add(appPackage: AppPackage): void {
+  set(appPackage: AppPackage): void {
     if (this.isCached(appPackage)) {
       return;
     }
-    const appToCache = appPackage;
-    //TODO: Test if objects share reference
-    appToCache.symbolReference = undefined; // Free up unnecessary memory allocation
-    this.cache.set(this.id(appToCache), appToCache);
-  }
-
-  update(appPackage: AppPackage): void {
     const appToCache = appPackage;
     //TODO: Test if objects share reference
     appToCache.symbolReference = undefined; // Free up unnecessary memory allocation

--- a/extension/src/SymbolReference/SymbolReferenceCache.ts
+++ b/extension/src/SymbolReference/SymbolReferenceCache.ts
@@ -1,7 +1,7 @@
 import { AppPackage, AppIdentifier } from "./types/AppPackage";
 
 export class SymbolReferenceCache {
-  private cache: Map<AppIdentifier, AppPackage>;
+  private cache: Map<string, AppPackage>;
 
   public get size(): number {
     return this.cache.size;
@@ -11,25 +11,28 @@ export class SymbolReferenceCache {
     this.cache = new Map();
   }
 
-  get(app: AppIdentifier): AppPackage | undefined {
-    return this.cache.get(app);
+  static key(appId: AppIdentifier): string {
+    return `${appId.name}-${appId.publisher}-${appId.version}`;
+  }
+
+  get(appId: AppIdentifier): AppPackage | undefined {
+    return this.cache.get(SymbolReferenceCache.key(appId));
   }
 
   set(appPackage: AppPackage): void {
     if (this.isCached(appPackage)) {
       return;
     }
-    const appToCache: AppPackage = Object.assign({}, appPackage);
-    appToCache.symbolReference = undefined; // Free up unnecessary memory allocation
-    this.cache.set(appToCache, appToCache);
+    const appToCache = appPackage;
+    this.cache.set(SymbolReferenceCache.key(appToCache), appToCache);
   }
 
-  isCached(app: AppIdentifier): boolean {
-    return this.cache.get(app) !== undefined;
+  isCached(appId: AppIdentifier): boolean {
+    return this.cache.get(SymbolReferenceCache.key(appId)) !== undefined;
   }
 
-  delete(app: AppPackage): boolean {
-    return this.cache.delete(app);
+  delete(appId: AppIdentifier): boolean {
+    return this.cache.delete(SymbolReferenceCache.key(appId));
   }
 
   clear(): void {

--- a/extension/src/SymbolReference/SymbolReferenceCache.ts
+++ b/extension/src/SymbolReference/SymbolReferenceCache.ts
@@ -1,4 +1,4 @@
-import { AppPackage, AppPackageMeta } from "./types/AppPackage";
+import { AppPackage, AppIdentifier } from "./types/AppPackage";
 
 export class SymbolReferenceCache {
   private cache: Map<string, AppPackage>;
@@ -11,11 +11,11 @@ export class SymbolReferenceCache {
     this.cache = new Map();
   }
 
-  private id(app: AppPackageMeta): string {
+  private id(app: AppIdentifier): string {
     return `${app.name}-${app.publisher}-${app.version}`;
   }
 
-  get(app: AppPackageMeta): AppPackage | undefined {
+  get(app: AppIdentifier): AppPackage | undefined {
     return this.cache.get(this.id(app));
   }
 
@@ -29,7 +29,7 @@ export class SymbolReferenceCache {
     this.cache.set(this.id(appToCache), appToCache);
   }
 
-  isCached(app: AppPackageMeta): boolean {
+  isCached(app: AppIdentifier): boolean {
     return this.cache.get(this.id(app)) !== undefined;
   }
 

--- a/extension/src/SymbolReference/SymbolReferenceReader.ts
+++ b/extension/src/SymbolReference/SymbolReferenceReader.ts
@@ -26,7 +26,7 @@ import { ALPageField } from "../ALObject/ALPageField";
 import { ALPagePart } from "../ALObject/ALPagePart";
 import { BinaryReader } from "./BinaryReader";
 
-export function getAppFileContent(
+function getAppFileContent(
   appFilePath: string,
   loadSymbols = true
 ): { symbolReference: string; manifest: string; packageId: string } {

--- a/extension/src/SymbolReference/SymbolReferenceReader.ts
+++ b/extension/src/SymbolReference/SymbolReferenceReader.ts
@@ -1,6 +1,3 @@
-import * as AdmZip from "adm-zip"; // Ref: https://www.npmjs.com/package/adm-zip
-import * as fs from "fs";
-import * as path from "path";
 import {
   ALObject,
   ALControl,
@@ -12,170 +9,32 @@ import {
   ControlKind,
   PageDefinition,
   SymbolProperty,
-  SymbolReference,
   TableDefinition,
 } from "./interfaces/SymbolReference";
 import { ALControlType, ALObjectType } from "../ALObject/Enums";
 import { ALTableField } from "../ALObject/ALTableField";
 import { alPropertyTypeMap, multiLanguageTypeMap } from "../ALObject/Maps";
-import * as txml from "txml";
-import { ManifestPackage, NavxManifest } from "./interfaces/NavxManifest";
 import { AppPackage } from "./types/AppPackage";
 import { symbolReferenceCache } from "./SymbolReferenceCache";
 import { ALPageField } from "../ALObject/ALPageField";
 import { ALPagePart } from "../ALObject/ALPagePart";
-import { BinaryReader } from "./BinaryReader";
-
-function getAppFileContent(
-  appFilePath: string,
-  loadSymbols = true
-): { symbolReference: string; manifest: string; packageId: string } {
-  let symbolReference = "";
-  let manifest = "";
-  const fileContent = fs.readFileSync(appFilePath);
-  const view = new BinaryReader(fileContent, true);
-
-  const magicNumber1 = view.getUint32(0);
-  const metadataSize = view.getUint32(4);
-  const metadataVersion = view.getUint32(8);
-
-  const packageIdArray = Buffer.from(view.getBytes(16, 12));
-  const byteArray: number[] = [];
-  packageIdArray.forEach((b) => byteArray.push(b));
-  const packageId = byteArrayToGuid(byteArray);
-  const contentLength = view.getUint64(28);
-  const magicNumber2 = view.getUint32(36);
-  const magicNumber3 = view.getUint16(40);
-
-  const appIdentifier = 0x5856414e; // "NAVX"
-  const runtimePackageIdentifier = 20014; // "."
-  const regularAppIdentifier = 19280; // "P"
-
-  if (
-    magicNumber1 !== appIdentifier ||
-    magicNumber2 !== appIdentifier ||
-    metadataVersion > 2
-  ) {
-    throw new Error(`"${appFilePath}" is not a valid app file`);
-  }
-
-  if (
-    magicNumber3 !== runtimePackageIdentifier &&
-    magicNumber3 !== regularAppIdentifier
-  ) {
-    throw new Error(
-      `Unsupported package format (unknown package container type in "${appFilePath})"`
-    );
-  }
-
-  if (magicNumber3 === runtimePackageIdentifier) {
-    // Runtime Package
-    throw new Error(`Runtime Packages is not supported (${appFilePath})`);
-  }
-
-  const buffer = Buffer.from(
-    view.getBytes(contentLength.valueOf(), metadataSize)
-  );
-
-  const zip = new AdmZip(buffer);
-  const zipEntries = zip.getEntries(); // an array of ZipEntry records
-  if (loadSymbols) {
-    symbolReference = getZipEntryContentOrEmpty(
-      zipEntries,
-      "SymbolReference.json"
-    );
-    symbolReference = symbolReference.replace(/\0/g, ""); // Trailing NULL characters seems to be common...
-  }
-  manifest = getZipEntryContentOrEmpty(zipEntries, "NavxManifest.xml");
-
-  return {
-    symbolReference: symbolReference,
-    manifest: manifest,
-    packageId: packageId,
-  };
-}
-
-function byteArrayToGuid(byteArray: number[]): string {
-  // reverse first four bytes, and join with following two reversed, joined with following two reversed, joined with rest of the bytes
-  byteArray = byteArray
-    .slice(0, 4)
-    .reverse()
-    .concat(byteArray.slice(4, 6).reverse())
-    .concat(byteArray.slice(6, 8).reverse())
-    .concat(byteArray.slice(8));
-
-  let guidValue = byteArray
-    .map(function (item) {
-      // return hex value with "0" padding
-      return ("00" + item.toString(16).toUpperCase()).substr(-2, 2);
-    })
-    .join("");
-  guidValue = `${guidValue.substr(0, 8)}-${guidValue.substr(
-    8,
-    4
-  )}-${guidValue.substr(12, 4)}-${guidValue.substr(16, 4)}-${guidValue.substr(
-    20
-  )}`;
-  return guidValue.toLowerCase();
-}
-
-function getZipEntryContentOrEmpty(
-  zipEntries: AdmZip.IZipEntry[],
-  fileName: string
-): string {
-  const zipEntry = zipEntries.filter(
-    (zipEntry) => zipEntry.name === fileName
-  )[0];
-  if (zipEntry === undefined) {
-    return "";
-  }
-  let fileContent = zipEntry.getData().toString("utf8");
-  if (fileContent.charCodeAt(0) === 0xfeff) {
-    // Remove BOM
-    fileContent = fileContent.slice(1);
-  }
-  return fileContent;
-}
-export function getAppPackage(
-  appFilePath: string,
-  loadSymbols = true
-): AppPackage {
-  const appFileContent = getAppFileContent(appFilePath);
-  let symbols: SymbolReference;
-  const manifest: ManifestPackage = (<NavxManifest>(
-    txml.simplifyLostLess(txml.parse(appFileContent.manifest) as txml.tNode[])
-  )).Package[0];
-  const appPackage: AppPackage = new AppPackage(
-    appFilePath,
-    manifest.App[0]._attributes.Name,
-    manifest.App[0]._attributes.Publisher,
-    manifest.App[0]._attributes.Version,
-    appFileContent.packageId,
-    manifest
-  );
-  if (loadSymbols) {
-    symbols = <SymbolReference>JSON.parse(appFileContent.symbolReference);
-    appPackage.symbolReference = symbols;
-  }
-  return appPackage;
-}
 
 export function getObjectsFromAppFile(appFilePath: string): AppPackage {
-  const appMeta = getAppIdentifiersFromFilename(appFilePath);
+  const appIdentifier = AppPackage.appIdentifier(appFilePath);
 
   let appPackage;
-  if (symbolReferenceCache.isCached(appMeta)) {
-    appPackage = symbolReferenceCache.get(appMeta);
+  if (symbolReferenceCache.isCached(appIdentifier)) {
+    appPackage = symbolReferenceCache.get(appIdentifier);
   }
   if (!appPackage) {
-    appPackage = getAppPackage(appFilePath);
+    appPackage = AppPackage.getAppPackage(appFilePath);
     parseObjectsInAppPackage(appPackage);
-    symbolReferenceCache.add(appPackage);
+    symbolReferenceCache.set(appPackage);
   }
   return appPackage;
 }
 
-export function parseObjectsInAppPackage(appPackage: AppPackage): void {
+function parseObjectsInAppPackage(appPackage: AppPackage): void {
   if (appPackage.symbolReference === undefined) {
     return;
   }
@@ -317,22 +176,4 @@ function addProperty(prop: SymbolProperty, obj: ALControl): void {
   } else if (alPropertyTypeMap.has(prop.Name.toLowerCase())) {
     obj.properties.push(new ALProperty(obj, 0, prop.Name, prop.Value));
   }
-}
-
-export function getAppIdentifiersFromFilename(
-  filePath: string
-): { valid: boolean; name: string; publisher: string; version: string } {
-  let fileName = path.basename(filePath);
-  const ext = path.extname(filePath);
-  fileName = fileName.slice(0, fileName.length - ext.length);
-  if (fileName.indexOf("_") > 0) {
-    const appParts = fileName.split("_");
-    return {
-      valid: true,
-      name: appParts[1],
-      publisher: appParts[0],
-      version: appParts[2],
-    };
-  }
-  return { valid: false, name: fileName, publisher: "", version: "" };
 }

--- a/extension/src/SymbolReference/SymbolReferenceReader.ts
+++ b/extension/src/SymbolReference/SymbolReferenceReader.ts
@@ -27,7 +27,7 @@ export function getObjectsFromAppFile(appFilePath: string): AppPackage {
     appPackage = symbolReferenceCache.get(appIdentifier);
   }
   if (!appPackage) {
-    appPackage = AppPackage.getAppPackage(appFilePath);
+    appPackage = AppPackage.fromFile(appFilePath);
     parseObjectsInAppPackage(appPackage);
     symbolReferenceCache.set(appPackage);
   }

--- a/extension/src/SymbolReference/SymbolReferenceReader.ts
+++ b/extension/src/SymbolReference/SymbolReferenceReader.ts
@@ -107,13 +107,13 @@ function byteArrayToGuid(byteArray: number[]): string {
   let guidValue = byteArray
     .map(function (item) {
       // return hex value with "0" padding
-      return ("00" + item.toString(16).toUpperCase()).slice(-2, 2);
+      return ("00" + item.toString(16).toUpperCase()).substr(-2, 2);
     })
     .join("");
-  guidValue = `${guidValue.slice(0, 8)}-${guidValue.slice(
+  guidValue = `${guidValue.substr(0, 8)}-${guidValue.substr(
     8,
     4
-  )}-${guidValue.slice(12, 4)}-${guidValue.slice(16, 4)}-${guidValue.slice(
+  )}-${guidValue.substr(12, 4)}-${guidValue.substr(16, 4)}-${guidValue.substr(
     20
   )}`;
   return guidValue.toLowerCase();

--- a/extension/src/SymbolReference/SymbolReferenceReader.ts
+++ b/extension/src/SymbolReference/SymbolReferenceReader.ts
@@ -49,11 +49,11 @@ function parseObjectsInAppPackage(appPackage: AppPackage): void {
     obj.alObjects = objects;
     if (obj.sourceTable !== "") {
       // Substitute Table No. against Table Name
-      const table = objects.filter(
+      const table = objects.find(
         (tbl) =>
           tbl.objectType === ALObjectType.table &&
           tbl.objectId === Number(obj.sourceTable)
-      )[0];
+      );
       if (table) {
         obj.sourceTable = table.name;
       }
@@ -67,11 +67,11 @@ function parseObjectsInAppPackage(appPackage: AppPackage): void {
       .forEach((partControl) => {
         const alPagePart = partControl as ALPagePart;
         // Substitute Page no. against page names
-        const page = objects.filter(
+        const page = objects.find(
           (tbl) =>
             tbl.objectType === ALObjectType.page &&
             tbl.objectId === Number(alPagePart.value)
-        )[0];
+        );
         if (page) {
           alPagePart.value = page.name;
         }

--- a/extension/src/SymbolReference/SymbolReferenceReader.ts
+++ b/extension/src/SymbolReference/SymbolReferenceReader.ts
@@ -29,6 +29,8 @@ export function getObjectsFromAppFile(appFilePath: string): AppPackage {
   if (!appPackage) {
     appPackage = AppPackage.fromFile(appFilePath);
     parseObjectsInAppPackage(appPackage);
+    // Free up unnecessary memory allocation
+    appPackage.symbolReference = undefined;
     symbolReferenceCache.set(appPackage);
   }
   return appPackage;

--- a/extension/src/SymbolReference/SymbolReferenceReader.ts
+++ b/extension/src/SymbolReference/SymbolReferenceReader.ts
@@ -107,13 +107,13 @@ function byteArrayToGuid(byteArray: number[]): string {
   let guidValue = byteArray
     .map(function (item) {
       // return hex value with "0" padding
-      return ("00" + item.toString(16).toUpperCase()).substr(-2, 2);
+      return ("00" + item.toString(16).toUpperCase()).slice(-2, 2);
     })
     .join("");
-  guidValue = `${guidValue.substr(0, 8)}-${guidValue.substr(
+  guidValue = `${guidValue.slice(0, 8)}-${guidValue.slice(
     8,
     4
-  )}-${guidValue.substr(12, 4)}-${guidValue.substr(16, 4)}-${guidValue.substr(
+  )}-${guidValue.slice(12, 4)}-${guidValue.slice(16, 4)}-${guidValue.slice(
     20
   )}`;
   return guidValue.toLowerCase();
@@ -132,7 +132,7 @@ function getZipEntryContentOrEmpty(
   let fileContent = zipEntry.getData().toString("utf8");
   if (fileContent.charCodeAt(0) === 0xfeff) {
     // Remove BOM
-    fileContent = fileContent.substr(1);
+    fileContent = fileContent.slice(1);
   }
   return fileContent;
 }
@@ -324,7 +324,7 @@ export function getAppIdentifiersFromFilename(
 ): { valid: boolean; name: string; publisher: string; version: string } {
   let fileName = path.basename(filePath);
   const ext = path.extname(filePath);
-  fileName = fileName.substr(0, fileName.length - ext.length);
+  fileName = fileName.slice(0, fileName.length - ext.length);
   if (fileName.indexOf("_") > 0) {
     const appParts = fileName.split("_");
     return {

--- a/extension/src/SymbolReference/SymbolReferenceReader.ts
+++ b/extension/src/SymbolReference/SymbolReferenceReader.ts
@@ -21,7 +21,7 @@ import { alPropertyTypeMap, multiLanguageTypeMap } from "../ALObject/Maps";
 import * as txml from "txml";
 import { ManifestPackage, NavxManifest } from "./interfaces/NavxManifest";
 import { AppPackage } from "./types/AppPackage";
-import * as SymbolReferenceCache from "./SymbolReferenceCache";
+import { symbolReferenceCache } from "./SymbolReferenceCache";
 import { ALPageField } from "../ALObject/ALPageField";
 import { ALPagePart } from "../ALObject/ALPagePart";
 import { BinaryReader } from "./BinaryReader";
@@ -161,22 +161,17 @@ export function getAppPackage(
 }
 
 export function getObjectsFromAppFile(appFilePath: string): AppPackage {
-  const { name, publisher, version } = getAppIdentifiersFromFilename(
-    appFilePath
-  );
+  const appMeta = getAppIdentifiersFromFilename(appFilePath);
 
   let appPackage;
-  if (SymbolReferenceCache.appInCache(name, publisher, version)) {
-    appPackage = SymbolReferenceCache.getAppPackageFromCache(
-      name,
-      publisher,
-      version
-    );
-    return appPackage;
+  if (symbolReferenceCache.isCached(appMeta)) {
+    appPackage = symbolReferenceCache.get(appMeta);
   }
-  appPackage = getAppPackage(appFilePath);
-  parseObjectsInAppPackage(appPackage);
-  SymbolReferenceCache.addAppPackageToCache(appPackage);
+  if (!appPackage) {
+    appPackage = getAppPackage(appFilePath);
+    parseObjectsInAppPackage(appPackage);
+    symbolReferenceCache.add(appPackage);
+  }
   return appPackage;
 }
 

--- a/extension/src/SymbolReference/SymbolReferenceReader.ts
+++ b/extension/src/SymbolReference/SymbolReferenceReader.ts
@@ -151,16 +151,16 @@ function addControl(control: ControlDefinition, parent: ALControl): void {
       alControl = new ALControl(newAlControlType, control.Name);
     }
   }
-  if (alControl !== undefined) {
+  if (alControl) {
     control.Properties?.forEach((prop) => {
-      if (alControl !== undefined) {
+      if (alControl) {
         addProperty(prop, alControl);
       }
     });
     alControl.parent = parent;
     parent.controls.push(alControl);
     control.Controls?.forEach((c) => {
-      if (alControl !== undefined) {
+      if (alControl) {
         addControl(c, alControl);
       }
     });

--- a/extension/src/SymbolReference/SymbolReferenceReader.ts
+++ b/extension/src/SymbolReference/SymbolReferenceReader.ts
@@ -20,7 +20,7 @@ import { ALPageField } from "../ALObject/ALPageField";
 import { ALPagePart } from "../ALObject/ALPagePart";
 
 export function getObjectsFromAppFile(appFilePath: string): AppPackage {
-  const appIdentifier = AppPackage.appIdentifier(appFilePath);
+  const appIdentifier = AppPackage.appIdentifierFromFilename(appFilePath);
 
   let appPackage;
   if (symbolReferenceCache.isCached(appIdentifier)) {

--- a/extension/src/SymbolReference/types/AppPackage.ts
+++ b/extension/src/SymbolReference/types/AppPackage.ts
@@ -1,8 +1,27 @@
+import * as AdmZip from "adm-zip"; // Ref: https://www.npmjs.com/package/adm-zip
+import * as fs from "fs";
+import * as path from "path";
 import { ALObject } from "../../ALObject/ALElementTypes";
-import { ManifestPackage } from "../interfaces/NavxManifest";
+import { ManifestPackage, NavxManifest } from "../interfaces/NavxManifest";
 import { SymbolReference } from "../interfaces/SymbolReference";
+import * as txml from "txml";
+import { BinaryReader } from "../BinaryReader";
+import * as FileFunctions from "../../FileFunctions";
+export interface AppPackageMeta {
+  name: string;
+  publisher: string;
+  version: string;
+  packageId?: string;
+  manifest?: ManifestPackage;
+  symbolReference?: SymbolReference;
+}
 
-
+interface AppIdentifier {
+  valid: boolean;
+  name: string;
+  publisher: string;
+  version: string;
+}
 export class AppPackage {
   name: string;
   publisher: string;
@@ -35,5 +54,142 @@ export class AppPackage {
     if (symbolReference) {
       this.symbolReference = symbolReference;
     }
+  }
+
+  static getAppPackage(appFilePath: string, loadSymbols = true): AppPackage {
+    const appFileContent = AppPackage.getAppFileContent(appFilePath);
+    let symbols: SymbolReference;
+    const manifest: ManifestPackage = (<NavxManifest>(
+      txml.simplifyLostLess(txml.parse(appFileContent.manifest) as txml.tNode[])
+    )).Package[0];
+    const appPackage: AppPackage = new AppPackage(
+      appFilePath,
+      manifest.App[0]._attributes.Name,
+      manifest.App[0]._attributes.Publisher,
+      manifest.App[0]._attributes.Version,
+      appFileContent.packageId,
+      manifest
+    );
+    if (loadSymbols) {
+      symbols = <SymbolReference>JSON.parse(appFileContent.symbolReference);
+      appPackage.symbolReference = symbols;
+    }
+    return appPackage;
+  }
+
+  static appIdentifier(filePath: string): AppIdentifier {
+    let fileName = path.basename(filePath);
+    const ext = path.extname(filePath);
+    fileName = fileName.slice(0, fileName.length - ext.length);
+    const appIdentifier: AppIdentifier = {
+      valid: false,
+      name: fileName,
+      publisher: "",
+      version: "",
+    };
+    if (fileName.indexOf("_") > 0) {
+      const appParts = fileName.split("_");
+      appIdentifier.valid = true;
+      appIdentifier.name = appParts[1];
+      appIdentifier.publisher = appParts[0];
+      appIdentifier.version = appParts[2];
+    }
+    return appIdentifier;
+  }
+
+  static getAppFileContent(
+    appFilePath: string,
+    loadSymbols = true
+  ): { symbolReference: string; manifest: string; packageId: string } {
+    let symbolReference = "";
+    let manifest = "";
+    const fileContent = fs.readFileSync(appFilePath);
+    const view = new BinaryReader(fileContent, true);
+
+    const magicNumber1 = view.getUint32(0);
+    const metadataSize = view.getUint32(4);
+    const metadataVersion = view.getUint32(8);
+
+    const packageIdArray = Buffer.from(view.getBytes(16, 12));
+    const byteArray: number[] = [];
+    packageIdArray.forEach((b) => byteArray.push(b));
+    const packageId = this.byteArrayToGuid(byteArray);
+    const contentLength = view.getUint64(28);
+    const magicNumber2 = view.getUint32(36);
+    const magicNumber3 = view.getUint16(40);
+
+    const appIdentifier = 0x5856414e; // "NAVX"
+    const runtimePackageIdentifier = 20014; // "."
+    const regularAppIdentifier = 19280; // "P"
+
+    if (
+      magicNumber1 !== appIdentifier ||
+      magicNumber2 !== appIdentifier ||
+      metadataVersion > 2
+    ) {
+      throw new Error(`"${appFilePath}" is not a valid app file`);
+    }
+
+    if (
+      magicNumber3 !== runtimePackageIdentifier &&
+      magicNumber3 !== regularAppIdentifier
+    ) {
+      throw new Error(
+        `Unsupported package format (unknown package container type in "${appFilePath})"`
+      );
+    }
+
+    if (magicNumber3 === runtimePackageIdentifier) {
+      // Runtime Package
+      throw new Error(`Runtime Packages is not supported (${appFilePath})`);
+    }
+
+    const buffer = Buffer.from(
+      view.getBytes(contentLength.valueOf(), metadataSize)
+    );
+
+    const zip = new AdmZip(buffer);
+    const zipEntries = zip.getEntries(); // an array of ZipEntry records
+    if (loadSymbols) {
+      symbolReference = FileFunctions.getZipEntryContentOrEmpty(
+        zipEntries,
+        "SymbolReference.json"
+      );
+      symbolReference = symbolReference.replace(/\0/g, ""); // Trailing NULL characters seems to be common...
+    }
+    manifest = FileFunctions.getZipEntryContentOrEmpty(
+      zipEntries,
+      "NavxManifest.xml"
+    );
+
+    return {
+      symbolReference: symbolReference,
+      manifest: manifest,
+      packageId: packageId,
+    };
+  }
+
+  static byteArrayToGuid(byteArray: number[]): string {
+    // reverse first four bytes, and join with following two reversed, joined with following two reversed, joined with rest of the bytes
+    byteArray = byteArray
+      .slice(0, 4)
+      .reverse()
+      .concat(byteArray.slice(4, 6).reverse())
+      .concat(byteArray.slice(6, 8).reverse())
+      .concat(byteArray.slice(8));
+
+    let guidValue = byteArray
+      .map(function (item) {
+        // return hex value with "0" padding
+        return ("00" + item.toString(16).toUpperCase()).substr(-2, 2);
+      })
+      .join("");
+    guidValue = `${guidValue.substr(0, 8)}-${guidValue.substr(
+      8,
+      4
+    )}-${guidValue.substr(12, 4)}-${guidValue.substr(16, 4)}-${guidValue.substr(
+      20
+    )}`;
+    return guidValue.toLowerCase();
   }
 }

--- a/extension/src/SymbolReference/types/AppPackage.ts
+++ b/extension/src/SymbolReference/types/AppPackage.ts
@@ -85,8 +85,10 @@ export class AppPackage {
 
   static appIdentifier(filePath: string): AppIdentifier {
     let fileName = path.basename(filePath);
-    const ext = path.extname(filePath);
-    fileName = fileName.slice(0, fileName.length - ext.length);
+    fileName = fileName.slice(
+      0,
+      fileName.length - path.extname(filePath).length
+    );
     const appIdentifier: AppIdentifier = {
       valid: false,
       name: fileName,

--- a/extension/src/SymbolReference/types/AppPackage.ts
+++ b/extension/src/SymbolReference/types/AppPackage.ts
@@ -8,16 +8,6 @@ import * as txml from "txml";
 import { BinaryReader } from "../BinaryReader";
 import * as FileFunctions from "../../FileFunctions";
 
-// TODO: Decide if AppPackageMeta should stay in or go
-export interface AppPackageMeta {
-  name: string;
-  publisher: string;
-  version: string;
-  packageId?: string;
-  manifest?: ManifestPackage;
-  symbolReference?: SymbolReference;
-}
-
 interface AppFileContent {
   symbolReference: string;
   manifest: string;

--- a/extension/src/SymbolReference/types/AppPackage.ts
+++ b/extension/src/SymbolReference/types/AppPackage.ts
@@ -7,6 +7,8 @@ import { SymbolReference } from "../interfaces/SymbolReference";
 import * as txml from "txml";
 import { BinaryReader } from "../BinaryReader";
 import * as FileFunctions from "../../FileFunctions";
+
+// TODO: Decide if AppPackageMeta should stay in or go
 export interface AppPackageMeta {
   name: string;
   publisher: string;

--- a/extension/src/SymbolReference/types/AppPackage.ts
+++ b/extension/src/SymbolReference/types/AppPackage.ts
@@ -20,6 +20,7 @@ export interface AppIdentifier {
   publisher: string;
   version: string;
 }
+
 export class AppPackage {
   name: string;
   publisher: string;
@@ -75,7 +76,15 @@ export class AppPackage {
     return appPackage;
   }
 
-  static appIdentifier(filePath: string): AppIdentifier {
+  public get appIdentifier(): AppIdentifier {
+    return {
+      name: this.name,
+      publisher: this.publisher,
+      version: this.version,
+    };
+  }
+
+  static appIdentifierFromFilename(filePath: string): AppIdentifier {
     let fileName = path.basename(filePath);
     fileName = fileName.slice(
       0,

--- a/extension/src/SymbolReference/types/AppPackage.ts
+++ b/extension/src/SymbolReference/types/AppPackage.ts
@@ -1,7 +1,7 @@
 import { ALObject } from "../../ALObject/ALElementTypes";
 import { ManifestPackage } from "../interfaces/NavxManifest";
 import { SymbolReference } from "../interfaces/SymbolReference";
-import * as Version from "../../helpers/Version";
+
 
 export class AppPackage {
   name: string;
@@ -35,20 +35,5 @@ export class AppPackage {
     if (symbolReference) {
       this.symbolReference = symbolReference;
     }
-  }
-
-  public sort(other: AppPackage): number {
-    if (this.publisher !== other.publisher) {
-      return this.publisher.localeCompare(other.publisher);
-    }
-    if (this.name !== other.name) {
-      return this.name.localeCompare(other.name);
-    }
-    if (Version.lt(other.version, this.version)) {
-      return -1;
-    } else if (Version.gt(other.version, this.version)) {
-      return 1;
-    }
-    return 0;
   }
 }

--- a/extension/src/SymbolReference/types/AppPackage.ts
+++ b/extension/src/SymbolReference/types/AppPackage.ts
@@ -56,8 +56,7 @@ export class AppPackage {
     }
   }
 
-  static getAppPackage(appFilePath: string, loadSymbols = true): AppPackage {
-    const appFileContent = AppPackage.getAppFileContent(appFilePath);
+  static fromFile(appFilePath: string, loadSymbols = true): AppPackage {
     let symbols: SymbolReference;
     const manifest: ManifestPackage = (<NavxManifest>(
       txml.simplifyLostLess(txml.parse(appFileContent.manifest) as txml.tNode[])

--- a/extension/src/SymbolReference/types/AppPackage.ts
+++ b/extension/src/SymbolReference/types/AppPackage.ts
@@ -24,8 +24,8 @@ interface AppFileContent {
   packageId: string;
 }
 
-interface AppIdentifier {
-  valid: boolean;
+export interface AppIdentifier {
+  valid?: boolean;
   name: string;
   publisher: string;
   version: string;

--- a/extension/src/WorkspaceFunctions.ts
+++ b/extension/src/WorkspaceFunctions.ts
@@ -63,16 +63,17 @@ async function getSymbolFilesFromCurrentWorkspace(
   const appSymbolFiles = FileFunctions.findFiles("*.app", alPackageFolderPath);
 
   appSymbolFiles.forEach((filePath) => {
-    const { valid, name, publisher, version } = AppPackage.appIdentifier(
-      filePath
-    );
-    if (valid) {
-      if (name !== appManifest.name && publisher !== appManifest.publisher) {
+    const appId = AppPackage.appIdentifier(filePath);
+    if (appId.valid) {
+      if (
+        appId.name !== appManifest.name &&
+        appId.publisher !== appManifest.publisher
+      ) {
         const app: SymbolFile = new SymbolFile(
           filePath,
-          name,
-          publisher,
-          version
+          appId.name,
+          appId.publisher,
+          appId.version
         );
         symbolFiles.push(app);
       }

--- a/extension/src/WorkspaceFunctions.ts
+++ b/extension/src/WorkspaceFunctions.ts
@@ -63,12 +63,9 @@ async function getSymbolFilesFromCurrentWorkspace(
   const appSymbolFiles = FileFunctions.findFiles("*.app", alPackageFolderPath);
 
   appSymbolFiles.forEach((filePath) => {
-    const {
-      valid,
-      name,
-      publisher,
-      version,
-    } = SymbolReferenceReader.getAppIdentifiersFromFilename(filePath);
+    const { valid, name, publisher, version } = AppPackage.appIdentifier(
+      filePath
+    );
     if (valid) {
       if (name !== appManifest.name && publisher !== appManifest.publisher) {
         const app: SymbolFile = new SymbolFile(

--- a/extension/src/WorkspaceFunctions.ts
+++ b/extension/src/WorkspaceFunctions.ts
@@ -63,7 +63,7 @@ async function getSymbolFilesFromCurrentWorkspace(
   const appSymbolFiles = FileFunctions.findFiles("*.app", alPackageFolderPath);
 
   appSymbolFiles.forEach((filePath) => {
-    const appId = AppPackage.appIdentifier(filePath);
+    const appId = AppPackage.appIdentifierFromFilename(filePath);
     if (appId.valid) {
       if (
         appId.name !== appManifest.name &&

--- a/extension/src/test/SymbolReference/AppPackage.test.ts
+++ b/extension/src/test/SymbolReference/AppPackage.test.ts
@@ -68,7 +68,7 @@ suite("AppPackage", () => {
       publisher: "Default publisher",
       version: "1.0.0.0",
     };
-    const appIdentifier = AppPackage.appIdentifier(testAppPath);
+    const appIdentifier = AppPackage.appIdentifierFromFilename(testAppPath);
     assert.deepStrictEqual(appIdentifier, expected, "Unexpected identifier");
   });
 

--- a/extension/src/test/SymbolReference/AppPackage.test.ts
+++ b/extension/src/test/SymbolReference/AppPackage.test.ts
@@ -1,0 +1,97 @@
+import * as assert from "assert";
+import * as path from "path";
+import { AppPackage } from "../../SymbolReference/types/AppPackage";
+
+suite("AppPackage", () => {
+  const testResourcesPath = path.resolve(
+    __dirname,
+    "../../../src/test/resources"
+  );
+  const testAppPath = path.resolve(
+    testResourcesPath,
+    ".alpackages/Default publisher_Al_1.0.0.0.app"
+  );
+  test("AppPackage.fromFile", function () {
+    const appPackage = AppPackage.fromFile(testAppPath);
+    assert.strictEqual(appPackage.filePath, testAppPath);
+    assert.strictEqual(appPackage.name, "Al");
+    assert.strictEqual(appPackage.publisher, "Default publisher");
+    assert.strictEqual(appPackage.version, "1.0.0.0");
+    assert.ok(appPackage.manifest);
+    assert.ok(appPackage.symbolReference);
+  });
+
+  test("AppPackage.fromFile - Error: RT Package", function () {
+    const runtimePackagePath = path.resolve(
+      testResourcesPath,
+      ".alpackages/Default publisher_AlRuntimePackage_18.3.24557.0.app"
+    );
+    assert.throws(
+      () => {
+        AppPackage.fromFile(runtimePackagePath);
+      },
+      (err) => {
+        assert.ok(err instanceof Error);
+        assert.strictEqual(
+          err.message,
+          `Runtime Packages is not supported (${runtimePackagePath})`
+        );
+        return true;
+      }
+    );
+  });
+
+  test("AppPackage.fromFile - Error: not an app file", function () {
+    const notAnAppFile = path.resolve(
+      testResourcesPath,
+      "XliffCacheTest.da-DK.xlf"
+    );
+    assert.throws(
+      () => {
+        AppPackage.fromFile(notAnAppFile);
+      },
+      (err) => {
+        assert.ok(err instanceof Error);
+        assert.strictEqual(
+          err.message,
+          `"${notAnAppFile}" is not a valid app file`
+        );
+        return true;
+      }
+    );
+  });
+
+  test("AppPackage.appIdentifier", function () {
+    const expected = {
+      valid: true,
+      name: "Al",
+      publisher: "Default publisher",
+      version: "1.0.0.0",
+    };
+    const appIdentifier = AppPackage.appIdentifier(testAppPath);
+    assert.deepStrictEqual(appIdentifier, expected, "Unexpected identifier");
+  });
+
+  test("AppPackage.byteArrayToGuid", function () {
+    const byteArray = [
+      230,
+      206,
+      240,
+      58,
+      187,
+      136,
+      57,
+      69,
+      131,
+      93,
+      96,
+      17,
+      81,
+      33,
+      160,
+      197,
+    ];
+    const guid = AppPackage.byteArrayToGuid(byteArray);
+    assert.strictEqual(guid, "3af0cee6-88bb-4539-835d-60115121a0c5");
+  });
+});

--- a/extension/src/test/SymbolReference/SymbolReferenceCache.test.ts
+++ b/extension/src/test/SymbolReference/SymbolReferenceCache.test.ts
@@ -16,7 +16,7 @@ suite("Symbol Reference Cache", () => {
     const cache = new SymbolReferenceCache();
     cache.set(appPackage);
     assert.strictEqual(cache.size, 1);
-    assert.deepStrictEqual(cache.get(appPackage), appPackage);
+    assert.deepStrictEqual(cache.get(appPackage.appIdentifier), appPackage);
   });
 
   test("SymbolReferenceCache.set()", function () {

--- a/extension/src/test/SymbolReference/SymbolReferenceCache.test.ts
+++ b/extension/src/test/SymbolReference/SymbolReferenceCache.test.ts
@@ -1,0 +1,50 @@
+import * as path from "path";
+import * as assert from "assert";
+import { SymbolReferenceCache } from "../../SymbolReference/SymbolReferenceCache";
+import * as SymbolReferenceReader from "../../SymbolReference/SymbolReferenceReader";
+
+suite("Symbol Reference Cache", () => {
+  const testResourcesPath = "../../../src/test/resources/.alpackages";
+  const testAppPath = path.resolve(
+    __dirname,
+    testResourcesPath,
+    "Default publisher_Al_1.0.0.0.app"
+  );
+
+  const appPackage = SymbolReferenceReader.getObjectsFromAppFile(testAppPath);
+  test("SymbolReferenceCache.get()", function () {
+    const cache = new SymbolReferenceCache();
+    cache.set(appPackage);
+    assert.strictEqual(cache.size, 1);
+    assert.deepStrictEqual(cache.get(appPackage), appPackage);
+  });
+
+  test("SymbolReferenceCache.set()", function () {
+    const cache = new SymbolReferenceCache();
+    cache.set(appPackage);
+    assert.strictEqual(cache.size, 1);
+    assert.ok(cache.isCached(appPackage));
+  });
+
+  test("SymbolReferenceCache.isCached()", function () {
+    const cache = new SymbolReferenceCache();
+    cache.set(appPackage);
+    assert.ok(cache.isCached(appPackage));
+  });
+
+  test("SymbolReferenceCache.delete()", function () {
+    const cache = new SymbolReferenceCache();
+    cache.set(appPackage);
+    assert.strictEqual(cache.size, 1);
+    assert.ok(cache.delete(appPackage));
+    assert.strictEqual(cache.size, 0);
+  });
+
+  test("SymbolReferenceCache.clear()", function () {
+    const cache = new SymbolReferenceCache();
+    cache.set(appPackage);
+    assert.strictEqual(cache.size, 1);
+    cache.clear();
+    assert.strictEqual(cache.size, 0);
+  });
+});

--- a/extension/src/test/SymbolReference/SymbolReferenceCache.test.ts
+++ b/extension/src/test/SymbolReference/SymbolReferenceCache.test.ts
@@ -1,7 +1,7 @@
 import * as path from "path";
 import * as assert from "assert";
 import { SymbolReferenceCache } from "../../SymbolReference/SymbolReferenceCache";
-import * as SymbolReferenceReader from "../../SymbolReference/SymbolReferenceReader";
+import { AppPackage } from "../../SymbolReference/types/AppPackage";
 
 suite("Symbol Reference Cache", () => {
   const testResourcesPath = "../../../src/test/resources/.alpackages";
@@ -11,7 +11,7 @@ suite("Symbol Reference Cache", () => {
     "Default publisher_Al_1.0.0.0.app"
   );
 
-  const appPackage = SymbolReferenceReader.getObjectsFromAppFile(testAppPath);
+  const appPackage = AppPackage.fromFile(testAppPath);
   test("SymbolReferenceCache.get()", function () {
     const cache = new SymbolReferenceCache();
     cache.set(appPackage);
@@ -29,6 +29,7 @@ suite("Symbol Reference Cache", () => {
   test("SymbolReferenceCache.isCached()", function () {
     const cache = new SymbolReferenceCache();
     cache.set(appPackage);
+    assert.strictEqual(cache.size, 1);
     assert.ok(cache.isCached(appPackage));
   });
 

--- a/extension/src/test/Symbols.test.ts
+++ b/extension/src/test/Symbols.test.ts
@@ -75,10 +75,11 @@ suite("Symbol Parsing", function () {
       );
       assert.fail(`Unexpected success of parsing ${appPackage.name}`);
     } catch (error) {
+      const err = error as Error;
       assert.equal(
-        error.message.startsWith("Runtime Packages"),
+        err.message.startsWith("Runtime Packages"),
         true,
-        `Unexpected error message (${error.message}`
+        `Unexpected error message (${err.message}`
       );
     }
   });

--- a/extension/src/test/Symbols.test.ts
+++ b/extension/src/test/Symbols.test.ts
@@ -3,6 +3,7 @@ import * as assert from "assert";
 import * as SymbolReferenceReader from "../SymbolReference/SymbolReferenceReader";
 import { ALControlType } from "../ALObject/Enums";
 import { ALTableField } from "../ALObject/ALTableField";
+import { AppPackage } from "../SymbolReference/types/AppPackage";
 
 const testResourcesPath = "../../src/test/resources/.alpackages";
 
@@ -25,19 +26,19 @@ const runtimePackagePath = path.resolve(
 suite("Symbol Parsing", function () {
   test("TestApp", function () {
     const appPackage = SymbolReferenceReader.getObjectsFromAppFile(testAppPath);
-    assert.deepEqual(appPackage.manifest?.App[0]._attributes.Name, "Al");
-    assert.deepEqual(
+    assert.deepStrictEqual(appPackage.manifest?.App[0]._attributes.Name, "Al");
+    assert.deepStrictEqual(
       appPackage.packageId,
       "3af0cee6-88bb-4539-835d-60115121a0c5",
       "unexpected packageId"
     );
     if (appPackage.objects) {
-      assert.deepEqual(
+      assert.deepStrictEqual(
         appPackage.objects.length,
         6,
         "unexpected number of objects"
       );
-      assert.deepEqual(
+      assert.deepStrictEqual(
         appPackage.objects[0].name,
         "NAB Test Table",
         "unexpected table name"
@@ -48,7 +49,7 @@ suite("Symbol Parsing", function () {
   });
   test("BaseApp Package", function () {
     this.timeout(10000);
-    const appPackage = SymbolReferenceReader.getAppPackage(baseAppPath, false);
+    const appPackage = AppPackage.getAppPackage(baseAppPath, false);
     assert.deepEqual(
       appPackage.manifest?.App[0]._attributes.Name,
       "Base Application"

--- a/extension/src/test/Symbols.test.ts
+++ b/extension/src/test/Symbols.test.ts
@@ -17,11 +17,6 @@ const testAppPath = path.resolve(
   testResourcesPath,
   "Default publisher_Al_1.0.0.0.app"
 );
-const runtimePackagePath = path.resolve(
-  __dirname,
-  testResourcesPath,
-  "Default publisher_AlRuntimePackage_18.3.24557.0.app"
-);
 
 suite("Symbol Parsing", function () {
   test("TestApp", function () {
@@ -67,22 +62,6 @@ suite("Symbol Parsing", function () {
   test("BaseApp with objects from cache", function () {
     // Cached by previous test
     testBaseApp();
-  });
-
-  test("Runtime Package", function () {
-    try {
-      const appPackage = SymbolReferenceReader.getObjectsFromAppFile(
-        runtimePackagePath
-      );
-      assert.fail(`Unexpected success of parsing ${appPackage.name}`);
-    } catch (error) {
-      const err = error as Error;
-      assert.equal(
-        err.message.startsWith("Runtime Packages"),
-        true,
-        `Unexpected error message (${err.message}`
-      );
-    }
   });
 });
 

--- a/extension/src/test/Symbols.test.ts
+++ b/extension/src/test/Symbols.test.ts
@@ -49,7 +49,7 @@ suite("Symbol Parsing", function () {
   });
   test("BaseApp Package", function () {
     this.timeout(10000);
-    const appPackage = AppPackage.getAppPackage(baseAppPath, false);
+    const appPackage = AppPackage.fromFile(baseAppPath, false);
     assert.deepEqual(
       appPackage.manifest?.App[0]._attributes.Name,
       "Base Application"


### PR DESCRIPTION
Changes proposed in this PR:
- Move functions to more context appropriate files:
  - `getZipEntryContentOrEmpty` from `SymbolReferenceReader` to `FileFunctions`. 
- Separate AppPackage functions from `SymbolReferenceReader` by moving them to `AppPackage` class with the intention to make `AppPackage` more self sufficient and stand alone.
  - Added tests for `AppPackage`.
  - Added two new interfaces: `AppFileContent` and `AppIdentifier`
- New class `SymbolReferenceCache`that follows the same pattern as `XliffCache`.


Additional comments:
There still is a possibility to extract all functions except  `getObjectsFromAppFile` from `SymbolReferenceReader.ts` but I couldn't decide if that would be appropriate. The remaining functions feel like they're placed within the right context. 

`tableToObject` and `pageToObject` could be moved to `ALObject` if that wouldn't be the wrong place. Else I'm thinking that a class implementation of `SymbolReference` could be the right place for `SymbolReferenceReader.parseObjectsInAppPackage`and the subsequent function. Many ideas but not sure which is the better or if this is the right time.

There is one `TODO` left for be to look into. Anyhow, happy reviewing.