### PR TITLE
ci: upload coverage before running check

### DIFF
--- a/.github/workflows/nerd-stuff.yml
+++ b/.github/workflows/nerd-stuff.yml
@@ -44,7 +44,10 @@ jobs:
         with:
           run: npm run test:coverage
           working-directory: ${{env.working-directory}}
-      - name: Upload Coverage Report
+      - name: Generate Report
+        run:  npx nyc report --reporter=lcov --check-coverage=false
+        working-directory: ${{env.working-directory}}          
+      - name: Upload Report
         uses: actions/upload-artifact@v2
         with:
           name: code-coverage

--- a/.github/workflows/nerd-stuff.yml
+++ b/.github/workflows/nerd-stuff.yml
@@ -44,12 +44,12 @@ jobs:
         with:
           run: npm run test:coverage
           working-directory: ${{env.working-directory}}
-      - name: Code Coverage
-        run:  npx nyc report --reporter=lcov --reporter=text-summary --check-coverage
-        working-directory: ${{env.working-directory}}
       - name: Upload Coverage Report
         uses: actions/upload-artifact@v2
         with:
           name: code-coverage
           path: ${{env.working-directory}}.coverage/**
           retention-days: 7
+      - name: Code Coverage
+        run:  npx nyc report --reporter=lcov --reporter=text-summary --check-coverage
+        working-directory: ${{env.working-directory}}

--- a/extension/src/LanguageFunctions.ts
+++ b/extension/src/LanguageFunctions.ts
@@ -139,54 +139,6 @@ export function findNearestMultipleTargets(
   return result;
 }
 
-export async function copySourceToTarget(): Promise<boolean> {
-  if (vscode.window.activeTextEditor) {
-    const editor = vscode.window.activeTextEditor;
-    if (vscode.window.activeTextEditor.document.uri.fsPath.endsWith("xlf")) {
-      // in a xlf file
-      await vscode.window.activeTextEditor.document.save();
-      const docText = vscode.window.activeTextEditor.document.getText();
-      const lineEnding =
-        vscode.window.activeTextEditor.document.eol === vscode.EndOfLine.CRLF
-          ? "\r\n"
-          : "\n";
-
-      const docArray = docText.split(lineEnding);
-      if (
-        docArray[vscode.window.activeTextEditor.selection.active.line].match(
-          /<target.*>.*<\/target>/i
-        )
-      ) {
-        // on a target line
-        const sourceLine = docArray[
-          vscode.window.activeTextEditor.selection.active.line - 1
-        ].match(/<source>(.*)<\/source>/i);
-        if (sourceLine) {
-          // source line just above
-          const newLineText = `          <target>${sourceLine[1]}</target>`;
-          await editor.edit((editBuilder) => {
-            const targetLineRange = new vscode.Range(
-              editor.selection.active.line,
-              0,
-              editor.selection.active.line,
-              docArray[editor.selection.active.line].length
-            );
-            editBuilder.replace(targetLineRange, newLineText);
-          });
-          editor.selection = new vscode.Selection(
-            editor.selection.active.line,
-            18,
-            editor.selection.active.line,
-            18 + sourceLine[1].length
-          );
-          return true;
-        }
-      }
-    }
-  }
-  return false;
-}
-
 export function copyAllSourceToTarget(
   xliffDoc: Xliff,
   languageFunctionsSettings: LanguageFunctionsSettings,

--- a/extension/src/test/Settings/CliSettingsLoader.test.ts
+++ b/extension/src/test/Settings/CliSettingsLoader.test.ts
@@ -47,6 +47,19 @@ suite("CLI Settings Loader Tests", function () {
     );
   });
 
+  test("getSettings(): undefined workspaceFilePath", function () {
+    const settings = CliSettingsLoader.getSettings(
+      testAppWorkspaceFolder,
+      undefined
+    );
+
+    assert.notDeepStrictEqual(
+      Object.entries(settings).values(),
+      [],
+      "Expected launch settings to have values"
+    );
+  });
+
   test("getSettings(): Error - ENOENT", function () {
     assert.throws(
       () => CliSettingsLoader.getSettings("", ""),

--- a/extension/src/test/Settings/CliSettingsLoader.test.ts
+++ b/extension/src/test/Settings/CliSettingsLoader.test.ts
@@ -22,6 +22,18 @@ suite("CLI Settings Loader Tests", function () {
     );
   });
 
+  test("getAppSourceCopSettings(): Missing AppSourceCop.json", function () {
+    const appSourceCop = CliSettingsLoader.getAppSourceCopSettings(
+      "any/path/will/do"
+    );
+    assert.ok(appSourceCop);
+    assert.strictEqual(
+      appSourceCop.mandatoryAffixes.length,
+      0,
+      "Expected mandatoryAffixes to be empty array."
+    );
+  });
+
   test("getSettings()", function () {
     const settings = CliSettingsLoader.getSettings(
       testAppWorkspaceFolder,

--- a/extension/src/test/Template.test.ts
+++ b/extension/src/test/Template.test.ts
@@ -125,6 +125,39 @@ suite("Template", function () {
     );
   });
 
+  test("Validate Data: Illegal Characters", function () {
+    const templateSettings = new TemplateSettings(templateMappingGuid());
+    templateSettings.mappings[0].value = "NOT HOTDOG";
+    assert.throws(
+      () => TemplateFunctions.validateData(templateSettings),
+      (err) => {
+        assert.strictEqual(
+          err.message,
+          `"The TestApp Id", "NOT HOTDOG" is not a valid GUID.`
+        );
+        return true;
+      },
+      "validateData should throw."
+    );
+  });
+
+  test("Validate Data: invalid GUID", function () {
+    const templateSettings = new TemplateSettings(templateMappingJSON());
+    templateSettings.mappings[0].value = "\t\r\n";
+
+    assert.throws(
+      () => TemplateFunctions.validateData(templateSettings),
+      (err) => {
+        assert.strictEqual(
+          err.message,
+          `Illegal characters found for "The TestApp Id"`
+        );
+        return true;
+      },
+      "validateData should throw."
+    );
+  });
+
   test("Do conversion", async function () {
     const templateSettings = TemplateSettings.fromFile(
       templateSettingsFilePath
@@ -256,3 +289,47 @@ suite("Template", function () {
     );
   });
 });
+
+function templateMappingGuid(): string {
+  return `{
+  "mappings": [
+    {
+      "description": "The TestApp Id",
+      "example": "11112222-3333-4444-5555-666677778888",
+      "default": "$(guid)",
+      "placeholderSubstitutions": [
+        {
+          "path": "**/*",
+          "match": "[NAB_TESTAPP_GUID]"
+        }
+      ]
+    }
+  ],
+  "createXlfLanguages": [
+    "sv-SE",
+    "da-DK"
+  ]
+}`;
+}
+
+function templateMappingJSON(): string {
+  return `{
+  "mappings": [
+    {
+      "description": "The TestApp Id",
+      "example": "11112222-3333-4444-5555-666677778888",
+      "default": "NAB",
+      "placeholderSubstitutions": [
+        {
+          "path": "**/*",
+          "match": "[NAB_TESTAPP_GUID]"
+        }
+      ]
+    }
+  ],
+  "createXlfLanguages": [
+    "sv-SE",
+    "da-DK"
+  ]
+}`;
+}

--- a/extension/src/test/Template.test.ts
+++ b/extension/src/test/Template.test.ts
@@ -62,6 +62,21 @@ suite("Template", function () {
     );
   });
 
+  test("Parse Template Settings: Error - Path does not exist", function () {
+    assert.throws(
+      () => TemplateSettings.fromFile("path/does/not/exist"),
+      (err) => {
+        assert.ok(err instanceof Error);
+        assert.strictEqual(
+          err.message,
+          'Could not find file: "path/does/not/exist"'
+        );
+        return true;
+      },
+      "Expected function to throw error."
+    );
+  });
+
   test("Set defaults", function () {
     const templateSettings = TemplateSettings.fromFile(
       largerTemplateSettingsFilePath


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
Fixes #311  .

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- Generate and upload coverage report before running check. This will ensure that the artifact is available even if the threshold check fails.
- Added a few tests to make up for the threshold.