### PR TITLE
fix: Parsing Enum values one-liners #326

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -13,6 +13,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
   - `NAB: Create PermissionSet for all objects` - Creates a new AL file with a PermissionSet object. This PermissionSet object includes all objects in the current workspace folder. All objects are added with the "X" permissions. All tables are also added as TableData with "RIMD" permissions. Thanks to [kristerwiklund](https://github.com/kristerwiklund) for the feature suggestion! ([issue 322](https://github.com/jwikman/nab-al-tools/issues/322))
 - Fixes:
   - Fixed an issue where `Obsolete` properties on table fields was interpreted as `Obsolete` properties on the table object.
+  - Improved parsing of Enum values that are written on a single line with captions, comments and all. Thanks to [MisterTrojan](https://github.com/MisterTrojan) for reporting this! ([issue 326](https://github.com/jwikman/nab-al-tools/issues/326))
 
 ## [1.18]
 

--- a/extension/src/ALObject/ALParser.ts
+++ b/extension/src/ALObject/ALParser.ts
@@ -456,19 +456,17 @@ export function matchALControl(
         (alControlResultFiltered[2] as unknown) as number,
         alControlResultFiltered[3]
       );
-      if (alControlResult.groups?.enumValueCaption !== undefined) {
-        control.caption = alControlResult.groups.enumValueCaption;
-        if (alControlResult.groups?.enumValueCaptionLocked) {
-          const caption = control.multiLanguageObjects.find(
-            (x) =>
-              x.type === MultiLanguageType.property &&
-              x.name === MultiLanguageType.caption
-          );
-          if (caption) {
-            caption.locked = true;
-          }
+      if (alControlResult.groups?.enumOneLiner !== undefined) {
+        const tempCodeLine = new ALCodeLine(
+          alControlResult.groups?.enumOneLiner,
+          lineIndex,
+          codeLine.indentation + 1
+        );
+        const caption = getMlProperty(control, lineIndex, tempCodeLine);
+        if (caption !== undefined) {
+          control.multiLanguageObjects.push(caption);
+          result.controlIsComplete = true;
         }
-        result.controlIsComplete = true;
       }
       control.xliffTokenType = XliffTokenType.enumValue;
       break;

--- a/extension/src/constants.ts
+++ b/extension/src/constants.ts
@@ -47,7 +47,7 @@ const controlPatterns = [
   "^\\s*\\b(view)\\b\\((.*)\\)",
   "^\\s*\\b(dataitem)\\b\\((.*);.*\\)",
   "^\\s*\\b(column)\\b\\((.*);(.*)\\)",
-  `^\\s*\\b(value)\\b\\((\\d*);\\s*(${wordPattern})\\)(\\s*{\\s*Caption\\s*=\\s*'(?<enumValueCaption>.*?)'(\\s*,\\s*(?<enumValueCaptionLocked>Locked\\s*=\\s*true)\\s*)?;\\s*})?`,
+  `^\\s*\\b(value)\\b\\((\\d*);\\s*(${wordPattern})\\)(\\s*{\\s*(?<enumOneLiner>Caption\\s*=\\s*'(?<enumValueCaption>.*?)'(\\s*,\\s*(?<enumValueCaptionLocked>Locked\\s*=\\s*true)\\s*)?;\\s*)})?`,
   "^\\s*\\b(group)\\b\\((.*)\\)",
   "^\\s*\\b(field)\\b\\(\\s*(.*)\\s*;\\s*(.*);\\s*(.*)\\s*\\)",
   "^\\s*\\b(field)\\b\\((.*);(.*)\\)",

--- a/extension/src/test/ALObjectTestLibrary.ts
+++ b/extension/src/test/ALObjectTestLibrary.ts
@@ -1556,6 +1556,7 @@ export function getEnumWithDifferentFormats(): string {
     value(2; SharedAccessSignature) { Caption = 'Shared access signature (SAS)'; }
     value(3; " ") { Caption = ' '; }
     value(4; "") { Caption = ''; }
+    value(5; "none") { Caption = 'No note', Comment = 'DEA="kein ...", DEU="kein ..."'; }
 }`;
 }
 export function getPageWithoutToolTips(): string {

--- a/extension/src/test/ALParser.test.ts
+++ b/extension/src/test/ALParser.test.ts
@@ -39,7 +39,7 @@ suite("Classes.AL Functions Tests", function () {
     });
     assert.strictEqual(
       captionsToTranslate.length,
-      4,
+      5,
       "Unexpected number of captions to translate."
     );
     assert.strictEqual(
@@ -53,15 +53,17 @@ suite("Classes.AL Functions Tests", function () {
       "SharedAccessSignature",
       " ",
       "",
+      "none",
     ];
     const expectedCaptions = [
       "Invoice Posting (v.xx)",
       "Shared access signature (SAS)",
       " ",
       "",
+      "No note",
     ];
     assert.strictEqual(
-      expectedCaptions.length,
+      expectedValues.length,
       expectedCaptions.length,
       "Drunk programmer, couldn't update both arrays"
     );


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. -->
Fixes #326.

<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- Improved parsing of Enum values with captions written on one line, including comments.
- Instead of using custom caption parsing for enum values, the ordinary caption parser is now used.
