### PR TITLE
feat: PermissionSet conversion for non-first app folders and with al.packageCachePath

### DIFF
--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -1381,10 +1381,13 @@ export async function convertToPermissionSet(
 
 function getDefaultPrefix(): string {
   const appSourceCopSettings = SettingsLoader.getAppSourceCopSettings();
-  const defaultPrefix =
+  let defaultPrefix =
     appSourceCopSettings.mandatoryAffixes.length > 0
       ? appSourceCopSettings.mandatoryAffixes[0].trim() + " "
       : "";
+  if (!defaultPrefix && appSourceCopSettings.mandatoryPrefix) {
+    defaultPrefix = appSourceCopSettings.mandatoryPrefix;
+  }
   return defaultPrefix;
 }
 

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -1372,7 +1372,8 @@ export async function convertToPermissionSet(
     await PermissionSetNameEditorPanel.createOrShow(
       extensionUri,
       xmlPermissionSets,
-      prefix
+      prefix,
+      settings.workspaceFolderPath
     );
   } catch (error) {
     showErrorAndLog("Convert to PermissionSet object", error as Error);

--- a/extension/src/PermissionSet/PermissionSetFunctions.ts
+++ b/extension/src/PermissionSet/PermissionSetFunctions.ts
@@ -44,10 +44,11 @@ export async function getXmlPermissionSets(
 
 export async function startConversion(
   prefix: string,
-  xmlPermissionSets: XmlPermissionSet[]
+  xmlPermissionSets: XmlPermissionSet[],
+  workspaceFolderPath: string
 ): Promise<void> {
-  const settings = SettingsLoader.getSettings();
-  const manifest = SettingsLoader.getAppManifest();
+  const settings = SettingsLoader.getSettingsForFolder(workspaceFolderPath);
+  const manifest = SettingsLoader.getAppManifestForFolder(workspaceFolderPath);
   await vscode.window.withProgress(
     {
       location: vscode.ProgressLocation.Notification,

--- a/extension/src/PermissionSet/PermissionSetNamePanel.ts
+++ b/extension/src/PermissionSet/PermissionSetNamePanel.ts
@@ -20,11 +20,13 @@ export class PermissionSetNameEditorPanel {
   private readonly _resourceRoot: vscode.Uri;
   private _xmlPermissionSets: XmlPermissionSet[];
   private _prefix: string;
+  private _workspaceFolderPath: string;
 
   public static async createOrShow(
     extensionUri: vscode.Uri,
     xmlPermissionSets: XmlPermissionSet[],
-    prefix: string
+    prefix: string,
+    workspaceFolderPath: string
   ): Promise<void> {
     const column = vscode.window.activeTextEditor
       ? vscode.window.activeTextEditor.viewColumn
@@ -60,7 +62,8 @@ export class PermissionSetNameEditorPanel {
       panel,
       extensionUri,
       xmlPermissionSets,
-      prefix
+      prefix,
+      workspaceFolderPath
     );
   }
 
@@ -68,7 +71,8 @@ export class PermissionSetNameEditorPanel {
     panel: vscode.WebviewPanel,
     extensionUri: vscode.Uri,
     xmlPermissionSets: XmlPermissionSet[],
-    prefix: string
+    prefix: string,
+    workspaceFolderPath: string
   ) {
     this._panel = panel;
     this._resourceRoot = vscode.Uri.joinPath(
@@ -78,6 +82,7 @@ export class PermissionSetNameEditorPanel {
     );
     this._xmlPermissionSets = xmlPermissionSets;
     this._prefix = prefix;
+    this._workspaceFolderPath = workspaceFolderPath;
     // Set the webview's initial html content
     this._recreateWebview();
 
@@ -124,7 +129,8 @@ export class PermissionSetNameEditorPanel {
     try {
       await PermissionSetFunctions.startConversion(
         this._prefix,
-        this._xmlPermissionSets
+        this._xmlPermissionSets,
+        this._workspaceFolderPath
       );
     } catch (error) {
       vscode.window.showErrorMessage(

--- a/extension/src/Settings/Settings.ts
+++ b/extension/src/Settings/Settings.ts
@@ -63,6 +63,8 @@ export class Settings {
   public enableTroubleshootingCommands = true;
   public useDictionaryInDTSImport = true;
   public enableXliffCache = true;
+  // Other extension's settings:
+  public packageCachePath = undefined;
 
   constructor(workspaceFolderPath: string) {
     this.workspaceFolderPath = workspaceFolderPath;

--- a/extension/src/Settings/Settings.ts
+++ b/extension/src/Settings/Settings.ts
@@ -130,6 +130,7 @@ export class LaunchSettings {
 
 export interface IAppSourceCopSettings {
   mandatoryAffixes: string[];
+  mandatoryPrefix: string;
 }
 
 export interface IExtensionPackage {

--- a/extension/src/Settings/SettingsLoader.ts
+++ b/extension/src/Settings/SettingsLoader.ts
@@ -33,9 +33,16 @@ export function getLaunchSettings(): LaunchSettings {
   return CliSettingsLoader.getLaunchSettings(workspaceFolderPath);
 }
 
+export function getAppSourceCopSettingsForFolder(
+  workspaceFolderPath: string
+): IAppSourceCopSettings {
+  return CliSettingsLoader.getAppSourceCopSettings(workspaceFolderPath);
+}
+
 export function getAppSourceCopSettings(): IAppSourceCopSettings {
   const workspaceFolderPath = getWorkspaceFolderPath();
-  return CliSettingsLoader.getAppSourceCopSettings(workspaceFolderPath);
+  return getAppSourceCopSettingsForFolder(workspaceFolderPath);
+}
 }
 
 export function getAppManifest(): AppManifest {

--- a/extension/src/Settings/SettingsLoader.ts
+++ b/extension/src/Settings/SettingsLoader.ts
@@ -9,8 +9,7 @@ import {
 import { settingsMap } from "./SettingsMap";
 import * as CliSettingsLoader from "./CliSettingsLoader";
 
-export function getSettings(): Settings {
-  const workspaceFolderPath = getWorkspaceFolderPath();
+export function getSettingsForFolder(workspaceFolderPath: string): Settings {
   const config = vscode.workspace.getConfiguration(
     undefined,
     vscode.Uri.file(workspaceFolderPath)
@@ -28,6 +27,11 @@ export function getSettings(): Settings {
   return settings;
 }
 
+export function getSettings(): Settings {
+  const workspaceFolderPath = getWorkspaceFolderPath();
+  return getSettingsForFolder(workspaceFolderPath);
+}
+
 export function getLaunchSettings(): LaunchSettings {
   const workspaceFolderPath = getWorkspaceFolderPath();
   return CliSettingsLoader.getLaunchSettings(workspaceFolderPath);
@@ -43,11 +47,16 @@ export function getAppSourceCopSettings(): IAppSourceCopSettings {
   const workspaceFolderPath = getWorkspaceFolderPath();
   return getAppSourceCopSettingsForFolder(workspaceFolderPath);
 }
+
+export function getAppManifestForFolder(
+  workspaceFolderPath: string
+): AppManifest {
+  return CliSettingsLoader.getAppManifest(workspaceFolderPath);
 }
 
 export function getAppManifest(): AppManifest {
   const workspaceFolderPath = getWorkspaceFolderPath();
-  return CliSettingsLoader.getAppManifest(workspaceFolderPath);
+  return getAppManifestForFolder(workspaceFolderPath);
 }
 
 export function getWorkspaceFolderPath(): string {

--- a/extension/src/Settings/SettingsMap.ts
+++ b/extension/src/Settings/SettingsMap.ts
@@ -63,4 +63,7 @@ export const settingsMap = new Map<string, keyof Settings>([
   ["NAB.EnableTelemetry", "enableTelemetry"],
   ["NAB.EnableTroubleshootingCommands", "enableTroubleshootingCommands"],
   ["NAB.EnableXliffCache", "enableXliffCache"],
+
+  // Other extension's settings:
+  ["al.packageCachePath", "packageCachePath"],
 ]);

--- a/extension/src/WorkspaceFunctions.ts
+++ b/extension/src/WorkspaceFunctions.ts
@@ -45,6 +45,7 @@ export async function getAlObjectsFromCurrentWorkspace(
 }
 
 async function getSymbolFilesFromCurrentWorkspace(
+  settings: Settings,
   appManifest: AppManifest,
   includeOldVersions = false
 ): Promise<SymbolFile[]> {
@@ -53,7 +54,9 @@ async function getSymbolFilesFromCurrentWorkspace(
   if (!workspaceFolderPath) {
     return symbolFiles;
   }
-  const alPackageFolderPath = path.join(workspaceFolderPath, ".alpackages");
+  const packageCachePath = settings.packageCachePath ?? ".alpackages";
+
+  const alPackageFolderPath = path.join(workspaceFolderPath, packageCachePath);
   if (!fs.existsSync(alPackageFolderPath)) {
     return symbolFiles;
   }
@@ -112,7 +115,10 @@ export async function getAlObjectsFromSymbols(
       return alObjects;
     }
   }
-  const symbolFiles = await getSymbolFilesFromCurrentWorkspace(appManifest);
+  const symbolFiles = await getSymbolFilesFromCurrentWorkspace(
+    settings,
+    appManifest
+  );
   if (!symbolFiles) {
     return alObjects;
   }

--- a/extension/src/test/PermissionSet.test.ts
+++ b/extension/src/test/PermissionSet.test.ts
@@ -2,6 +2,7 @@ import * as path from "path";
 import * as fs from "fs";
 import * as assert from "assert";
 import * as FileFunctions from "../FileFunctions";
+import * as SettingsLoader from "../Settings/SettingsLoader";
 import * as PermissionSetFunctions from "../PermissionSet/PermissionSetFunctions";
 
 import { getPermissionSetFiles } from "../WorkspaceFunctions";
@@ -61,7 +62,7 @@ suite("PermissionSet", function () {
     );
   });
 
-  test("Convert XML PermissionSet", async function () {
+  test.only("Convert XML PermissionSet", async function () {
     const filePaths = getPermissionSetFiles(testFilesPath);
     const prefix = "NAB ";
     const xmlPermissionSets = await PermissionSetFunctions.getXmlPermissionSets(
@@ -69,7 +70,11 @@ suite("PermissionSet", function () {
       prefix
     );
     PermissionSetFunctions.validateData(xmlPermissionSets);
-    await PermissionSetFunctions.startConversion(prefix, xmlPermissionSets);
+    await PermissionSetFunctions.startConversion(
+      prefix,
+      xmlPermissionSets,
+      SettingsLoader.getWorkspaceFolderPath()
+    );
     const upgradeFilePath = path.join(
       testFilesPath,
       "PermissionSetUpgrade.Codeunit.al"

--- a/extension/src/test/PermissionSet.test.ts
+++ b/extension/src/test/PermissionSet.test.ts
@@ -62,7 +62,7 @@ suite("PermissionSet", function () {
     );
   });
 
-  test.only("Convert XML PermissionSet", async function () {
+  test("Convert XML PermissionSet", async function () {
     const filePaths = getPermissionSetFiles(testFilesPath);
     const prefix = "NAB ";
     const xmlPermissionSets = await PermissionSetFunctions.getXmlPermissionSets(


### PR DESCRIPTION
<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
Changes proposed in this pull request:

- Support for mandatoryPrefix in AppSourceCop.json
- Support conversion of PermissionSet for apps not in the first workspace folder - #334
- Support for the AL Language extension setting al.packageCachePath - #335
