### PR TITLE
feat: Renumber AL Objects

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -7,9 +7,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 -->
 
-## [1.16]
+## [1.15]
 
 - New features:
+  - `NAB: Renumber AL objects` renumbers all AL objects in the currently open project according to the idRanges in app.json.
   - New cli function `RefreshXLF.js` invokes `NAB: Refresh XLF files from g.xlf` and optionally `NAB: Update g.xlf`. See README for details. Want to see more functions enabled for command line/pipeline? Comment on [issue 158](https://github.com/jwikman/nab-al-tools/issues/158) while it's still open (or just create a new issue).
   - New feature `NAB: Create AL Project from Template (preview)` that uses a template settings file (named `al.template.json`) to create an AL Project from a Template Project. This is currently released as a "public preview" feature, and the functionality or naming can be changed.
     - The user is prompted to supply input values

--- a/extension/README.md
+++ b/extension/README.md
@@ -40,6 +40,7 @@ NAB AL Tools supports the pre-release functionality in VSCode v1.63 and later (r
   - [NAB: Export Translations to .csv (Select columns and filter)](#nab-export-translations-to-csv-select-columns-and-filter)
   - [NAB: Import Translations from .csv](#nab-import-translations-from-csv)
   - [NAB: Convert to PermissionSet object](#nab-convert-to-permissionset-object)
+  - [NAB: Renumber AL objects](#nab-renumber-al-objects)
   - [NAB: Create AL Project from Template](#nab-create-al-project-from-template)
 - [Snippets](#snippets)
 
@@ -551,6 +552,10 @@ Converts a PermissionSet defined in XML into a PermissionSet object.
   - etc.
 - After the PermissionSet objects has been created, the old Xml PermissionSet files are deleted.
 - An upgrade codeunit is created that maps the usage of the old Xml PermissionSet to the new PermissionSet object.
+
+### NAB: Renumber AL objects
+
+Renumbers all AL objects in the currently open project according to the idRanges in app.json.
 
 ### NAB: Create AL Project from Template
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -265,6 +265,10 @@
         "title": "NAB: Create AL Project from Template (preview)"
       },
       {
+        "command": "nab.renumberALObjects",
+        "title": "NAB: Renumber AL objects"
+      },
+      {
         "command": "nab.troubleshootParseCurrentFile",
         "title": "NAB: Troubleshoot - Parse current file",
         "enablement": "config.NAB.EnableTroubleshootingCommands"

--- a/extension/src/ALObject/ALParser.ts
+++ b/extension/src/ALObject/ALParser.ts
@@ -547,7 +547,14 @@ function getMlObjectFromMatch(
   }
   return;
 }
-
+export function getALObjectFromFile(
+  filePath: string,
+  parseBody?: boolean,
+  alObjects?: ALObject[]
+): ALObject | undefined {
+  const content = fs.readFileSync(filePath, { encoding: "utf8" });
+  return getALObjectFromText(content, parseBody, filePath, alObjects);
+}
 export function getALObjectFromText(
   objectAsText?: string,
   parseBody?: boolean,

--- a/extension/src/RenumberObjects.ts
+++ b/extension/src/RenumberObjects.ts
@@ -1,0 +1,52 @@
+import * as FileFunctions from "./FileFunctions";
+import * as CliSettingsLoader from "./Settings/CliSettingsLoader";
+import * as fs from "fs";
+import { ALObjectType } from "./ALObject/Enums";
+import { getALObjectFromFile } from "./ALObject/ALParser";
+
+export function renumberObjectsInFolder(folderPath: string): number {
+  let numberOfChangedObjects = 0;
+  const appManifest = CliSettingsLoader.getAppManifest(folderPath);
+  const alFiles = FileFunctions.findFiles("**/*.al", folderPath);
+  const objectNumbers: Map<ALObjectType, number> = new Map();
+  const currentIdRanges: Map<ALObjectType, number> = new Map();
+  for (const alFile of alFiles) {
+    const alObject = getALObjectFromFile(alFile, false);
+    if (alObject) {
+      const lastNumber = objectNumbers.get(alObject.objectType);
+      let newNumber = 0;
+      if (!lastNumber) {
+        newNumber = appManifest.idRanges[0].from;
+        currentIdRanges.set(alObject.objectType, 0);
+      } else {
+        newNumber = lastNumber + 1;
+        let currentIdRange = currentIdRanges.get(alObject.objectType) || 0;
+        if (newNumber > appManifest.idRanges[currentIdRange].to) {
+          currentIdRange++;
+          if (currentIdRange >= appManifest.idRanges.length) {
+            throw new Error(
+              "The idRanges in the app.json does not contain enough numbers to renumber all objects."
+            );
+          }
+          currentIdRanges.set(alObject.objectType, currentIdRange);
+          newNumber = appManifest.idRanges[currentIdRange].from;
+        }
+      }
+      objectNumbers.set(alObject.objectType, newNumber);
+      let content = fs.readFileSync(alFile, { encoding: "utf8" });
+      const regex = new RegExp(
+        `^(\\s*${alObject.objectType.toString()}\\s+)\\d+(\\s+"?${
+          alObject.objectName
+        }"?)`,
+        "im"
+      );
+      const oldContent = content;
+      content = content.replace(regex, `$1${newNumber}$2`);
+      if (content !== oldContent) {
+        numberOfChangedObjects++;
+      }
+      fs.writeFileSync(alFile, content, { encoding: "utf8" });
+    }
+  }
+  return numberOfChangedObjects;
+}

--- a/extension/src/Template/TemplateFunctions.ts
+++ b/extension/src/Template/TemplateFunctions.ts
@@ -1,14 +1,13 @@
 import * as FileFunctions from "../FileFunctions";
+import * as RenumberObjects from "../RenumberObjects";
+import * as CliSettingsLoader from "../Settings/CliSettingsLoader";
 import * as path from "path";
 import * as fs from "fs";
 import * as replace from "replace-in-file";
-import * as CliSettingsLoader from "../Settings/CliSettingsLoader";
 import { escapeRegex } from "../Common";
 import { TemplateSettings } from "./TemplateTypes";
 import { logger } from "../Logging/LogHelper";
 import { Xliff } from "../Xliff/XLIFFDocument";
-import { ALObjectType } from "../ALObject/Enums";
-import { getALObjectFromFile } from "../ALObject/ALParser";
 
 export function validateData(templateSettings: TemplateSettings): void {
   const guidRegex = RegExp(
@@ -144,34 +143,6 @@ function createXlfFiles(
 function renumberObjects(appManifestPaths: string[]): void {
   for (const appManifestPath of appManifestPaths) {
     const folderPath = path.dirname(appManifestPath);
-    renumberObjectsInFolder(folderPath);
-  }
-}
-function renumberObjectsInFolder(folderPath: string): void {
-  const appManifest = CliSettingsLoader.getAppManifest(folderPath);
-  const alFiles = FileFunctions.findFiles("**/*.al", folderPath);
-  const objectNumbers: Map<ALObjectType, number> = new Map();
-  for (const alFile of alFiles) {
-    const alObject = getALObjectFromFile(alFile, false);
-    if (alObject) {
-      const lastNumber = objectNumbers.get(alObject.objectType);
-      let newNumber = 0;
-      if (!lastNumber) {
-        newNumber = appManifest.idRanges[0].from;
-      } else {
-        newNumber = lastNumber + 1;
-      }
-      // TODO: Check if number is larger than appManifest.idRanges[0].to and handle
-      objectNumbers.set(alObject.objectType, newNumber);
-      let content = fs.readFileSync(alFile, { encoding: "utf8" });
-      const regex = new RegExp(
-        `^(\\s*${alObject.objectType.toString()}\\s+)\\d+(\\s+"?${
-          alObject.objectName
-        }"?)`,
-        "im"
-      );
-      content = content.replace(regex, `$1${newNumber}$2`);
-      fs.writeFileSync(alFile, content, { encoding: "utf8" });
-    }
+    RenumberObjects.renumberObjectsInFolder(folderPath);
   }
 }

--- a/extension/src/Template/TemplateFunctions.ts
+++ b/extension/src/Template/TemplateFunctions.ts
@@ -65,8 +65,11 @@ export async function startConversion(
           renameFile(
             filePath,
             renameFileSetting.match,
-            renameFileSetting.removeSpaces
-              ? mapping.value.replace(/ /g, "")
+            renameFileSetting.replaceSpaces
+              ? mapping.value.replace(
+                  / /g,
+                  renameFileSetting.replaceSpacesWith ?? ""
+                )
               : mapping.value
           );
         }

--- a/extension/src/Template/TemplateTypes.ts
+++ b/extension/src/Template/TemplateTypes.ts
@@ -5,6 +5,7 @@ export class TemplateSettings implements ITemplateSettings {
   templateSettingsPath = "";
   mappings: IMapping[];
   createXlfLanguages: string[];
+  renumberObjects = true;
 
   public static fromFile(templateSettingsPath: string): TemplateSettings {
     if (!existsSync(templateSettingsPath)) {
@@ -23,6 +24,9 @@ export class TemplateSettings implements ITemplateSettings {
 
     this.mappings = templateSettings.mappings;
     this.createXlfLanguages = templateSettings.createXlfLanguages;
+    if (templateSettings.renumberObjects === false) {
+      this.renumberObjects = false;
+    }
   }
 
   public setDefaults(): void {
@@ -37,6 +41,7 @@ export class TemplateSettings implements ITemplateSettings {
 interface ITemplateSettings {
   mappings: IMapping[];
   createXlfLanguages: string[];
+  renumberObjects: boolean;
 }
 interface IRenameFiles {
   path: string;

--- a/extension/src/Template/TemplateTypes.ts
+++ b/extension/src/Template/TemplateTypes.ts
@@ -46,7 +46,8 @@ interface ITemplateSettings {
 interface IRenameFiles {
   path: string;
   match: string;
-  removeSpaces: boolean;
+  replaceSpaces: boolean;
+  replaceSpacesWith: string;
 }
 
 interface IPlaceholderSubstitutions {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -152,6 +152,9 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand("nab.createProjectFromTemplate", () => {
       NABfunctions.createProjectFromTemplate(context.extensionUri);
     }),
+    vscode.commands.registerCommand("nab.renumberALObjects", () => {
+      NABfunctions.renumberALObjects();
+    }),
     vscode.commands.registerCommand("nab.troubleshootParseCurrentFile", () => {
       NABfunctions.troubleshootParseCurrentFile();
     }),

--- a/extension/src/test/ALObject/ALObject.test.ts
+++ b/extension/src/test/ALObject/ALObject.test.ts
@@ -20,15 +20,16 @@ const testFiles = [
   "NAB_AL_Tools.da-DK.xlf",
   "NAB_AL_Tools.sv-SE.xlf",
 ];
-const langFilesUri: string[] = [];
-testFiles.forEach((f) => {
-  const fromPath = path.resolve(__dirname, testResourcesPath, f);
-  const toPath = path.resolve(__dirname, testResourcesPath, "temp", f);
-  fs.copyFileSync(fromPath, toPath);
-  langFilesUri.push(toPath);
-});
 
 suite("ALObject TransUnit Tests", function () {
+  const langFilesUri: string[] = [];
+  testFiles.forEach((f) => {
+    const fromPath = path.resolve(__dirname, testResourcesPath, f);
+    const toPath = path.resolve(__dirname, testResourcesPath, "temp", f);
+    fs.copyFileSync(fromPath, toPath);
+    langFilesUri.push(toPath);
+  });
+
   test("Refresh xlf - Detect Invalid Targets - NabTags", function () {
     const translationMode = TranslationMode.nabTags;
 

--- a/extension/src/test/DTSImport.test.ts
+++ b/extension/src/test/DTSImport.test.ts
@@ -14,15 +14,16 @@ const testFiles = [
   "NAB_AL_Tools.da-DK.xlf",
   "NAB_AL_Tools.sv-SE.xlf",
 ];
-const langFilesUri: string[] = [];
-testFiles.forEach((f) => {
-  const fromPath = path.resolve(__dirname, testResourcesPath, f);
-  const toPath = path.resolve(__dirname, testResourcesPath, "temp", f);
-  fs.copyFileSync(fromPath, toPath);
-  langFilesUri.push(toPath);
-});
 
 suite("DTS Import Tests", function () {
+  const langFilesUri: string[] = [];
+  testFiles.forEach((f) => {
+    const fromPath = path.resolve(__dirname, testResourcesPath, f);
+    const toPath = path.resolve(__dirname, testResourcesPath, "temp", f);
+    fs.copyFileSync(fromPath, toPath);
+    langFilesUri.push(toPath);
+  });
+
   const sourceXliff = Xliff.fromString(`<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="sv-SE" original="AlTestApp.g.xlf">

--- a/extension/src/test/LanguageFunctions.test.ts
+++ b/extension/src/test/LanguageFunctions.test.ts
@@ -34,14 +34,14 @@ const testFiles = [
   "NAB_AL_Tools.sv-SE.xlf",
 ];
 const langFilesUri: string[] = [];
-testFiles.forEach((f) => {
-  const fromPath = path.resolve(__dirname, testResourcesPath, f);
-  const toPath = path.resolve(__dirname, testResourcesPath, "temp", f);
-  fs.copyFileSync(fromPath, toPath);
-  langFilesUri.push(toPath);
-});
 
 suite("Language Functions Tests", function () {
+  testFiles.forEach((f) => {
+    const fromPath = path.resolve(__dirname, testResourcesPath, f);
+    const toPath = path.resolve(__dirname, testResourcesPath, "temp", f);
+    fs.copyFileSync(fromPath, toPath);
+    langFilesUri.push(toPath);
+  });
   const settings = SettingsLoader.getSettings();
   const appManifest = SettingsLoader.getAppManifest();
 

--- a/extension/src/test/Template.test.ts
+++ b/extension/src/test/Template.test.ts
@@ -17,22 +17,24 @@ const testResourcesPath = path.resolve(
   __dirname,
   "../../src/test/resources/temp/templateSettings"
 );
-if (fs.existsSync(testResourcesPath)) {
-  FileFunctions.deleteFolderRecursive(testResourcesPath);
-}
 
 const testFilesSourcePath = path.resolve(
   __dirname,
   sourceResourcesPath,
   "files"
 );
-FileFunctions.copyFolderSync(testFilesSourcePath, testResourcesPath);
-const templateSettingsFilePath = path.resolve(
-  testResourcesPath,
-  templateSettingsFilename
-);
 
-suite("Template", function () {
+suite.only("Template", function () {
+  if (fs.existsSync(testResourcesPath)) {
+    FileFunctions.deleteFolderRecursive(testResourcesPath);
+  }
+
+  FileFunctions.copyFolderSync(testFilesSourcePath, testResourcesPath);
+  const templateSettingsFilePath = path.resolve(
+    testResourcesPath,
+    templateSettingsFilename
+  );
+
   test("Parse Template Settings file", function () {
     const templateSettings = TemplateSettings.fromFile(
       largerTemplateSettingsFilePath
@@ -176,6 +178,24 @@ suite("Template", function () {
         .replace(/[\r\n]*/g, ""),
       `${templateSettings.mappings[2].value} - ${templateSettings.mappings[3].value}`,
       "Unexpected content in file2"
+    );
+    assert.strictEqual(
+      fs
+        .readFileSync(path.join(testResourcesPath, "App/src/file3.al"), {
+          encoding: "utf8",
+        })
+        .replace(/[\r\n]*/g, ""),
+      'codeunit 50000 "Test object 1"',
+      "Unexpected content in file3"
+    );
+    assert.strictEqual(
+      fs
+        .readFileSync(path.join(testResourcesPath, "App/src/file4.al"), {
+          encoding: "utf8",
+        })
+        .replace(/[\r\n]*/g, ""),
+      'codeunit 50001 "Test object 2"',
+      "Unexpected content in file4"
     );
     assert.strictEqual(
       fs.existsSync(templateSettingsFilePath),

--- a/extension/src/test/Template.test.ts
+++ b/extension/src/test/Template.test.ts
@@ -155,7 +155,7 @@ suite("Template", function () {
     assert.strictEqual(
       path.basename(workspaceFile),
       `${FileFunctions.replaceIllegalFilenameCharacters(
-        appName.replace(/ /g, ""),
+        appName.replace(/ /g, "-"),
         "-"
       )}.code-workspace`,
       "Unexpected workspace file name"

--- a/extension/src/test/Template.test.ts
+++ b/extension/src/test/Template.test.ts
@@ -24,7 +24,7 @@ const testFilesSourcePath = path.resolve(
   "files"
 );
 
-suite.only("Template", function () {
+suite("Template", function () {
   if (fs.existsSync(testResourcesPath)) {
     FileFunctions.deleteFolderRecursive(testResourcesPath);
   }

--- a/extension/src/test/resources/templateSettings/al.template.json
+++ b/extension/src/test/resources/templateSettings/al.template.json
@@ -8,7 +8,8 @@
         {
           "path": "/NAB_PTE_TEMPLATE.code-workspace",
           "match": "NAB_PTE_TEMPLATE",
-          "removeSpaces": true
+          "replaceSpaces": true,
+          "replaceSpacesWith": "-"
         }
       ],
       "placeholderSubstitutions": [

--- a/extension/src/test/resources/templateSettings/files/App/src/file3.al
+++ b/extension/src/test/resources/templateSettings/files/App/src/file3.al
@@ -1,0 +1,1 @@
+codeunit [NAB_RANGE_START] "Test object 1"

--- a/extension/src/test/resources/templateSettings/files/App/src/file4.al
+++ b/extension/src/test/resources/templateSettings/files/App/src/file4.al
@@ -1,0 +1,1 @@
+codeunit [NAB_RANGE_START] "Test object 2"

--- a/extension/src/test/resources/templateSettings/files/al.template.json
+++ b/extension/src/test/resources/templateSettings/files/al.template.json
@@ -8,7 +8,8 @@
         {
           "path": "/NAB_PTE_TEMPLATE.code-workspace",
           "match": "NAB_PTE_TEMPLATE",
-          "removeSpaces": true
+          "replaceSpaces": true,
+          "replaceSpacesWith": "-"
         }
       ],
       "placeholderSubstitutions": [

--- a/extension/syntaxes/templateSettingsSyntax.json
+++ b/extension/syntaxes/templateSettingsSyntax.json
@@ -202,6 +202,14 @@
         ],
         "pattern": "^\\w+-\\w+$"
       }
+    },
+    "renumberObjects": {
+      "$id": "#root/mappings/items/renameFiles/items/renumberObjects",
+      "title": "Renumber objects",
+      "description": "Specifies if the AL objects should be renumbered according to the object range in app.json after all replacements are finished.",
+      "type": "boolean",
+      "examples": [],
+      "default": true
     }
   }
 }

--- a/extension/syntaxes/templateSettingsSyntax.json
+++ b/extension/syntaxes/templateSettingsSyntax.json
@@ -126,13 +126,20 @@
                   "examples": [],
                   "pattern": "^.+$"
                 },
-                "removeSpaces": {
-                  "$id": "#root/mappings/items/renameFiles/items/removeSpaces",
+                "replaceSpaces": {
+                  "$id": "#root/mappings/items/renameFiles/items/replaceSpaces",
                   "title": "Remove Spaces",
-                  "description": "Specifies if any whitespace in the text that is used for replacing will get any whitespace removed.",
+                  "description": "Specifies if any whitespace in the text that is used for replacing will get any whitespace replaced.",
                   "type": "boolean",
                   "examples": [],
                   "default": false
+                },
+                "replaceSpacesWith": {
+                  "$id": "#root/mappings/items/renameFiles/items/replaceSpaces",
+                  "title": "Remove Spaces",
+                  "description": "Specifies what the whitespace should be replaced with if the replaceSpaces is `true`. Default is an empty string, which will remove any whitespace.",
+                  "type": "string",
+                  "default": ""
                 }
               }
             }


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
Fixes one of the remaining items in #275.

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:
- Support of renumbering AL Objects after Template is applied with a new setting, `renumberObjects` (default active)
- New feature: `NAB: Renumber AL objects`
- Moved some test code with file operations inside the suite. I believe that unnecessary things has been running when only one test is run. 
- Changed a Template setting, `removeSpaces` is now `replaceSpaces` and a new setting `replaceSpacesWith` specifies what the spaces should be replaced with
