### PR TITLE
fix: Allow non-existing AppSourceCop.json

### DIFF
--- a/extension/src/Settings/CliSettingsLoader.ts
+++ b/extension/src/Settings/CliSettingsLoader.ts
@@ -68,12 +68,15 @@ export function getAppSourceCopSettings(
 ): IAppSourceCopSettings {
   const filePath = join(workspaceFolderPath, "AppSourceCop.json");
 
-  const appSourceCopSettingsJson = loadJson(filePath) as IAppSourceCopSettings;
-  if (!appSourceCopSettingsJson.mandatoryAffixes) {
-    appSourceCopSettingsJson.mandatoryAffixes = [];
+  let appSourceCopSettings = {} as IAppSourceCopSettings;
+  if (fs.existsSync(filePath)) {
+    appSourceCopSettings = loadJson(filePath) as IAppSourceCopSettings;
+  }
+  if (!appSourceCopSettings.mandatoryAffixes) {
+    appSourceCopSettings.mandatoryAffixes = [];
   }
 
-  return appSourceCopSettingsJson;
+  return appSourceCopSettings;
 }
 
 export function getAppManifest(workspaceFolderPath: string): AppManifest {


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
Fixes #290 .

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- If the file AppSourceCop.json does not exist, it will not throw error anymore.
