### PR TITLE
Support Page Views

### DIFF
--- a/extension/.vscode/launch.json
+++ b/extension/.vscode/launch.json
@@ -19,7 +19,6 @@
             "args": [
                 "${workspaceFolder}/../test-app/TestApp.code-workspace",
                 "--extensionDevelopmentPath=${workspaceFolder}",
-                "--disable-extensions",
                 "--skip-welcome",
                 "--skip-release-notes",
                 "--disable-workspace-trust",

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -12,6 +12,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - New features:
   - When running `NAB: Generate External Documentation` an index file is created if the new setting `NAB.documentation.output.indexFile` is enabled. The setting `NAB.documentation.output.indexFileDepth` specifies how many levels of the Table Of Content files that should be used in the index file. The setting `NAB.CreateTocFilesForDocs` must be enabled, otherwise no index file is created, since the index file is created from the Table Of Content (TOC) files.
     - By changing the setting `NAB.documentation.output.indexFilePath` you can give the specify the name of the index file (default `index.md`) and where it should be saved (default in the `Docs` folder).
+  - Added support for [Views](https://docs.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-page-object#views) to Pages and Page Extensions. Thanks to [NKarolak](https://github.com/NKarolak) for bringing this to our attention ([issue 288](https://github.com/jwikman/nab-al-tools/issues/288)).
 - Fixes:
   - Fixed an issue where Tables and Fields with `ObsoleteState = Removed` was included in the "External Documentation" ([issue 287](https://github.com/jwikman/nab-al-tools/issues/287))
 

--- a/extension/src/ALObject/ALElementTypes.ts
+++ b/extension/src/ALObject/ALElementTypes.ts
@@ -506,6 +506,9 @@ export class MultiLanguageObject extends ALElement {
           parent.type === XliffTokenType.control &&
           element.type === XliffTokenType.action;
       }
+      if (!popParent) {
+        popParent = parent.type === XliffTokenType.view;
+      }
       if (popParent) {
         xliffIdTokenArray.splice(index - 1, 1);
         index--;

--- a/extension/src/ALObject/ALParser.ts
+++ b/extension/src/ALObject/ALParser.ts
@@ -212,7 +212,7 @@ export function matchALControl(
   lineIndex: number,
   codeLine: ALCodeLine
 ): ALControl | undefined {
-  const alControlPattern = /^\s*\b(modify)\b\((.*)\)$|^\s*\b(dataitem)\b\((.*);.*\)|^\s*\b(column)\b\((.*);(.*)\)|^\s*\b(value)\b\((\d*);\s*(.*)\)|^\s*\b(group)\b\((.*)\)|^\s*\b(field)\b\(\s*(.*)\s*;\s*(.*);\s*(.*)\s*\)|^\s*\b(field)\b\((.*);(.*)\)|^\s*\b(part)\b\((.*);(.*)\)|^\s*\b(action)\b\((.*)\)|^\s*\b(area)\b\((.*)\)|^\s*\b(trigger)\b (.*)\(.*\)|^\s*\b(procedure)\b ([^()]*)\(|^\s*\blocal (procedure)\b ([^()]*)\(|^\s*\binternal (procedure)\b ([^()]*)\(|^\s*\b(layout)\b$|^\s*\b(requestpage)\b$|^\s*\b(actions)\b$|^\s*\b(cuegroup)\b\((.*)\)|^\s*\b(repeater)\b\((.*)\)|^\s*\b(separator)\b\((.*)\)|^\s*\b(textattribute)\b\((.*)\)|^\s*\b(fieldattribute)\b\(([^;)]*);/i;
+  const alControlPattern = /^\s*\b(modify)\b\((.*)\)$|^\s*\b(view)\b\((.*)\)|^\s*\b(dataitem)\b\((.*);.*\)|^\s*\b(column)\b\((.*);(.*)\)|^\s*\b(value)\b\((\d*);\s*(.*)\)|^\s*\b(group)\b\((.*)\)|^\s*\b(field)\b\(\s*(.*)\s*;\s*(.*);\s*(.*)\s*\)|^\s*\b(field)\b\((.*);(.*)\)|^\s*\b(part)\b\((.*);(.*)\)|^\s*\b(action)\b\((.*)\)|^\s*\b(area)\b\((.*)\)|^\s*\b(trigger)\b (.*)\(.*\)|^\s*\b(procedure)\b ([^()]*)\(|^\s*\blocal (procedure)\b ([^()]*)\(|^\s*\binternal (procedure)\b ([^()]*)\(|^\s*\b(layout)\b$|^\s*\b(requestpage)\b$|^\s*\b(actions)\b$|^\s*\b(cuegroup)\b\((.*)\)|^\s*\b(repeater)\b\((.*)\)|^\s*\b(separator)\b\((.*)\)|^\s*\b(textattribute)\b\((.*)\)|^\s*\b(fieldattribute)\b\(([^;)]*);/i;
   let alControlResult = codeLine.code.match(alControlPattern);
   if (!alControlResult) {
     return;
@@ -222,6 +222,7 @@ export function matchALControl(
   switch (alControlResult[1].toLowerCase()) {
     case "modify":
       switch (parent.getObjectType()) {
+        case ALObjectType.page:
         case ALObjectType.pageExtension:
           control = new ALControl(
             ALControlType.modifiedPageField,
@@ -283,6 +284,10 @@ export function matchALControl(
       } else {
         control.xliffTokenType = XliffTokenType.control;
       }
+      break;
+    case "view":
+      control = new ALControl(ALControlType.pageView, alControlResult[2]);
+      control.xliffTokenType = XliffTokenType.view;
       break;
     case "part":
       control = new ALPagePart(

--- a/extension/src/ALObject/ALParser.ts
+++ b/extension/src/ALObject/ALParser.ts
@@ -224,6 +224,7 @@ export function matchALControl(
       switch (parent.getObjectType()) {
         case ALObjectType.page:
         case ALObjectType.pageExtension:
+        case ALObjectType.pageCustomization:
           control = new ALControl(
             ALControlType.modifiedPageField,
             alControlResult[2]

--- a/extension/src/ALObject/Enums.ts
+++ b/extension/src/ALObject/Enums.ts
@@ -75,6 +75,7 @@ export enum ALControlType {
   modifiedPageField = "ModifiedPageField",
   modifiedTableField = "ModifiedTableField",
   modifiedReportColumn = "ModifiedReportColumn",
+  pageView = "PageView",
 }
 
 export enum MultiLanguageType {
@@ -110,6 +111,7 @@ export enum XliffTokenType {
   action = "Action",
   field = "Field",
   change = "Change",
+  view = "View",
 }
 export enum ALAccessModifier {
   public,

--- a/test-app/TestApp.code-workspace
+++ b/test-app/TestApp.code-workspace
@@ -39,7 +39,8 @@
     "alVarHelper.ignoreALPrefix": "NAB",
     "NAB.documentation.output.indexFile": true,
     "NAB.documentation.output.indexFilePath": "../README.md",
-    "NAB.documentation.output.indexFileDepth": 5
+    "NAB.documentation.output.indexFileDepth": 5,
+    "NAB.GenerateTooltipDocsWithExternalDocs": true
   },
   "extensions": {
     "recommendations": []

--- a/test-app/Xliff-test/README.md
+++ b/test-app/Xliff-test/README.md
@@ -16,6 +16,8 @@
 ### [Pages](docs/pages.md)
 #### [NAB Test Table](docs/page-nab-test-table/index.md)
 ##### [TestMethodPage](docs/page-nab-test-table/test-method-page.md)
+#### [NAB Test View](docs/page-nab-test-view/index.md)
+##### [TestMethodPage](docs/page-nab-test-view/test-method-page.md)
 #### [NAB ToolTip Part 1](docs/page-nab-tool-tip-part-1/index.md)
 #### [NAB ToolTip Part 2](docs/page-nab-tool-tip-part-2/index.md)
 #### [NAB ToolTips](docs/page-nab-tool-tips/index.md)

--- a/test-app/Xliff-test/ToolTips.md
+++ b/test-app/Xliff-test/ToolTips.md
@@ -9,6 +9,13 @@
 | Field | Field | Tooltup 3 |
 | Action | Action | Tooltip 4 |
 
+### Page Caption
+
+| Type | Caption | Description |
+| ----- | --------- | ------- |
+| Field | Field | Tooltup 3 |
+| Action | Action | Tooltip 4 |
+
 ### NAB ToolTip Part 1
 
 | Type | Caption | Description |

--- a/test-app/Xliff-test/ToolTips.md
+++ b/test-app/Xliff-test/ToolTips.md
@@ -9,13 +9,6 @@
 | Field | Field | Tooltup 3 |
 | Action | Action | Tooltip 4 |
 
-### Page Caption
-
-| Type | Caption | Description |
-| ----- | --------- | ------- |
-| Field | Field | Tooltup 3 |
-| Action | Action | Tooltip 4 |
-
 ### NAB ToolTip Part 1
 
 | Type | Caption | Description |

--- a/test-app/Xliff-test/Translations/Al.g.xlf
+++ b/test-app/Xliff-test/Translations/Al.g.xlf
@@ -288,11 +288,6 @@
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - ReportDataItem DataItemName - Property RequestFilterHeading</note>
         </trans-unit>
-        <trans-unit id="Report 529985455 - ReportColumn 967337907 - Property 2879900210" maxwidth="50" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Column</source>
-          <note from="Developer" annotates="general" priority="2">ColumnComment</note>
-          <note from="Xliff Generator" annotates="general" priority="3">Report NAB Test Report - ReportColumn ColumnName - Property Caption</note>
-        </trans-unit>
         <trans-unit id="Report 529985455 - ReportColumn 967337907 - Property 62802879" size-unit="char" translate="yes" xml:space="preserve">
           <source>asd,asdf</source>
           <note from="Developer" annotates="general" priority="2"></note>
@@ -443,11 +438,6 @@
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - Change Application Method - Property Caption</note>
         </trans-unit>
-        <trans-unit id="PageExtension 3795862579 - Change 2039693239 - Property 62802879" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
-          <source>dfee</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - Change Application Method - Property OptionCaption</note>
-        </trans-unit>
         <trans-unit id="PageExtension 3795862579 - Control 3146432722 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
           <source>Tooltip 1</source>
           <note from="Developer" annotates="general" priority="2"></note>
@@ -498,11 +488,6 @@
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">TableExtension NAB Test Table Ext - Change Application Method - Property Caption</note>
         </trans-unit>
-        <trans-unit id="TableExtension 3999646232 - Change 2039693239 - Property 62802879" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Table 1994964448">
-          <source>asdf,adfe</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">TableExtension NAB Test Table Ext - Change Application Method - Property OptionCaption</note>
-        </trans-unit>
         <trans-unit id="TableExtension 2794708188 - Field 157186525 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Table 3276313895">
           <source>Field 1</source>
           <note from="Developer" annotates="general" priority="2"></note>
@@ -532,16 +517,6 @@
           <source>Enum1</source>
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Enum NAB TestEnum - EnumValue MyValue - Property Caption</note>
-        </trans-unit>
-        <trans-unit id="ReportExtension 1459638086 - ReportColumn 3168444338 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Report 919756715">
-          <source>Test 1</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">ReportExtension NAB Test Report Ext. - ReportColumn Address - Property Caption</note>
-        </trans-unit>
-        <trans-unit id="ReportExtension 1459638086 - ReportColumn 179365352 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Report 919756715">
-          <source>Test 2</source>
-          <note from="Developer" annotates="general" priority="2"></note>
-          <note from="Xliff Generator" annotates="general" priority="3">ReportExtension NAB Test Report Ext. - ReportColumn Address2 - Property Caption</note>
         </trans-unit>
       </group>
     </body>

--- a/test-app/Xliff-test/Translations/Al.g.xlf
+++ b/test-app/Xliff-test/Translations/Al.g.xlf
@@ -33,6 +33,11 @@
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Table NAB Test Table - Field MyField - Property Caption</note>
         </trans-unit>
+        <trans-unit id="Table 596208023 - Field 3945078064 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>MyField2</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Table NAB Test Table - Field MyField2 - Property Caption</note>
+        </trans-unit>
         <trans-unit id="Table 596208023 - Field 440443472 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
           <source>Field</source>
           <note from="Developer" annotates="general" priority="2"></note>
@@ -172,6 +177,111 @@
           <source>Local Test Label</source>
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test Table - Action ActionName - Method OnAction - NamedType LocalTestLabelTxt</note>
+        </trans-unit>
+        <trans-unit id="Page 1798807378 - Property 1968111052" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Instructions</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test View - Property InstructionalText</note>
+        </trans-unit>
+        <trans-unit id="Page 1798807378 - Property 2019332006" size-unit="char" translate="yes" xml:space="preserve">
+          <source>asdf,erewf</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test View - Property PromotedActionCategories</note>
+        </trans-unit>
+        <trans-unit id="Page 1798807378 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Page Caption</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test View - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="Page 1798807378 - NamedType 2688233357" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Global Test Label</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test View - NamedType GlobalTestLabelTxt</note>
+        </trans-unit>
+        <trans-unit id="Page 1798807378 - Method 1306612702 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Local Test Label</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test View - Method TestMethodPage - NamedType LocalTestLabelTxt</note>
+        </trans-unit>
+        <trans-unit id="Page 1798807378 - Control 4105281732 - Property 1968111052" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Instruction</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test View - Control GroupName - Property InstructionalText</note>
+        </trans-unit>
+        <trans-unit id="Page 1798807378 - Control 4105281732 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Grp</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test View - Control GroupName - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="Page 1798807378 - Control 1296262074 - Property 1064389655" size-unit="char" translate="yes" xml:space="preserve">
+          <source>MyChanged AboutTitle</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test View - Control MyField - Property AboutTitle</note>
+        </trans-unit>
+        <trans-unit id="Page 1798807378 - Control 1296262074 - Property 247559172" size-unit="char" translate="yes" xml:space="preserve">
+          <source>MyChanged AboutText</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test View - Control MyField - Property AboutText</note>
+        </trans-unit>
+        <trans-unit id="Page 1798807378 - Control 1296262074 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source></source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test View - Control MyField - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="Page 1798807378 - Control 2961552353 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Tooltup 3</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test View - Control Name - Property ToolTip</note>
+        </trans-unit>
+        <trans-unit id="Page 1798807378 - Control 2961552353 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Field</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test View - Control Name - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="Page 1798807378 - Control 2961552353 - Property 62802879" size-unit="char" translate="yes" xml:space="preserve">
+          <source>asdf,sadf,____ASADF</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test View - Control Name - Property OptionCaption</note>
+        </trans-unit>
+        <trans-unit id="Page 1798807378 - Control 2961552353 - Method 2699620902 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Local Test Label</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test View - Control Name - Method OnAssistEdit - NamedType LocalTestLabelTxt</note>
+        </trans-unit>
+        <trans-unit id="Page 1798807378 - Action 3862845261 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
+          <source>AreaTooltip</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test View - Action Processing - Property ToolTip</note>
+        </trans-unit>
+        <trans-unit id="Page 1798807378 - Action 1692444235 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Tooltip 4</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test View - Action ActionName - Property ToolTip</note>
+        </trans-unit>
+        <trans-unit id="Page 1798807378 - Action 1692444235 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Action</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test View - Action ActionName - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="Page 1798807378 - Action 1692444235 - Method 1377591017 - NamedType 1061650423" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Local Test Label</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test View - Action ActionName - Method OnAction - NamedType LocalTestLabelTxt</note>
+        </trans-unit>
+        <trans-unit id="Page 1798807378 - View 3072246430 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>ViewCaption</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test View - View ViewName - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="Page 1798807378 - Change 1296262074 - Property 1064389655" size-unit="char" translate="yes" xml:space="preserve">
+          <source>MyChanged AboutTitle</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test View - Change MyField - Property AboutTitle</note>
+        </trans-unit>
+        <trans-unit id="Page 1798807378 - Change 1296262074 - Property 247559172" size-unit="char" translate="yes" xml:space="preserve">
+          <source>MyChanged AboutText</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page NAB Test View - Change MyField - Property AboutText</note>
         </trans-unit>
         <trans-unit id="Page 883204498 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
           <source>NAB ToolTip Part 1</source>
@@ -452,6 +562,36 @@
           <source>asdf,ef</source>
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - Control NAB Blocked3 - Property OptionCaption</note>
+        </trans-unit>
+        <trans-unit id="PageExtension 3795862579 - View 2676260642 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
+          <source>MyViewCaption</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - View MyViewName - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="PageExtension 3795862579 - Change 3246865201 - Property 1064389655" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
+          <source>Modified AboutTitle1</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - Change Credit Limit (LCY) - Property AboutTitle</note>
+        </trans-unit>
+        <trans-unit id="PageExtension 3795862579 - Change 3246865201 - Property 247559172" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
+          <source>Modified AboutText1</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - Change Credit Limit (LCY) - Property AboutText</note>
+        </trans-unit>
+        <trans-unit id="PageExtension 3795862579 - View 369637368 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
+          <source>MyViewCaption</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - View MyViewName2 - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="PageExtension 3795862579 - Change 2039693239 - Property 1064389655" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
+          <source>Modified AboutTitle2</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - Change Application Method - Property AboutTitle</note>
+        </trans-unit>
+        <trans-unit id="PageExtension 3795862579 - Change 2039693239 - Property 247559172" size-unit="char" translate="yes" xml:space="preserve" al-object-target="Page 2901867346">
+          <source>Modified AboutText2</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">PageExtension NAB Test PageExt - Change Application Method - Property AboutText</note>
         </trans-unit>
         <trans-unit id="TableExtension 3999646232 - NamedType 1399329827" size-unit="char" translate="yes" xml:space="preserve" al-object-target="TableExtension 3999646232">
           <source>TableExt Label</source>

--- a/test-app/Xliff-test/docs/TOC.yml
+++ b/test-app/Xliff-test/docs/TOC.yml
@@ -34,6 +34,9 @@
     - name: NAB Test Table
       href: page-nab-test-table/TOC.yml
       topicHref: page-nab-test-table/index.md
+    - name: NAB Test View
+      href: page-nab-test-view/TOC.yml
+      topicHref: page-nab-test-view/index.md
     - name: NAB ToolTip Part 1
       href: page-nab-tool-tip-part-1/TOC.yml
       topicHref: page-nab-tool-tip-part-1/index.md

--- a/test-app/Xliff-test/docs/info.json
+++ b/test-app/Xliff-test/docs/info.json
@@ -1,6 +1,6 @@
 {
-  "generated-date": "2022-02-15",
-  "generator": "NAB AL Tools v1.17.202140831",
+  "generated-date": "2022-02-18",
+  "generator": "NAB AL Tools v1.17.202181026",
   "app-name": "Al",
   "app-version": "1.0.0.0"
 }

--- a/test-app/Xliff-test/docs/page-nab-test-view/TOC.yml
+++ b/test-app/Xliff-test/docs/page-nab-test-view/TOC.yml
@@ -1,0 +1,3 @@
+items:
+  - name: TestMethodPage
+    href: test-method-page.md

--- a/test-app/Xliff-test/docs/page-nab-test-view/index.md
+++ b/test-app/Xliff-test/docs/page-nab-test-view/index.md
@@ -18,10 +18,3 @@ title: Page NAB Test View
 | Name | Description |
 | ----- | ------ |
 | [TestMethodPage()](test-method-page.md#test_method_page) |  |
-
-## Controls
-
-| Type | Caption | ToolTip |
-| ---- | ------- | ----------- |
-| Field | Field | Tooltup 3 |
-| Action | Action | Tooltip 4 |

--- a/test-app/Xliff-test/docs/page-nab-test-view/index.md
+++ b/test-app/Xliff-test/docs/page-nab-test-view/index.md
@@ -1,0 +1,27 @@
+---
+uid: page_nab_test_view
+title: Page NAB Test View
+---
+# NAB Test View
+
+## Object Definition
+
+<table>
+<tr><td><b>Object Type</b></td><td>Page</td></tr>
+<tr><td><b>Object ID</b></td><td>50004</td></tr>
+<tr><td><b>Object Name</b></td><td>NAB Test View</td></tr>
+<tr><td><b>Source Table</b></td><td>NAB Test Table</td></tr>
+</table>
+
+## Procedures
+
+| Name | Description |
+| ----- | ------ |
+| [TestMethodPage()](test-method-page.md#test_method_page) |  |
+
+## Controls
+
+| Type | Caption | ToolTip |
+| ---- | ------- | ----------- |
+| Field | Field | Tooltup 3 |
+| Action | Action | Tooltip 4 |

--- a/test-app/Xliff-test/docs/page-nab-test-view/test-method-page.md
+++ b/test-app/Xliff-test/docs/page-nab-test-view/test-method-page.md
@@ -1,0 +1,12 @@
+---
+uid: page_nab_test_view_test_method_page
+---
+# <a name="test_method_page"></a>TestMethodPage Procedure
+
+[Page NAB Test View](index.md)
+
+## <a name="signature"></a>Signature
+
+```al
+TestMethodPage()
+```

--- a/test-app/Xliff-test/docs/pages.md
+++ b/test-app/Xliff-test/docs/pages.md
@@ -3,6 +3,7 @@
 | Name | Source Table | Read-only |
 | ----- | ------ | ------ |
 | [NAB Test Table](page-nab-test-table/index.md) | NAB Test Table |  |
+| [NAB Test View](page-nab-test-view/index.md) | NAB Test Table |  |
 | [NAB ToolTip Part 1](page-nab-tool-tip-part-1/index.md) | Item |  |
 | [NAB ToolTip Part 2](page-nab-tool-tip-part-2/index.md) | NAB ToolTip |  |
 | [NAB ToolTips](page-nab-tool-tips/index.md) | NAB ToolTip |  |

--- a/test-app/Xliff-test/docs/public-objects.md
+++ b/test-app/Xliff-test/docs/public-objects.md
@@ -26,6 +26,7 @@
 | Name | Source Table | Read-only |
 | ----- | ------ | ------ |
 | [NAB Test Table](page-nab-test-table/index.md) | NAB Test Table |  |
+| [NAB Test View](page-nab-test-view/index.md) | NAB Test Table |  |
 | [NAB ToolTip Part 1](page-nab-tool-tip-part-1/index.md) | Item |  |
 | [NAB ToolTip Part 2](page-nab-tool-tip-part-2/index.md) | NAB ToolTip |  |
 | [NAB ToolTips](page-nab-tool-tips/index.md) | NAB ToolTip |  |

--- a/test-app/Xliff-test/docs/table-nab-test-table/index.md
+++ b/test-app/Xliff-test/docs/table-nab-test-table/index.md
@@ -25,3 +25,4 @@ title: Table NAB Test Table
 | 1 | Test Field | Option |
 | 2 | MyField | Blob |
 | 3 | My <> & Field | Blob |
+| 5 | MyField2 | Code[20] |

--- a/test-app/Xliff-test/src/RemovedTable.Table.al
+++ b/test-app/Xliff-test/src/RemovedTable.Table.al
@@ -2,11 +2,13 @@ table 50014 "NAB Removed Table"
 {
     DataClassification = CustomerContent;
     ObsoleteState = Removed;
+    ObsoleteReason = 'This table is not used anymore';
 
     fields
     {
         field(1; "Test Field"; Option)
         {
+            OptionMembers = " ","one";
             DataClassification = CustomerContent;
         }
         field(2; MyField; Blob)
@@ -17,7 +19,7 @@ table 50014 "NAB Removed Table"
         {
             DataClassification = ToBeClassified;
         }
-        field(4; DeprecatedField; Text)
+        field(4; DeprecatedField; Text[100])
         {
             DataClassification = ToBeClassified;
         }

--- a/test-app/Xliff-test/src/TestPageExt.PageExt.al
+++ b/test-app/Xliff-test/src/TestPageExt.PageExt.al
@@ -53,6 +53,46 @@ pageextension 50000 "NAB Test PageExt" extends "Customer List"
         }
         // Add changes to page actions here
     }
+    views
+    {
+        addfirst
+        {
+            view(MyViewName)
+            {
+                Caption = 'MyViewCaption';
+                Filters = where(Address = filter('A*'));
+                SharedLayout = false;
+
+                layout
+                {
+                    modify("Credit Limit (LCY)")
+                    {
+                        AboutText = 'Modified AboutText1';
+                        AboutTitle = 'Modified AboutTitle1';
+                    }
+
+                }
+            }
+            view(MyViewName2)
+            {
+                Caption = 'MyViewCaption';
+                Filters = where(Address = filter('A*'));
+                SharedLayout = false;
+
+                layout
+                {
+                    modify("Application Method")
+                    {
+
+                        AboutText = 'Modified AboutText2';
+                        AboutTitle = 'Modified AboutTitle2';
+                    }
+
+                }
+            }
+        }
+    }
+
     procedure TestMethodPageExt()
     var
         LocalTestLabelTxt: Label 'Local Test Label';

--- a/test-app/Xliff-test/src/TestPageExt.PageExt.al
+++ b/test-app/Xliff-test/src/TestPageExt.PageExt.al
@@ -1,3 +1,4 @@
+#pragma implicitwith disable
 pageextension 50000 "NAB Test PageExt" extends "Customer List"
 {
     layout
@@ -5,7 +6,6 @@ pageextension 50000 "NAB Test PageExt" extends "Customer List"
 
         modify("Application Method")
         {
-            OptionCaption = 'dfee';
             Caption = 'dsfe';
             ToolTip = 'Specifies ...';
         }
@@ -19,7 +19,7 @@ pageextension 50000 "NAB Test PageExt" extends "Customer List"
         addafter("VAT Bus. Posting Group")
         {
 
-            field("NAB Blocked3"; "NAB Test Field")
+            field("NAB Blocked3"; Rec."NAB Test Field")
             {
                 Caption = 'Capt';
                 ToolTip = 'Tooltip 1';
@@ -63,3 +63,4 @@ pageextension 50000 "NAB Test PageExt" extends "Customer List"
         GlobalTestLabelTxt: Label 'Global Test Label';
 
 }
+#pragma implicitwith restore

--- a/test-app/Xliff-test/src/TestReport.Report.al
+++ b/test-app/Xliff-test/src/TestReport.Report.al
@@ -11,7 +11,6 @@ report 50000 "NAB Test Report"
             RequestFilterHeading = 'sdfa';
             column(ColumnName; asdf)
             {
-                Caption = 'Column', Comment = 'ColumnComment', MaxLength = 50;
                 OptionCaption = 'asd,asdf';
 
             }

--- a/test-app/Xliff-test/src/TestReportExt.ReportExt.al
+++ b/test-app/Xliff-test/src/TestReportExt.ReportExt.al
@@ -6,11 +6,9 @@ reportextension 50000 "NAB Test Report Ext." extends "Customer - Top 10 List"
         {
             column(Address; Address)
             {
-                Caption = 'Test 1';
             }
             column(Address2; "Address 2")
             {
-                Caption = 'Test 2';
             }
         }
         modify(Name_Customer)

--- a/test-app/Xliff-test/src/TestTable.Page.al
+++ b/test-app/Xliff-test/src/TestTable.Page.al
@@ -1,3 +1,4 @@
+#pragma implicitwith disable
 page 50000 "NAB Test Table"
 {
     PageType = Card;
@@ -32,7 +33,7 @@ page 50000 "NAB Test Table"
 
                     end;
                 }
-                field(MyField; "MyField")
+                field(MyField; Rec."MyField")
                 {
                     Caption = '';
                 }
@@ -70,3 +71,4 @@ page 50000 "NAB Test Table"
         GlobalTestLabelTxt: Label 'Global Test Label';
         asdf: Option;
 }
+#pragma implicitwith restore

--- a/test-app/Xliff-test/src/TestTable.Table.al
+++ b/test-app/Xliff-test/src/TestTable.Table.al
@@ -33,6 +33,12 @@ table 50000 "NAB Test Table"
             ObsoleteState = Removed;
             ObsoleteReason = 'This field is not used anymore.';
         }
+        field(5; "MyField2"; Code[20])
+        {
+            Caption = 'MyField2';
+            DataClassification = CustomerContent;
+        }
+
     }
 
     keys

--- a/test-app/Xliff-test/src/TestTable.Table.al
+++ b/test-app/Xliff-test/src/TestTable.Table.al
@@ -27,10 +27,11 @@ table 50000 "NAB Test Table"
         {
             DataClassification = ToBeClassified;
         }
-        field(4; DeprecatedField; Text)
+        field(4; DeprecatedField; Text[1000])
         {
             DataClassification = ToBeClassified;
             ObsoleteState = Removed;
+            ObsoleteReason = 'This field is not used anymore.';
         }
     }
 

--- a/test-app/Xliff-test/src/TestTableExt.TableExt.al
+++ b/test-app/Xliff-test/src/TestTableExt.TableExt.al
@@ -9,7 +9,6 @@ tableextension 50000 "NAB Test Table Ext" extends Customer
         modify("Application Method")
         {
             Caption = 'asdf2';
-            OptionCaption = 'asdf,adfe';
         }
         field(50000; "NAB Test Field"; Option)
         {

--- a/test-app/Xliff-test/src/TestView.Page.al
+++ b/test-app/Xliff-test/src/TestView.Page.al
@@ -1,0 +1,105 @@
+#pragma implicitwith disable
+page 50004 "NAB Test View"
+{
+    PageType = List;
+    ApplicationArea = All;
+    UsageCategory = Administration;
+    SourceTable = "NAB Test Table";
+    Caption = 'Page Caption';
+    InstructionalText = 'Instructions';
+    PromotedActionCategories = 'asdf,erewf';
+
+    layout
+    {
+        area(Content)
+        {
+            group(GroupName)
+            {
+                Caption = 'Grp';
+                InstructionalText = 'Instruction';
+                field(Name; "asdf")
+                {
+                    ApplicationArea = All;
+                    Caption = 'Field';
+                    OptionCaption = 'asdf,sadf,____ASADF';
+                    // Page 3710665244 - Control 2961552353 - Property 62802879
+                    ToolTip = 'Tooltup 3';
+
+                    trigger OnAssistEdit()
+                    var
+                        LocalTestLabelTxt: Label 'Local Test Label';
+
+                    begin
+
+                    end;
+                }
+                field(MyField; Rec."MyField")
+                {
+                    Caption = '';
+                    AboutText = 'MyChanged AboutText';
+                    AboutTitle = 'MyChanged AboutTitle';
+                }
+                field(MyField2; Rec.MyField2)
+                {
+                    ApplicationArea = All;
+                }
+
+            }
+        }
+    }
+
+    actions
+    {
+        area(Processing)
+        {
+            ToolTip = 'AreaTooltip';
+            action(ActionName)
+            {
+                Caption = 'Action';
+                ToolTip = 'Tooltip 4';
+                ApplicationArea = All;
+
+                trigger OnAction()
+                var
+                    LocalTestLabelTxt: Label 'Local Test Label';
+                begin
+
+                end;
+            }
+        }
+    }
+    views
+    {
+        view(ViewName)
+        {
+            Caption = 'ViewCaption';
+            Filters = where(MyField2 = filter(1));
+            SharedLayout = false;
+
+            layout
+            {
+                modify(MyField)
+                {
+                    Visible = false;
+                    Importance = Additional;
+                    AboutText = 'MyChanged AboutText';
+                    AboutTitle = 'MyChanged AboutTitle';
+                }
+                movefirst(Content; MyField2)
+                movelast(Content; MyField)
+                moveafter(GroupName; Name)
+
+            }
+        }
+    }
+    procedure TestMethodPage()
+    var
+        LocalTestLabelTxt: Label 'Local Test Label';
+    begin
+    end;
+
+    var
+        GlobalTestLabelTxt: Label 'Global Test Label';
+        asdf: Option;
+}
+#pragma implicitwith restore

--- a/test-app/Xliff-test/src/TestView.Page.al
+++ b/test-app/Xliff-test/src/TestView.Page.al
@@ -17,22 +17,6 @@ page 50004 "NAB Test View"
             {
                 Caption = 'Grp';
                 InstructionalText = 'Instruction';
-                field(Name; "asdf")
-                {
-                    ApplicationArea = All;
-                    Caption = 'Field';
-                    OptionCaption = 'asdf,sadf,____ASADF';
-                    // Page 3710665244 - Control 2961552353 - Property 62802879
-                    ToolTip = 'Tooltup 3';
-
-                    trigger OnAssistEdit()
-                    var
-                        LocalTestLabelTxt: Label 'Local Test Label';
-
-                    begin
-
-                    end;
-                }
                 field(MyField; Rec."MyField")
                 {
                     Caption = '';
@@ -56,7 +40,6 @@ page 50004 "NAB Test View"
             action(ActionName)
             {
                 Caption = 'Action';
-                ToolTip = 'Tooltip 4';
                 ApplicationArea = All;
 
                 trigger OnAction()


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
Fixes parts of #288, where the command stops due to unexpected `modify`.

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- Implemented support for Views in Pages and Page Extensions
- More info on Views: https://docs.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/devenv-page-object#views
- Re-enabled other extensions when running the TestApp
- Added `modify` support for PageExtensions
- Changes in the TestApp:
  - Added a Page with views
  - Added Views to a Page Extension
  - Fixed some AL Warnings that wasn't visible before when AL Language extension was disabled
  - Updated documentation


Additional comments
The other problems that are mentioned in #288 will be tracked in other issues.
After the changes in this PR, I can parse the complete Base Application without any stopping errors. (Will need to fix some parsing of procedures, though. But that's another issue.) External Documentation ended upp with 45000+ .md files! 😅