### PR TITLE
Refactor: Powershell functions

### DIFF
--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -9,7 +9,6 @@ import * as DebugTests from "./DebugTests";
 import * as ALParser from "./ALObject/ALParser";
 import * as path from "path";
 import * as Common from "./Common";
-import * as PowerShellFunctions from "./PowerShellFunctions";
 import * as DocumentFunctions from "./DocumentFunctions";
 import * as FileFunctions from "./FileFunctions";
 import * as RenumberObjects from "./RenumberObjects";
@@ -439,44 +438,6 @@ export async function findSourceOfCurrentTranslationUnit(): Promise<void> {
     return;
   }
   logger.log("Done: FindSourceOfCurrentTranslationUnit");
-}
-
-export async function uninstallDependencies(): Promise<void> {
-  logger.log("Running: UninstallDependencies");
-  Telemetry.trackEvent("uninstallDependencies");
-  let appName;
-  try {
-    appName = await PowerShellFunctions.uninstallDependenciesPS(
-      SettingsLoader.getAppManifest(),
-      SettingsLoader.getLaunchSettings()
-    );
-  } catch (error) {
-    showErrorAndLog("Uninstall dependencies", error as Error);
-    return;
-  }
-  vscode.window.showInformationMessage(
-    `All apps that depends on ${appName} are uninstalled and unpublished`
-  );
-  logger.log("Done: UninstallDependencies");
-}
-
-export async function signAppFile(): Promise<void> {
-  logger.log("Running: SignAppFile");
-  Telemetry.trackEvent("signAppFile");
-  let signedAppFileName;
-  try {
-    signedAppFileName = await PowerShellFunctions.signAppFilePS(
-      SettingsLoader.getSettings(),
-      SettingsLoader.getAppManifest()
-    );
-  } catch (error) {
-    showErrorAndLog("Sign app file", error as Error);
-    return;
-  }
-  vscode.window.showInformationMessage(
-    `App file "${signedAppFileName}" is now signed`
-  );
-  logger.log("Done: SignAppFile");
 }
 
 export async function deployAndRunTestTool(noDebug: boolean): Promise<void> {

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -38,6 +38,7 @@ import { logger } from "./Logging/LogHelper";
 import { PermissionSetNameEditorPanel } from "./PermissionSet/PermissionSetNamePanel";
 import { TemplateEditorPanel } from "./Template/TemplatePanel";
 import { OutputLogger } from "./Logging/OutputLogger";
+import { showErrorAndLog } from "./VSCodeFunctions";
 
 export async function refreshXlfFilesFromGXlf(
   suppressMessage = false
@@ -548,14 +549,6 @@ export async function generateExternalDocumentation(): Promise<void> {
   }
 
   logger.log("Done: GenerateExternalDocumentation");
-}
-
-function showErrorAndLog(action: string, error: Error): void {
-  const errMsg = `${action} failed with error: ${error.message}`;
-  vscode.window.showErrorMessage(errMsg);
-  logger.log(`Error: ${error.message}`);
-  logger.log(`Stack trace: ${error.stack}`);
-  Telemetry.trackException(error);
 }
 
 export async function matchTranslations(): Promise<void> {

--- a/extension/src/PowerShellFunctions.ts
+++ b/extension/src/PowerShellFunctions.ts
@@ -97,7 +97,7 @@ export async function uninstallDependenciesPS(
   // Unpublishing LicenseProvider
 }
 
-export async function signAppFilePS(
+async function signAppFilePS(
   settings: Settings,
   appManifest: AppManifest
 ): Promise<string> {

--- a/extension/src/PowerShellFunctions.ts
+++ b/extension/src/PowerShellFunctions.ts
@@ -3,7 +3,48 @@ import { Powershell } from "./PowerShell";
 import { join } from "path";
 import * as fs from "fs";
 import { AppManifest, LaunchSettings, Settings } from "./Settings/Settings";
+import * as SettingsLoader from "./Settings/SettingsLoader";
 import { logger } from "./Logging/LogHelper";
+import * as Telemetry from "./Telemetry";
+import { showErrorAndLog } from "./VSCodeFunctions";
+
+export async function uninstallDependencies(): Promise<void> {
+  logger.log("Running: UninstallDependencies");
+  Telemetry.trackEvent("uninstallDependencies");
+  let appName;
+  try {
+    appName = await uninstallDependenciesPS(
+      SettingsLoader.getAppManifest(),
+      SettingsLoader.getLaunchSettings()
+    );
+  } catch (error) {
+    showErrorAndLog("Uninstall dependencies", error as Error);
+    return;
+  }
+  vscode.window.showInformationMessage(
+    `All apps that depends on ${appName} are uninstalled and unpublished`
+  );
+  logger.log("Done: UninstallDependencies");
+}
+
+export async function signAppFile(): Promise<void> {
+  logger.log("Running: SignAppFile");
+  Telemetry.trackEvent("signAppFile");
+  let signedAppFileName;
+  try {
+    signedAppFileName = await signAppFilePS(
+      SettingsLoader.getSettings(),
+      SettingsLoader.getAppManifest()
+    );
+  } catch (error) {
+    showErrorAndLog("Sign app file", error as Error);
+    return;
+  }
+  vscode.window.showInformationMessage(
+    `App file "${signedAppFileName}" is now signed`
+  );
+  logger.log("Done: SignAppFile");
+}
 
 export async function uninstallDependenciesPS(
   appManifest: AppManifest,

--- a/extension/src/VSCodeFunctions.ts
+++ b/extension/src/VSCodeFunctions.ts
@@ -1,4 +1,6 @@
 import * as vscode from "vscode";
+import { logger } from "./Logging/LogHelper";
+import * as Telemetry from "./Telemetry";
 
 export async function findTextInFiles(
   textToSearchFor: string,
@@ -13,4 +15,12 @@ export async function findTextInFiles(
     matchWholeWord: false,
     filesToInclude: filesToIncludeFilter,
   });
+}
+
+export function showErrorAndLog(action: string, error: Error): void {
+  const errMsg = `${action} failed with error: ${error.message}`;
+  vscode.window.showErrorMessage(errMsg);
+  logger.log(`Error: ${error.message}`);
+  logger.log(`Stack trace: ${error.stack}`);
+  Telemetry.trackException(error);
 }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -25,6 +25,14 @@ export function activate(context: vscode.ExtensionContext): void {
 
   // The command has been defined in the package.json file
   // The commandId parameter must match the command field in package.json
+  const powerShellFunctions = [
+    vscode.commands.registerCommand("nab.UninstallDependencies", () => {
+      PowerShellFunctions.uninstallDependencies();
+    }),
+    vscode.commands.registerCommand("nab.SignAppFile", () => {
+      PowerShellFunctions.signAppFile();
+    }),
+  ];
 
   const commandlist = [
     vscode.commands.registerCommand("nab.RefreshXlfFilesFromGXlf", () => {
@@ -69,12 +77,6 @@ export function activate(context: vscode.ExtensionContext): void {
         NABfunctions.findSourceOfCurrentTranslationUnit();
       }
     ),
-    vscode.commands.registerCommand("nab.UninstallDependencies", () => {
-      PowerShellFunctions.uninstallDependencies();
-    }),
-    vscode.commands.registerCommand("nab.SignAppFile", () => {
-      PowerShellFunctions.signAppFile();
-    }),
     vscode.commands.registerCommand("nab.DeployAndRunTestToolNoDebug", () => {
       NABfunctions.deployAndRunTestTool(true);
     }),
@@ -219,8 +221,8 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand("nab.openXliffId", (params) => {
       NABfunctions.openXliffId(params);
     }),
+    ...powerShellFunctions,
   ];
-
   context.subscriptions.concat(commandlist);
   //context.subscriptions.push(disposable);
 }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -8,6 +8,7 @@ import { XlfHighlighter } from "./XlfHighlighter";
 import * as Telemetry from "./Telemetry";
 import { setLogger } from "./Logging/LogHelper";
 import { OutputLogger } from "./Logging/OutputLogger";
+import * as PowerShellFunctions from "./PowerShellFunctions";
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -69,10 +70,10 @@ export function activate(context: vscode.ExtensionContext): void {
       }
     ),
     vscode.commands.registerCommand("nab.UninstallDependencies", () => {
-      NABfunctions.uninstallDependencies();
+      PowerShellFunctions.uninstallDependencies();
     }),
     vscode.commands.registerCommand("nab.SignAppFile", () => {
-      NABfunctions.signAppFile();
+      PowerShellFunctions.signAppFile();
     }),
     vscode.commands.registerCommand("nab.DeployAndRunTestToolNoDebug", () => {
       NABfunctions.deployAndRunTestTool(true);


### PR DESCRIPTION
This mainly to illustrate my idea dividing the code to more separated areas of responsibility, or legs, or domains or whatever would be the best word. As this PR doesn't contribute much more value than the start and template of that idea, it's totally fine if we discard it :)

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- Move PowerShell functions from `NABFunctions.ts` to `PowerShellFunctions.ts`.
- Move function `showErrorAndLog` from `NABFunctions.ts` to `VSCodeFunctions.ts` as it's now shared.
- In `extension.ts` declare PowerShell commands in a new array `powerShellFunctions` and join it with `commandlist`.

Additional comments
I have limited ability to test this but I've ensured that commands from both arrays are triggered.