### PR TITLE
fix: Improved code parsing

### DIFF
--- a/extension/src/ALObject/ALElementTypes.ts
+++ b/extension/src/ALObject/ALElementTypes.ts
@@ -46,6 +46,9 @@ export class ALControl extends ALElement {
     super();
     this.type = type;
     if (name) {
+      if (name === '""') {
+        name = "";
+      }
       this.name = name.replace(/""/g, '"');
     }
   }
@@ -341,7 +344,7 @@ export class ALControl extends ALElement {
   }
 
   public xliffIdToken(): XliffIdToken | undefined {
-    if (!this.name) {
+    if (this._name === undefined) {
       return;
     }
     if (this.xliffTokenType === XliffTokenType.skip) {

--- a/extension/src/ALObject/ALParser.ts
+++ b/extension/src/ALObject/ALParser.ts
@@ -1,6 +1,7 @@
 import * as Common from "../Common";
 import {
   attributePattern,
+  controlPattern,
   returnVariablePattern,
   wordPattern,
 } from "../constants";
@@ -246,14 +247,17 @@ export function matchALControl(
   codeLine: ALCodeLine
 ): ALControlMatchResult {
   const result: ALControlMatchResult = { controlIsComplete: false };
-  const alControlPattern = /^\s*\b(modify)\b\((.*)\)$|^\s*\b(view)\b\((.*)\)|^\s*\b(dataitem)\b\((.*);.*\)|^\s*\b(column)\b\((.*);(.*)\)|^\s*\b(value)\b\((\d*);\s*(.*?)\)(\s*{\s*Caption\s*=\s*'(.*?)'(\s*,\s*Locked\s*=\s*true\s*)?;\s*})?|^\s*\b(group)\b\((.*)\)|^\s*\b(field)\b\(\s*(.*)\s*;\s*(.*);\s*(.*)\s*\)|^\s*\b(field)\b\((.*);(.*)\)|^\s*\b(part)\b\((.*);(.*)\)|^\s*\b(action)\b\((.*)\)|^\s*\b(area)\b\((.*)\)|^\s*\b(trigger)\b (.*)\(.*\)|^\s*\b(procedure)\b ([^()]*)\(|^\s*\blocal (procedure)\b ([^()]*)\(|^\s*\binternal (procedure)\b ([^()]*)\(|^\s*\b(layout)\b$|^\s*\b(requestpage)\b$|^\s*\b(actions)\b$|^\s*\b(cuegroup)\b\((.*)\)|^\s*\b(repeater)\b\((.*)\)|^\s*\b(separator)\b\((.*)\)|^\s*\b(textattribute)\b\((.*)\)|^\s*\b(fieldattribute)\b\(([^;)]*);/i;
-  let alControlResult = codeLine.code.match(alControlPattern);
+
+  const controlPatternRegex = new RegExp(controlPattern, "im");
+  const alControlResult = codeLine.code.match(controlPatternRegex);
   if (!alControlResult) {
     return result;
   }
   let control;
-  alControlResult = alControlResult.filter((elmt) => elmt !== undefined);
-  switch (alControlResult[1].toLowerCase()) {
+  const alControlResultFiltered = alControlResult.filter(
+    (elmt) => elmt !== undefined
+  );
+  switch (alControlResultFiltered[1].toLowerCase()) {
     case "modify":
       switch (parent.getObjectType()) {
         case ALObjectType.page:
@@ -261,19 +265,19 @@ export function matchALControl(
         case ALObjectType.pageCustomization:
           control = new ALControl(
             ALControlType.modifiedPageField,
-            alControlResult[2]
+            alControlResultFiltered[2]
           );
           break;
         case ALObjectType.tableExtension:
           control = new ALControl(
             ALControlType.modifiedTableField,
-            alControlResult[2]
+            alControlResultFiltered[2]
           );
           break;
         case ALObjectType.reportExtension:
           control = new ALControl(
             ALControlType.modifiedReportColumn,
-            alControlResult[2]
+            alControlResultFiltered[2]
           );
           break;
         default:
@@ -286,26 +290,38 @@ export function matchALControl(
       control.xliffTokenType = XliffTokenType.change;
       break;
     case "textattribute":
-      control = new ALControl(ALControlType.textAttribute, alControlResult[2]);
+      control = new ALControl(
+        ALControlType.textAttribute,
+        alControlResultFiltered[2]
+      );
       control.xliffTokenType = XliffTokenType.xmlPortNode;
       break;
     case "fieldattribute":
-      control = new ALControl(ALControlType.fieldAttribute, alControlResult[2]);
+      control = new ALControl(
+        ALControlType.fieldAttribute,
+        alControlResultFiltered[2]
+      );
       control.xliffTokenType = XliffTokenType.xmlPortNode;
       break;
     case "cuegroup":
-      control = new ALControl(ALControlType.cueGroup, alControlResult[2]);
+      control = new ALControl(
+        ALControlType.cueGroup,
+        alControlResultFiltered[2]
+      );
       control.xliffTokenType = XliffTokenType.control;
       break;
     case "repeater":
-      control = new ALControl(ALControlType.repeater, alControlResult[2]);
+      control = new ALControl(
+        ALControlType.repeater,
+        alControlResultFiltered[2]
+      );
       control.xliffTokenType = XliffTokenType.control;
       break;
     case "requestpage":
       control = new ALControl(ALControlType.requestPage, "RequestOptionsPage");
       break;
     case "area":
-      control = new ALControl(ALControlType.area, alControlResult[2]);
+      control = new ALControl(ALControlType.area, alControlResultFiltered[2]);
       if (parent.getGroupType() === ALControlType.actions) {
         control.xliffTokenType = XliffTokenType.action;
       } else {
@@ -313,7 +329,7 @@ export function matchALControl(
       }
       break;
     case "group":
-      control = new ALControl(ALControlType.group, alControlResult[2]);
+      control = new ALControl(ALControlType.group, alControlResultFiltered[2]);
       if (parent.getGroupType() === ALControlType.actions) {
         control.xliffTokenType = XliffTokenType.action;
       } else {
@@ -321,14 +337,17 @@ export function matchALControl(
       }
       break;
     case "view":
-      control = new ALControl(ALControlType.pageView, alControlResult[2]);
+      control = new ALControl(
+        ALControlType.pageView,
+        alControlResultFiltered[2]
+      );
       control.xliffTokenType = XliffTokenType.view;
       break;
     case "part":
       control = new ALPagePart(
         ALControlType.part,
-        alControlResult[2],
-        alControlResult[3]
+        alControlResultFiltered[2],
+        alControlResultFiltered[3]
       );
       control.xliffTokenType = XliffTokenType.control;
       break;
@@ -341,8 +360,8 @@ export function matchALControl(
         case ALObjectType.xmlPort:
           control = new ALPageField(
             ALControlType.pageField,
-            alControlResult[2],
-            alControlResult[3]
+            alControlResultFiltered[2],
+            alControlResultFiltered[3]
           );
           control.xliffTokenType = XliffTokenType.control;
           break;
@@ -350,9 +369,9 @@ export function matchALControl(
         case ALObjectType.table:
           control = new ALTableField(
             ALControlType.tableField,
-            (alControlResult[2] as unknown) as number,
-            alControlResult[3],
-            alControlResult[4]
+            (alControlResultFiltered[2] as unknown) as number,
+            alControlResultFiltered[3],
+            alControlResultFiltered[4]
           );
           control.xliffTokenType = XliffTokenType.field;
           break;
@@ -365,21 +384,34 @@ export function matchALControl(
       }
       break;
     case "separator":
-      control = new ALControl(ALControlType.separator, alControlResult[2]);
+      control = new ALControl(
+        ALControlType.separator,
+        alControlResultFiltered[2]
+      );
       control.xliffTokenType = XliffTokenType.action;
       break;
     case "action":
-      control = new ALControl(ALControlType.action, alControlResult[2]);
+      control = new ALControl(ALControlType.action, alControlResultFiltered[2]);
+      break;
+    case "label":
+      control = new ALControl(ALControlType.label, alControlResultFiltered[2]);
+      control.xliffTokenType = XliffTokenType.control;
       break;
     case "dataitem":
       switch (parent.getObjectType()) {
         case ALObjectType.reportExtension:
         case ALObjectType.report:
-          control = new ALControl(ALControlType.dataItem, alControlResult[2]);
+          control = new ALControl(
+            ALControlType.dataItem,
+            alControlResultFiltered[2]
+          );
           control.xliffTokenType = XliffTokenType.reportDataItem;
           break;
         case ALObjectType.query:
-          control = new ALControl(ALControlType.dataItem, alControlResult[2]);
+          control = new ALControl(
+            ALControlType.dataItem,
+            alControlResultFiltered[2]
+          );
           control.xliffTokenType = XliffTokenType.queryDataItem;
           break;
         default:
@@ -393,12 +425,12 @@ export function matchALControl(
     case "value":
       control = new ALEnumValue(
         ALControlType.enumValue,
-        (alControlResult[2] as unknown) as number,
-        alControlResult[3]
+        (alControlResultFiltered[2] as unknown) as number,
+        alControlResultFiltered[3]
       );
-      if (alControlResult[4]) {
-        control.caption = alControlResult[5];
-        if (alControlResult[6]) {
+      if (alControlResult.groups?.enumValueCaption !== undefined) {
+        control.caption = alControlResult.groups.enumValueCaption;
+        if (alControlResult.groups?.enumValueCaptionLocked) {
           const caption = control.multiLanguageObjects.find(
             (x) =>
               x.type === MultiLanguageType.property &&
@@ -415,12 +447,18 @@ export function matchALControl(
     case "column":
       switch (parent.getObjectType()) {
         case ALObjectType.query:
-          control = new ALControl(ALControlType.column, alControlResult[2]);
+          control = new ALControl(
+            ALControlType.column,
+            alControlResultFiltered[2]
+          );
           control.xliffTokenType = XliffTokenType.queryColumn;
           break;
         case ALObjectType.reportExtension:
         case ALObjectType.report:
-          control = new ALControl(ALControlType.column, alControlResult[2]);
+          control = new ALControl(
+            ALControlType.column,
+            alControlResultFiltered[2]
+          );
           control.xliffTokenType = XliffTokenType.reportColumn;
           break;
         default:
@@ -432,12 +470,18 @@ export function matchALControl(
       }
       break;
     case "trigger":
-      control = new ALControl(ALControlType.trigger, alControlResult[2]);
+      control = new ALControl(
+        ALControlType.trigger,
+        alControlResultFiltered[2]
+      );
       control.xliffTokenType = XliffTokenType.method;
       control.isALCode = true;
       break;
     case "procedure":
-      control = new ALControl(ALControlType.procedure, alControlResult[2]);
+      control = new ALControl(
+        ALControlType.procedure,
+        alControlResultFiltered[2]
+      );
       control.xliffTokenType = XliffTokenType.method;
       control.isALCode = true;
       break;
@@ -451,7 +495,7 @@ export function matchALControl(
       break;
     default:
       throw new Error(
-        `Control type ${alControlResult[1].toLowerCase()} is unhandled${
+        `Control type ${alControlResultFiltered[1].toLowerCase()} is unhandled${
           parent.fileName ? ` ("${parent.fileName}")` : ""
         }`
       );

--- a/extension/src/ALObject/ALParser.ts
+++ b/extension/src/ALObject/ALParser.ts
@@ -459,6 +459,11 @@ export function matchALControl(
   control.startLineIndex = control.endLineIndex = lineIndex;
   control.alCodeLines = parent.alCodeLines;
   control.parent = parent;
+  if (result.controlIsComplete) {
+    control.multiLanguageObjects.forEach(
+      (x) => (x.startLineIndex = x.endLineIndex = lineIndex)
+    );
+  }
   result.alControl = control;
   return result;
 }

--- a/extension/src/ALObject/ALParser.ts
+++ b/extension/src/ALObject/ALParser.ts
@@ -502,7 +502,8 @@ export function matchIndentationIncreased(codeLine: ALCodeLine): boolean {
     if (increaseResult.index) {
       if (
         codeLine.code.trim().indexOf("//") !== -1 &&
-        codeLine.code.trim().indexOf("//") < increaseResult.index
+        codeLine.code.trim().indexOf("//") < increaseResult.index &&
+        !codeLine.code.trim().match(/'.*\/\/.*'/i) // matches url inside string
       ) {
         return false;
       }

--- a/extension/src/ALObject/ALParser.ts
+++ b/extension/src/ALObject/ALParser.ts
@@ -112,8 +112,10 @@ export function parseCode(
 export function parseProcedureDeclaration(
   alControl: ALControl,
   alCodeLines: ALCodeLine[],
-  procedureLineNo: number
+  procedureLineNo: number,
+  withFallback = true
 ): ALControl {
+  let procedureDeclarationText = alCodeLines[procedureLineNo].code;
   try {
     const attributes: string[] = [];
     let lineNo = procedureLineNo - 1;
@@ -140,7 +142,7 @@ export function parseProcedureDeclaration(
     procedureDeclarationArr.push(alCodeLines[procedureLineNo].code.trim());
     lineNo = procedureLineNo + 1;
     const endOfDeclarationPattern = new RegExp(
-      `\\)\\s*(${returnVariablePattern})?$`, // Ends with a parenthesis or a return variable
+      `\\)(;)?\\s*(${returnVariablePattern})?$`, // Ends with a parenthesis or a return variable
       "i"
     );
 
@@ -177,7 +179,7 @@ export function parseProcedureDeclaration(
       } while (loop);
     }
 
-    const procedureDeclarationText = [
+    procedureDeclarationText = [
       attributes.join("\n"),
       procedureDeclarationArr.join("\n"),
     ].join("\n");
@@ -194,7 +196,12 @@ export function parseProcedureDeclaration(
         alControl.fileName ? ` in "${alControl.fileName}"` : ""
       }. Failing code:\n\`${alCodeLines[procedureLineNo].code}\`\n${error}`
     );
-    return alControl; // Fallback so that Xliff functions still work
+    if (withFallback) {
+      return alControl; // Fallback so that Xliff functions still work
+    }
+    throw new Error(
+      `Could not find a procedure in:\n'${procedureDeclarationText}'`
+    );
   }
 }
 

--- a/extension/src/ALObject/Enums.ts
+++ b/extension/src/ALObject/Enums.ts
@@ -62,6 +62,7 @@ export enum ALControlType {
   enumValue = "EnumValue",
   tableField = "TableField",
   area = "Area",
+  label = "Label",
   trigger = "Trigger",
   procedure = "Procedure",
   layout = "Layout",

--- a/extension/src/ALObject/XliffIdToken.ts
+++ b/extension/src/ALObject/XliffIdToken.ts
@@ -17,7 +17,9 @@ export class XliffIdToken {
   }
   public set name(v: string) {
     if (v.startsWith('"') && v.endsWith('"')) {
-      v = v.substr(1, v.length - 2);
+      if (!v.substr(1, v.length - 2).includes('"')) {
+        v = v.substr(1, v.length - 2);
+      }
     }
     this.id = alFnv(v);
     this._name = v;

--- a/extension/src/Common.ts
+++ b/extension/src/Common.ts
@@ -11,11 +11,9 @@ export function trimAndRemoveQuotes(text: string): string {
   text = text
     .trim()
     .toString()
-    .replace(/^"(.+(?="$))"$/, "$1");
-  text = text
-    .trim()
-    .toString()
+    .replace(/^"(.+(?="$))"$/, "$1")
     .replace(/^'(.+(?='$))'$/, "$1");
+
   return text;
 }
 

--- a/extension/src/Troubleshooting.ts
+++ b/extension/src/Troubleshooting.ts
@@ -142,7 +142,7 @@ export async function troubleshootFindTransUnitsWithoutSource(): Promise<void> {
         tu.getXliffIdTokenArray()
       );
       const mlObjects = obj.getAllMultiLanguageObjects({
-        onlyForTranslation: true,
+        onlyForTranslation: false, // Include obsoleted objects and controls
       });
       const mlObject = mlObjects.find(
         (x) => x.xliffId().toLowerCase() === tu.id.toLowerCase()

--- a/extension/src/constants.ts
+++ b/extension/src/constants.ts
@@ -42,6 +42,35 @@ export const procedurePattern = `^${anyWhiteSpacePattern}*(?<attributes>((\\s*\\
   parameterPattern
 )})*)${anyWhiteSpacePattern}*\\)${anyWhiteSpacePattern}*(?<returns>[^#]*)?$`;
 
+const controlPatterns = [
+  "^\\s*\\b(modify)\\b\\((.*)\\)$",
+  "^\\s*\\b(view)\\b\\((.*)\\)",
+  "^\\s*\\b(dataitem)\\b\\((.*);.*\\)",
+  "^\\s*\\b(column)\\b\\((.*);(.*)\\)",
+  `^\\s*\\b(value)\\b\\((\\d*);\\s*(${wordPattern})\\)(\\s*{\\s*Caption\\s*=\\s*'(?<enumValueCaption>.*?)'(\\s*,\\s*(?<enumValueCaptionLocked>Locked\\s*=\\s*true)\\s*)?;\\s*})?`,
+  "^\\s*\\b(group)\\b\\((.*)\\)",
+  "^\\s*\\b(field)\\b\\(\\s*(.*)\\s*;\\s*(.*);\\s*(.*)\\s*\\)",
+  "^\\s*\\b(field)\\b\\((.*);(.*)\\)",
+  "^\\s*\\b(part)\\b\\((.*);(.*)\\)",
+  "^\\s*\\b(area)\\b\\((.*)\\)",
+  "^\\s*\\b(actions)\\b$",
+  "^\\s*\\b(action)\\b\\((.*)\\)",
+  "^\\s*\\b(label)\\b\\((.*)\\)",
+  "^\\s*\\b(trigger)\\b (.*)\\(.*\\)",
+  "^\\s*\\b(procedure)\\b ([^()]*)\\(",
+  "^\\s*\\blocal (procedure)\\b ([^()]*)\\(",
+  "^\\s*\\binternal (procedure)\\b ([^()]*)\\(",
+  "^\\s*\\b(layout)\\b$",
+  "^\\s*\\b(requestpage)\\b$",
+  "^\\s*\\b(cuegroup)\\b\\((.*)\\)",
+  "^\\s*\\b(repeater)\\b\\((.*)\\)",
+  "^\\s*\\b(separator)\\b\\((.*)\\)",
+  "^\\s*\\b(textattribute)\\b\\((.*)\\)",
+  "^\\s*\\b(fieldattribute)\\b\\(([^;)]*);",
+];
+
+export const controlPattern = controlPatterns.join("|");
+
 // Used for troubleshooting regex nightmare:
 // console.log("dictionaryDataTypePattern:\n", dictionaryDataTypePattern);
 // console.log("wordPattern:\n", wordPattern);

--- a/extension/src/test/ALObjectTestLibrary.ts
+++ b/extension/src/test/ALObjectTestLibrary.ts
@@ -1535,6 +1535,23 @@ export function getEnumWithOneLiners(): string {
     value(6; SharedAccessSignature) { Caption = 'Shared access signature (SAS)'; }
 }`;
 }
+
+export function getEnumWithDifferentFormats(): string {
+  return `enum 50004 "NAB Different Formats" implements "Posting"
+{
+    Extensible = true;
+    AssignmentCompatibility = true;
+
+    value(1; "Invoice Posting (v.xx)")
+    {
+        Caption = 'Invoice Posting (v.xx)';
+        Implementation = "Posting" = "Post Invoice";
+    }
+    value(2; SharedAccessSignature) { Caption = 'Shared access signature (SAS)'; }
+    value(3; " ") { Caption = ' '; }
+    value(4; "") { Caption = ''; }
+}`;
+}
 export function getPageWithoutToolTips(): string {
   return `
 page 50000 "NAB Test Table Card"

--- a/extension/src/test/ALObjectTestLibrary.ts
+++ b/extension/src/test/ALObjectTestLibrary.ts
@@ -1531,7 +1531,8 @@ export function getEnumWithOneLiners(): string {
     value(2; "Days per Period") { Caption = 'Days per Period'; }
     value(3; "User-Defined") { Caption = 'User-Defined'; }
     value(4; none) { Caption = '', Locked = true; }
-    value(5; SharedAccessSignature) { Caption = 'Shared access signature (SAS)'; }
+    value(5; " ") { Caption = ' '; }
+    value(6; SharedAccessSignature) { Caption = 'Shared access signature (SAS)'; }
 }`;
 }
 export function getPageWithoutToolTips(): string {

--- a/extension/src/test/ALParser.test.ts
+++ b/extension/src/test/ALParser.test.ts
@@ -19,6 +19,66 @@ import { ALTableField } from "../ALObject/ALTableField";
 import { ALPagePart } from "../ALObject/ALPagePart";
 
 suite("Classes.AL Functions Tests", function () {
+  test("Enum different formats", function () {
+    const alObj = ALParser.getALObjectFromText(
+      ALObjectTestLibrary.getEnumWithDifferentFormats(),
+      true
+    );
+    if (!alObj) {
+      assert.fail("Could not find object");
+    }
+
+    const values = alObj.controls.filter(
+      (c) => c.type === ALControlType.enumValue
+    ); // Do not use alObj.getAllMultiLanguageObjects() since it does not test if the levels are correct.
+    const captionsToTranslate = alObj.getAllMultiLanguageObjects({
+      onlyForTranslation: true,
+    });
+    const captions = alObj.getAllMultiLanguageObjects({
+      onlyForTranslation: false,
+    });
+    assert.strictEqual(
+      captionsToTranslate.length,
+      4,
+      "Unexpected number of captions to translate."
+    );
+    assert.strictEqual(
+      alObj.getPropertyValue(ALPropertyType.extensible),
+      "true",
+      "Unexpected extensible"
+    );
+
+    const expectedValues = [
+      "Invoice Posting (v.xx)",
+      "SharedAccessSignature",
+      " ",
+      "",
+    ];
+    const expectedCaptions = [
+      "Invoice Posting (v.xx)",
+      "Shared access signature (SAS)",
+      " ",
+      "",
+    ];
+    assert.strictEqual(
+      expectedCaptions.length,
+      expectedCaptions.length,
+      "Drunk programmer, couldn't update both arrays"
+    );
+    for (let index = 0; index < expectedValues.length; index++) {
+      assert.strictEqual(
+        values[index]._name,
+        expectedValues[index],
+        `Unexpected value ${index}`
+      );
+      assert.strictEqual(
+        captions[index].text,
+        expectedCaptions[index],
+        `Unexpected value ${index}`
+      );
+    }
+  });
+
   test("Enum one liners", function () {
     const alObj = ALParser.getALObjectFromText(
       ALObjectTestLibrary.getEnumWithOneLiners(),

--- a/extension/src/test/ALParser.test.ts
+++ b/extension/src/test/ALParser.test.ts
@@ -37,11 +37,11 @@ suite("Classes.AL Functions Tests", function () {
     const captions = alObj.getAllMultiLanguageObjects({
       onlyForTranslation: false,
     });
-    assert.strictEqual(values.length, 6, "Unexpected number of enum values.");
-    assert.strictEqual(captions.length, 6, "Unexpected number of captions.");
+    assert.strictEqual(values.length, 7, "Unexpected number of enum values.");
+    assert.strictEqual(captions.length, 7, "Unexpected number of captions.");
     assert.strictEqual(
       captionsToTranslate.length,
-      5,
+      6,
       "Unexpected number of captions to translate."
     );
     assert.strictEqual(
@@ -472,7 +472,7 @@ suite("Classes.AL Functions Tests", function () {
     }
   }
 
-  test.only("Procedure parsing", function () {
+  test("Procedure parsing", function () {
     testProcedure(
       `local procedure AddSoapActionHeader(SoapAction: Text; var DotNet_HttpWebRequest: DotNet HttpWebRequest);
 var

--- a/extension/src/test/ALParser.test.ts
+++ b/extension/src/test/ALParser.test.ts
@@ -472,7 +472,17 @@ suite("Classes.AL Functions Tests", function () {
     }
   }
 
-  test("Procedure parsing", function () {
+  test.only("Procedure parsing", function () {
+    testProcedure(
+      `local procedure AddSoapActionHeader(SoapAction: Text; var DotNet_HttpWebRequest: DotNet HttpWebRequest);
+var
+`,
+      0,
+      ALAccessModifier.local,
+      "AddSoapActionHeader",
+      2,
+      0
+    );
     testProcedure(
       `
     procedure Initialize(PriceListHeader: Record "Price List Header"; CopyLines: Boolean)
@@ -833,7 +843,8 @@ local procedure OnCalcDateBOCOnAfterGetCalendarCodes(var CustomCalendarChange: A
     const procedure = ALParser.parseProcedureDeclaration(
       alControl,
       alCodeLines,
-      procedureLineNo
+      procedureLineNo,
+      false
     ) as ALProcedure;
 
     assert.strictEqual(

--- a/extension/src/test/AlFunctions.test.ts
+++ b/extension/src/test/AlFunctions.test.ts
@@ -8,6 +8,11 @@ import * as ALParser from "../ALObject/ALParser";
 suite("Classes.AL Functions Tests", function () {
   test("AL Fnv", function () {
     assert.strictEqual(
+      AlFunctions.alFnv('"VAT Report Header"."Period Year"'),
+      1098503538,
+      'Value: "VAT Report Header"."Period Year"'
+    );
+    assert.strictEqual(
       AlFunctions.alFnv("MyPage"),
       2931038265,
       "Value: MyPage"


### PR DESCRIPTION


<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- Improved parsing of procedures
- Improved parsing of enums, especially one-liners
- Support translations of blank strings (why they aren't locked, I don't know)
- Refactored the regex for ALControl detection, easier to add new ones
- Support for Label controls in pages
- The Xliff hash should not exclude surrounding " if the name includes "

Additional comments
Most of controls and translatable things in the Base App are now properly detected.