### PR TITLE
chore: Updated GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,17 +1,21 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
-labels: ''
-assignees: ''
-
+title: ""
+labels: "bug"
+assignees: ""
 ---
 
 **Describe the bug**
 A clear and concise description of what the bug is.
 
+**Versions used**
+VSCode:
+NAB AL Tools:
+
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -25,3 +29,6 @@ If applicable, add screenshots to help explain your problem.
 
 **Additional context**
 Add any other context about the problem here.
+
+- Does it happen all the time?
+- Did it use to work?

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,4 +31,4 @@ If applicable, add screenshots to help explain your problem.
 Add any other context about the problem here.
 
 - Does it happen all the time?
-- Did it use to work?
+- Did it used to work?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,14 +1,13 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
-labels: ''
-assignees: ''
-
+title: ""
+labels: "enhancement"
+assignees: ""
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+A clear and concise description of what the problem is. E.g. I'm always frustrated when [...]
 
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
-<!-- If there's an open issue please reference this here. -->
-Fixes # .
+<!-- If there's an open issue please reference this here. If there's no open issue, consider opening one first. -->
 
-<!-- If there's no open issue consider opening one first otherwise please describe the changes. -->
+Related to # .
+
 Changes proposed in this pull request:
 
 -


### PR DESCRIPTION
I do not like the auto-closing of issues from PR with the `Fixes #XXX`...
Now that we've got the pre-release feature, I prefer to release any fix as pre-release and then wait for feedback before closing the issue. 

When we get the pipelines for Pre-Release and Release in place we could automate the flow a bit with Labels.
Manually set `Label:Ships in future version` -> [pre-release pipeline] -> `Label:Pre-Release` -> [release pipeline] -> `Label:Shipped`

Changes proposed in this pull request:
- Updated PR template to not auto-close issues
- Update issue templates
  - Auto-set labels (we can remove or change on issue if needed)


What do you think?