### PR TITLE
Catch error and reject promise on functions run with progress

### DIFF
--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -502,8 +502,8 @@ export async function generateToolTipDocumentation(): Promise<void> {
       },
       () => {
         return new Promise<void>((resolve, reject) => {
-          setTimeout(async () => {
-            await ToolTipsDocumentation.generateToolTipDocumentation(
+          setTimeout(() => {
+            ToolTipsDocumentation.generateToolTipDocumentation(
               SettingsLoader.getSettings(),
               SettingsLoader.getAppManifest()
             )

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -501,16 +501,21 @@ export async function generateToolTipDocumentation(): Promise<void> {
         title: "Generating ToolTip Documentation...",
       },
       () => {
-        return new Promise<void>((resolve) => {
+        return new Promise<void>((resolve, reject) => {
           setTimeout(async () => {
             await ToolTipsDocumentation.generateToolTipDocumentation(
               SettingsLoader.getSettings(),
               SettingsLoader.getAppManifest()
-            );
-            vscode.window.showInformationMessage(
-              `ToolTip documentation (re)created from al files.`
-            );
-            resolve();
+            )
+              .then(() => {
+                vscode.window.showInformationMessage(
+                  `ToolTip documentation (re)created from al files.`
+                );
+                resolve();
+              })
+              .catch((err) => {
+                reject(err);
+              });
           }, 10);
         });
       }
@@ -532,17 +537,21 @@ export async function generateExternalDocumentation(): Promise<void> {
         title: "Generating External Documentation...",
       },
       () => {
-        return new Promise<void>((resolve) => {
+        return new Promise<void>((resolve, reject) => {
           setTimeout(() => {
             Documentation.generateExternalDocumentation(
               SettingsLoader.getSettings(),
               SettingsLoader.getAppManifest()
-            ).then(() => {
-              vscode.window.showInformationMessage(
-                `Documentation (re)created from al files.`
-              );
-              resolve();
-            });
+            )
+              .then(() => {
+                vscode.window.showInformationMessage(
+                  `Documentation (re)created from al files.`
+                );
+                resolve();
+              })
+              .catch((err) => {
+                reject(err);
+              });
           }, 10);
         });
       }


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
Fixes #289 .

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- Reject promise on error in `NABFunctions.generateExternalDocumentation` and `NABFunctions.generateToolTipDocumentation()`.

