### PR TITLE
ci: cli tests and coverage

### DIFF
--- a/dev-tools/test-coverage/README.md
+++ b/dev-tools/test-coverage/README.md
@@ -1,0 +1,19 @@
+# Test Coverage
+
+Run the following command from the `extension` directory.
+
+```bash
+$ npx nyc npm run test:coverage
+
+# Test runner output...
+
+# Lastly a coverage summary is printed
+=============================== Coverage summary ===============================
+Statements   : 82.61% ( 3830/4636 )
+Branches     : 65.11% ( 1786/2743 )
+Functions    : 84.54% ( 662/783 )
+Lines        : 82.43% ( 3751/4550 )
+================================================================================
+```
+
+The report files can be found in [extension/.coverage/lcov-report/index.html](../../extension/.coverage/lcov-report/index.html)

--- a/extension/.nycrc.json
+++ b/extension/.nycrc.json
@@ -21,7 +21,7 @@
   "check-coverage": true,
   "report-dir": ".coverage",
   "statements": 82,
-  "branches": 64,
-  "functions": 83,
+  "branches": 65,
+  "functions": 84,
   "lines": 82
 }

--- a/extension/src/test/VSCodeFunctions.test.ts
+++ b/extension/src/test/VSCodeFunctions.test.ts
@@ -2,9 +2,15 @@ import * as assert from "assert";
 import * as VSCodeFunctions from "../VSCodeFunctions";
 
 suite("VSCodeFunctions", function () {
-  test("findTextFiles()", async function () {
+  test("findTextFiles() - optional param filesToInclude", async function () {
     await assert.doesNotReject(async () => {
       VSCodeFunctions.findTextInFiles("table", false, ".md");
+    }, "Unexpected rejection of promise");
+  });
+
+  test("findTextFiles()", async function () {
+    await assert.doesNotReject(async () => {
+      VSCodeFunctions.findTextInFiles("table", false);
     }, "Unexpected rejection of promise");
   });
 });

--- a/extension/src/test/XliffFunctions.test.ts
+++ b/extension/src/test/XliffFunctions.test.ts
@@ -1,5 +1,6 @@
 import * as assert from "assert";
 import { TranslationMode } from "../Enums";
+import * as SettingsLoader from "../Settings/SettingsLoader";
 import {
   SizeUnit,
   Target,
@@ -10,6 +11,14 @@ import {
 import * as XliffFunctions from "../XliffFunctions";
 
 suite("XliffFunctions Tests", function () {
+  test("getGXlfDocument()", async function () {
+    const settings = SettingsLoader.getSettings();
+    const appManifest = SettingsLoader.getAppManifest();
+    await assert.doesNotReject(async () => {
+      return XliffFunctions.getGXlfDocument(settings, appManifest);
+    }, "Unexpected rejection of promise");
+  });
+
   test("formatTransUnitForTranslationMode: dts", function () {
     const tu = getTransUnit();
     tu.target.translationToken = TranslationToken.notTranslated;

--- a/extension/src/test/markdown/YamlItem.test.ts
+++ b/extension/src/test/markdown/YamlItem.test.ts
@@ -1,0 +1,85 @@
+import * as assert from "assert";
+import { YamlItem } from "../../markdown/YamlItem";
+suite("YamlItem", () => {
+  const items = [
+    new YamlItem({
+      name: "test1",
+      topicHref: "testTopicHref1",
+      href: "testHref1",
+    }),
+    new YamlItem({
+      name: "test2",
+      topicHref: "testTopicHref1",
+      href: "testHref3",
+    }),
+  ];
+  const parent = new YamlItem({
+    name: "parent",
+    topicHref: "parentTopicHef",
+    href: "parentHref",
+    items: items,
+  });
+
+  test("YamlItem.toString()", function () {
+    const actual = parent.toString();
+    assert.strictEqual(
+      actual,
+      expectedToStringValue(),
+      "Unexpected string returned"
+    );
+  });
+  test("YamlItem.toString() - level", function () {
+    const actual = parent.toString(1);
+    assert.strictEqual(
+      actual,
+      expectedToStringLevelValue(),
+      "Unexpected string returned"
+    );
+  });
+  test("YamlItem.arrayToString()", function () {
+    const actual = YamlItem.arrayToString(items);
+    assert.strictEqual(
+      actual,
+      expectedArrayToStringValue(),
+      "Unexpected string returned"
+    );
+  });
+});
+
+function expectedToStringValue(): string {
+  return `- name: parent
+  href: parentHref
+  topicHref: parentTopicHef
+  items:
+  - name: test1
+    href: testHref1
+    topicHref: testTopicHref1
+  - name: test2
+    href: testHref3
+    topicHref: testTopicHref1
+`;
+}
+
+function expectedToStringLevelValue(): string {
+  return `  - name: parent
+    href: parentHref
+    topicHref: parentTopicHef
+    items:
+    - name: test1
+      href: testHref1
+      topicHref: testTopicHref1
+    - name: test2
+      href: testHref3
+      topicHref: testTopicHref1
+`;
+}
+
+function expectedArrayToStringValue(): string {
+  return `- name: test1
+  href: testHref1
+  topicHref: testTopicHref1
+- name: test2
+  href: testHref3
+  topicHref: testTopicHref1
+`;
+}

--- a/extension/src/test/runTest-coverage.ts
+++ b/extension/src/test/runTest-coverage.ts
@@ -22,6 +22,7 @@ async function main(): Promise<void> {
     );
     // Download VS Code, unzip it and run the integration test
     await runTests({
+      version: "insiders",
       extensionDevelopmentPath,
       extensionTestsPath,
       launchArgs: [testWorkspace],

--- a/extension/src/test/suite/index-coverage.ts
+++ b/extension/src/test/suite/index-coverage.ts
@@ -59,8 +59,6 @@ export function run(): Promise<void> {
           }
         });
       } catch (err) {
-        // tslint:disable-next-line: no-console
-        console.error(err);
         e(err);
       } finally {
         if (nyc) {

--- a/extension/src/test/suite/index-coverage.ts
+++ b/extension/src/test/suite/index-coverage.ts
@@ -16,7 +16,6 @@ function setupNyc(): any {
     hookRunInContext: true,
     hookRunInThisContext: true,
     instrument: true,
-    reporter: ["text", "html", "cobertura"],
     require: ["ts-node/register"],
     sourceMap: true,
   });

--- a/extension/src/test/suite/index.ts
+++ b/extension/src/test/suite/index.ts
@@ -35,7 +35,6 @@ export function run(): Promise<void> {
           }
         });
       } catch (err) {
-        console.error(err);
         e(err);
       }
     });


### PR DESCRIPTION
<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- use `insiders` when running tests with `runTest-coverage.ts` this enables running command line tests without closing all instances of vscode! A [tip](https://code.visualstudio.com/api/working-with-extensions/testing-extension#tips) I just happened to stumble upon. I haven't noticed any issues running with insiders but it's important to note that this means that `insiders` will always be used in the workflow. It should be fine and it's simple to revert.
- I removed the reporters from NYC configuration. Duplicate reports were exported and only on of them were correct. The new README points you in the right direction.
- Removed some console logs that seemed out of place in the test runners.
- Added to tests to confirm that the coverage report was behaving correctly.

Additional comments
At first I thought that I had fixed the unwanted terminal output... but that doesn't seem to be the case.
