### PR TITLE
feat: Create Permission Set

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -269,6 +269,10 @@
         "title": "NAB: Renumber AL objects"
       },
       {
+        "command": "nab.createPermissionSetForAllObjects",
+        "title": "NAB: Create PermissionSet for all objects"
+      },
+      {
         "command": "nab.troubleshootParseCurrentFile",
         "title": "NAB: Troubleshoot - Parse current file",
         "enablement": "config.NAB.EnableTroubleshootingCommands"

--- a/extension/src/ALObject/ALElementTypes.ts
+++ b/extension/src/ALObject/ALElementTypes.ts
@@ -3,6 +3,7 @@ import {
   ALControlType,
   ALObjectType,
   ALPropertyType,
+  ALTableType,
   DocsType,
   EndOfLine,
   MultiLanguageType,
@@ -676,6 +677,15 @@ export class ALObject extends ALControl {
   public get sourceTable(): string {
     return this.getProperty(ALPropertyType.sourceTable, "") as string;
   }
+  public get tableType(): ALTableType {
+    if (this.objectType !== ALObjectType.table) {
+      return ALTableType.normal;
+    }
+    return this.getProperty(
+      ALPropertyType.tableType,
+      ALTableType.normal
+    ) as ALTableType;
+  }
   public get readOnly(): boolean {
     if (!this.getProperty(ALPropertyType.editable, true)) {
       return true;
@@ -853,6 +863,18 @@ export class ALPermissionSet extends ALObject {
     Permissions =
          ${this.permissions
            .sort((a, b) => {
+             if (
+               a.type === ALObjectType.tableData &&
+               b.type !== ALObjectType.tableData
+             ) {
+               return 1;
+             }
+             if (
+               b.type === ALObjectType.tableData &&
+               a.type !== ALObjectType.tableData
+             ) {
+               return -1;
+             }
              return a.type !== b.type
                ? a.type.localeCompare(b.type)
                : a.name.localeCompare(b.name);

--- a/extension/src/ALObject/Enums.ts
+++ b/extension/src/ALObject/Enums.ts
@@ -22,6 +22,7 @@ export enum ALObjectType {
 export enum ALPropertyType {
   unknown,
   sourceTable,
+  tableType,
   pageType,
   queryType,
   obsoleteState,
@@ -48,6 +49,15 @@ export enum ALCodeunitSubtype {
   install,
   upgrade,
   unknown,
+}
+export enum ALTableType {
+  normal = "Normal",
+  temporary = "Temporary",
+  cds = "CDS",
+  crm = "CRM",
+  exchange = "Exchange",
+  externalSql = "ExternalSQL",
+  microsoftGraph = "MicrosoftGraph",
 }
 
 export enum ALControlType {

--- a/extension/src/ALObject/Maps.ts
+++ b/extension/src/ALObject/Maps.ts
@@ -42,6 +42,7 @@ export const multiLanguageTypeMap = new Map<string, MultiLanguageType>([
 
 export const alPropertyTypeMap = new Map<string, ALPropertyType>([
   ["sourcetable", ALPropertyType.sourceTable],
+  ["tabletype", ALPropertyType.tableType],
   ["pagetype", ALPropertyType.pageType],
   ["querytype", ALPropertyType.queryType],
   ["obsoletestate", ALPropertyType.obsoleteState],

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -37,6 +37,8 @@ import { logger } from "./Logging/LogHelper";
 import { PermissionSetNameEditorPanel } from "./PermissionSet/PermissionSetNamePanel";
 import { TemplateEditorPanel } from "./Template/TemplatePanel";
 import { showErrorAndLog } from "./VSCodeFunctions";
+import { ALPermission, ALPermissionSet } from "./ALObject/ALElementTypes";
+import { ALObjectType, ALPropertyType, ALTableType } from "./ALObject/Enums";
 
 export async function refreshXlfFilesFromGXlf(
   suppressMessage = false
@@ -1347,11 +1349,7 @@ export async function convertToPermissionSet(
   Telemetry.trackEvent("convertToPermissionSet");
   try {
     const settings = SettingsLoader.getSettings();
-    const appSourceCopSettings = SettingsLoader.getAppSourceCopSettings();
-    const defaultPrefix =
-      appSourceCopSettings.mandatoryAffixes.length > 0
-        ? appSourceCopSettings.mandatoryAffixes[0].trim() + " "
-        : "";
+    const defaultPrefix = getDefaultPrefix();
     const permissionSetFilePaths = WorkspaceFunctions.getPermissionSetFiles(
       settings.workspaceFolderPath
     );
@@ -1379,6 +1377,15 @@ export async function convertToPermissionSet(
   } catch (error) {
     showErrorAndLog("Convert to PermissionSet object", error as Error);
   }
+}
+
+function getDefaultPrefix(): string {
+  const appSourceCopSettings = SettingsLoader.getAppSourceCopSettings();
+  const defaultPrefix =
+    appSourceCopSettings.mandatoryAffixes.length > 0
+      ? appSourceCopSettings.mandatoryAffixes[0].trim() + " "
+      : "";
+  return defaultPrefix;
 }
 
 function appendActiveDocument(filesToSearch: string[]): string[] {
@@ -1457,4 +1464,70 @@ function activeTextEditorIsXlf(): boolean {
     vscode.window.activeTextEditor !== undefined &&
     vscode.window.activeTextEditor.document.uri.fsPath.endsWith("xlf")
   );
+}
+
+export async function createPermissionSetForAllObjects(): Promise<void> {
+  logger.log("Running: createPermissionSetForAllObjects");
+  Telemetry.trackEvent("createPermissionSetForAllObjects");
+  try {
+    const appManifest = SettingsLoader.getAppManifest();
+    const settings = SettingsLoader.getSettings();
+    const allObjects = await WorkspaceFunctions.getAlObjectsFromCurrentWorkspace(
+      settings,
+      appManifest,
+      true,
+      false,
+      false
+    );
+    const firstNumber = appManifest.idRanges[0]
+      ? appManifest.idRanges[0].from
+      : 50000;
+    const prefix = getDefaultPrefix();
+    const permissionSet = new ALPermissionSet(
+      `${prefix}All`,
+      "All permissions",
+      firstNumber
+    );
+    allObjects
+      .filter(
+        (obj) =>
+          [
+            ALObjectType.codeunit,
+            ALObjectType.page,
+            ALObjectType.query,
+            ALObjectType.report,
+            ALObjectType.table,
+            ALObjectType.xmlPort,
+          ].includes(obj.objectType) && !obj.isObsolete()
+      )
+      .forEach((obj) => {
+        if (
+          obj.objectType === ALObjectType.table &&
+          obj.getProperty(ALPropertyType.tableType, ALTableType.normal) ===
+            ALTableType.normal
+        ) {
+          permissionSet.permissions.push(
+            new ALPermission(ALObjectType.tableData, obj.objectName, "RIMD")
+          );
+        }
+        permissionSet.permissions.push(
+          new ALPermission(obj.objectType, obj.objectName, "X")
+        );
+      });
+    const filePath = path.join(
+      settings.sourceFolderPath,
+      `All.PermissionSet.al`
+    );
+    if (fs.existsSync(filePath)) {
+      throw new Error(`File ${filePath} already exists.`);
+    }
+    FileFunctions.createFolderIfNotExist(settings.sourceFolderPath);
+    fs.writeFileSync(filePath, permissionSet.toString(), { encoding: "utf8" });
+    vscode.workspace
+      .openTextDocument(filePath)
+      .then((doc) => vscode.window.showTextDocument(doc));
+    logger.log("Done: createPermissionSetForAllObjects");
+  } catch (error) {
+    showErrorAndLog("Create PermissionSet for all objects", error as Error);
+  }
 }

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -1472,6 +1472,13 @@ export async function createPermissionSetForAllObjects(): Promise<void> {
   try {
     const appManifest = SettingsLoader.getAppManifest();
     const settings = SettingsLoader.getSettings();
+    const filePath = path.join(
+      settings.sourceFolderPath,
+      `All.PermissionSet.al`
+    );
+    if (fs.existsSync(filePath)) {
+      throw new Error(`File ${filePath} already exists.`);
+    }
     const allObjects = await WorkspaceFunctions.getAlObjectsFromCurrentWorkspace(
       settings,
       appManifest,
@@ -1479,9 +1486,7 @@ export async function createPermissionSetForAllObjects(): Promise<void> {
       false,
       false
     );
-    const firstNumber = appManifest.idRanges[0]
-      ? appManifest.idRanges[0].from
-      : 50000;
+    const firstNumber = appManifest.idRanges[0].from ?? 50000;
     const prefix = getDefaultPrefix();
     const permissionSet = new ALPermissionSet(
       `${prefix}All`,
@@ -1514,13 +1519,6 @@ export async function createPermissionSetForAllObjects(): Promise<void> {
           new ALPermission(obj.objectType, obj.objectName, "X")
         );
       });
-    const filePath = path.join(
-      settings.sourceFolderPath,
-      `All.PermissionSet.al`
-    );
-    if (fs.existsSync(filePath)) {
-      throw new Error(`File ${filePath} already exists.`);
-    }
     FileFunctions.createFolderIfNotExist(settings.sourceFolderPath);
     fs.writeFileSync(filePath, permissionSet.toString(), { encoding: "utf8" });
     vscode.workspace

--- a/extension/src/Settings/Settings.ts
+++ b/extension/src/Settings/Settings.ts
@@ -71,6 +71,9 @@ export class Settings {
   public get translationFolderPath(): string {
     return path.join(this.workspaceFolderPath, "Translations");
   }
+  public get sourceFolderPath(): string {
+    return path.join(this.workspaceFolderPath, "src");
+  }
 
   public get dtsWorkFolderPath(): string {
     return path.join(this.workspaceFolderPath, ".dts");

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -150,6 +150,12 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand("nab.renumberALObjects", () => {
       NABfunctions.renumberALObjects();
     }),
+    vscode.commands.registerCommand(
+      "nab.createPermissionSetForAllObjects",
+      () => {
+        NABfunctions.createPermissionSetForAllObjects();
+      }
+    ),
     vscode.commands.registerTextEditorCommand(
       "nab.AddXmlCommentBold",
       (textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit) => {


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
Fixes #322.

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- A new command to create a permission set with 
  - All objects in the current workspace folder
  - Objects with `ObsoleteState = Removed ` is ignored
  - All objects are added with "X" permissions
  - TableData are added with "RIMD" permissions
