### PR TITLE
fix: ObsoleteState Removed removed from docs

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -12,6 +12,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - New features:
   - When running `NAB: Generate External Documentation` an index file is created if the new setting `NAB.documentation.output.indexFile` is enabled. The setting `NAB.documentation.output.indexFileDepth` specifies how many levels of the Table Of Content files that should be used in the index file. The setting `NAB.CreateTocFilesForDocs` must be enabled, otherwise no index file is created, since the index file is created from the Table Of Content (TOC) files.
     - By changing the setting `NAB.documentation.output.indexFilePath` you can give the specify the name of the index file (default `index.md`) and where it should be saved (default in the `Docs` folder).
+- Fixes:
+  - Fixed an issue where Tables and Fields with `ObsoleteState = Removed` was included in the "External Documentation" ([issue 287](https://github.com/jwikman/nab-al-tools/issues/287))
 
 ## [1.16]
 

--- a/extension/src/Documentation.ts
+++ b/extension/src/Documentation.ts
@@ -123,7 +123,7 @@ export async function generateExternalDocumentation(
 
   const publicObjects = objects.filter(
     (obj) =>
-      ([
+      (([
         ALObjectType.codeunit,
         ALObjectType.interface,
         ALObjectType.permissionSet,
@@ -147,13 +147,14 @@ export async function generateExternalDocumentation(
             [ALObjectType.table, ALObjectType.tableExtension].includes(
               obj.getObjectType()
             )))) ||
-      (obj.publicAccess &&
-        obj.getObjectType() === ALObjectType.enum &&
-        obj.getProperty(ALPropertyType.extensible, false)) ||
-      ([ALObjectType.page, ALObjectType.pageExtension].includes(
-        obj.getObjectType()
-      ) &&
-        !obj.apiObject)
+        (obj.publicAccess &&
+          obj.getObjectType() === ALObjectType.enum &&
+          obj.getProperty(ALPropertyType.extensible, false)) ||
+        ([ALObjectType.page, ALObjectType.pageExtension].includes(
+          obj.getObjectType()
+        ) &&
+          !obj.apiObject)) &&
+      !obj.isObsolete()
   );
 
   await generateObjectsDocumentation(
@@ -303,7 +304,7 @@ export async function generateExternalDocumentation(
       webServices?: ALTenantWebService[]
     ): string {
       const filteredObjects = objects.filter(
-        (x) => x.objectType === alObjectType
+        (x) => x.objectType === alObjectType && !x.isObsolete()
       );
       let tableContent = "";
       let obsoleteControls: ALControl[] = [];

--- a/test-app/Xliff-test/src/RemovedTable.Table.al
+++ b/test-app/Xliff-test/src/RemovedTable.Table.al
@@ -1,0 +1,34 @@
+table 50014 "NAB Removed Table"
+{
+    DataClassification = CustomerContent;
+    ObsoleteState = Removed;
+
+    fields
+    {
+        field(1; "Test Field"; Option)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(2; MyField; Blob)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(3; "My <> & Field"; Blob)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(4; DeprecatedField; Text)
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+
+    keys
+    {
+        key(PK; "Test Field")
+        {
+            Clustered = true;
+        }
+    }
+
+}

--- a/test-app/Xliff-test/src/TestTable.Table.al
+++ b/test-app/Xliff-test/src/TestTable.Table.al
@@ -27,6 +27,11 @@ table 50000 "NAB Test Table"
         {
             DataClassification = ToBeClassified;
         }
+        field(4; DeprecatedField; Text)
+        {
+            DataClassification = ToBeClassified;
+            ObsoleteState = Removed;
+        }
     }
 
     keys


### PR DESCRIPTION
Fixes #286.

Changes proposed in this pull request:
- Tables and Table Fields with ObsoleteState = Removed should not be included in the external documentation
