### PR TITLE
fix: Template substitutions inside .vscode folder

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -16,7 +16,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Fixes:
   - Fixed an issue where Tables and Fields with `ObsoleteState = Removed` was included in the "External Documentation" ([issue 287](https://github.com/jwikman/nab-al-tools/issues/287)).
   - Fixed an issue with `NAB: Convert to PermissionSet object` if there was no AppSourceCop.json in the app folder. Thanks to [That NAV guy](https://thatnavguy.wordpress.com/2022/02/18/converting-bc-permissionset-xml-to-permissionset-object/) for getting this to our attention ([issue 290](https://github.com/jwikman/nab-al-tools/issues/290)).
-  - Improved the parsing of procedures quite a lot. Now all procedures in the Base Application and the System App is successfully identified. Thanks to [NKarolak](https://github.com/NKarolak) for reporting in [issue 292](https://github.com/jwikman/nab-al-tools/issues/292)).
+  - Improved the parsing of procedures quite a lot. Now all procedures in the Base Application and the System App is successfully identified. Thanks to [NKarolak](https://github.com/NKarolak) for reporting in [issue 292](https://github.com/jwikman/nab-al-tools/issues/292).
+  - Fixed an issue where the `NAB: Create AL Project from Template (preview)` command didn't replace texts inside folders that started with a dot (.). Thanks to [fvet](https://github.com/fvet) for reporting this in [issue 303](https://github.com/jwikman/nab-al-tools/issues/303).
 
 ## [1.16]
 

--- a/extension/src/FileFunctions.ts
+++ b/extension/src/FileFunctions.ts
@@ -7,7 +7,7 @@ import stripJsonComments = require("strip-json-comments");
 export function findFiles(pattern: string, root: string): string[] {
   let fileList = getAllFilesRecursive(root);
   fileList = fileList.filter((file) =>
-    minimatch(file, pattern, { matchBase: true, nocase: true })
+    minimatch(file, pattern, { matchBase: true, nocase: true, dot: true })
   );
   return fileList.sort((a, b) => a.localeCompare(b));
 }
@@ -16,6 +16,9 @@ export function getAllFilesRecursive(
   dir: string,
   fileList: string[] = []
 ): string[] {
+  if (path.basename(dir) === ".git") {
+    return [];
+  }
   fs.readdirSync(dir).forEach((file) => {
     fileList = fs.statSync(path.join(dir, file)).isDirectory()
       ? getAllFilesRecursive(path.join(dir, file), fileList)

--- a/extension/src/test/Template.test.ts
+++ b/extension/src/test/Template.test.ts
@@ -198,6 +198,18 @@ suite("Template", function () {
       "Unexpected content in file4"
     );
     assert.strictEqual(
+      fs
+        .readFileSync(
+          path.join(testResourcesPath, "App/.vscode/settings.json"),
+          {
+            encoding: "utf8",
+          }
+        )
+        .replace(/[\r\n]*/g, ""),
+      '{  "CRS.ObjectNamePrefix": "NAB",  "alVarHelper.ignoreALPrefix": "NAB"}',
+      "Unexpected content in .vscode/settings.json"
+    );
+    assert.strictEqual(
       fs.existsSync(templateSettingsFilePath),
       false,
       "al.Template.json should not exist."

--- a/extension/src/test/resources/templateSettings/files/App/.vscode/settings.json
+++ b/extension/src/test/resources/templateSettings/files/App/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "CRS.ObjectNamePrefix": "[NAB_PREFIX]",
+  "alVarHelper.ignoreALPrefix": "[NAB_PREFIX]"
+}

--- a/extension/src/test/resources/templateSettings/files/al.template.json
+++ b/extension/src/test/resources/templateSettings/files/al.template.json
@@ -51,6 +51,17 @@
           "match": "[NAB_RANGE_END]"
         }
       ]
+    },
+    {
+      "description": "The prefix to use for this app",
+      "example": "ABC",
+      "default": "NAB",
+      "placeholderSubstitutions": [
+        {
+          "path": "**/*",
+          "match": "[NAB_PREFIX]"
+        }
+      ]
     }
   ],
   "createXlfLanguages": [


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
Fixes #303 .

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- Folders with a dot prefix in the name was excluded when matching glob patterns.
- Hardcoded to always exclude the `.git` folder, since that could be a straight way to disaster...
- Added .vscode/settings.json to the test for this
- Changelog

