### PR TITLE
fix: Handle errors from Telemetry

### DIFF
--- a/extension/src/Error.ts
+++ b/extension/src/Error.ts
@@ -9,3 +9,9 @@ export class InvalidXmlError extends Error {
     this.name = "InvalidXmlError";
   }
 }
+export class InvalidJsonError extends Error {
+  constructor(msg: string, public path: string, public content: string) {
+    super(msg);
+    this.name = "InvalidJsonError";
+  }
+}

--- a/extension/src/Error.ts
+++ b/extension/src/Error.ts
@@ -9,9 +9,22 @@ export class InvalidXmlError extends Error {
     this.name = "InvalidXmlError";
   }
 }
+
+/**
+ * Thrown when a Json file cannot be parsed as valid Json
+ */
 export class InvalidJsonError extends Error {
   constructor(msg: string, public path: string, public content: string) {
     super(msg);
     this.name = "InvalidJsonError";
+  }
+}
+/**
+ * Thrown when there is no language files (xlf files) in the Translation folder
+ */
+export class NoLanguageFilesError extends Error {
+  constructor(msg: string, public path: string) {
+    super(msg);
+    this.name = "NoLanguageFilesError";
   }
 }

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -31,7 +31,11 @@ import { TranslationMode } from "./Enums";
 import { LanguageFunctionsSettings } from "./Settings/LanguageFunctionsSettings";
 import { RefreshResult } from "./RefreshResult";
 import * as XliffFunctions from "./XliffFunctions";
-import { InvalidJsonError, InvalidXmlError } from "./Error";
+import {
+  InvalidJsonError,
+  InvalidXmlError,
+  NoLanguageFilesError,
+} from "./Error";
 import { TextDocumentMatch } from "./Types";
 import { logger } from "./Logging/LogHelper";
 import { PermissionSetNameEditorPanel } from "./PermissionSet/PermissionSetNamePanel";
@@ -1273,6 +1277,8 @@ export function getHoverText(
       handleInvalidXmlError(error, true);
     } else if (error instanceof InvalidJsonError) {
       Telemetry.trackException(error as InvalidJsonError);
+    } else if (error instanceof NoLanguageFilesError) {
+      // Do nothing, a quite common issue :)
     } else {
       Telemetry.trackException(error as Error);
     }

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -31,7 +31,7 @@ import { TranslationMode } from "./Enums";
 import { LanguageFunctionsSettings } from "./Settings/LanguageFunctionsSettings";
 import { RefreshResult } from "./RefreshResult";
 import * as XliffFunctions from "./XliffFunctions";
-import { InvalidXmlError } from "./Error";
+import { InvalidJsonError, InvalidXmlError } from "./Error";
 import { TextDocumentMatch } from "./Types";
 import { logger } from "./Logging/LogHelper";
 import { PermissionSetNameEditorPanel } from "./PermissionSet/PermissionSetNamePanel";
@@ -1271,6 +1271,8 @@ export function getHoverText(
   } catch (error) {
     if (error instanceof InvalidXmlError) {
       handleInvalidXmlError(error, true);
+    } else if (error instanceof InvalidJsonError) {
+      Telemetry.trackException(error as InvalidJsonError);
     } else {
       Telemetry.trackException(error as Error);
     }

--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -1284,7 +1284,7 @@ export function getHoverText(
     }
     const markdownString = new vscode.MarkdownString();
     markdownString.appendMarkdown(
-      "_something went wrong_\n\nThere was an issue when reading the xlf files. Please check that the xlf files exists in the Translations folder and that they have a valid format."
+      "_something went wrong_\n\nThere was an issue when reading the xlf or app.json files. Please check that the xlf files exists in the Translations folder, that they have a valid format and that app.json is valid."
     );
     returnValues.push(markdownString);
   }

--- a/extension/src/WorkspaceFunctions.ts
+++ b/extension/src/WorkspaceFunctions.ts
@@ -10,6 +10,7 @@ import * as ALParser from "./ALObject/ALParser";
 import { AppManifest, Settings } from "./Settings/Settings";
 import minimatch = require("minimatch");
 import { logger } from "./Logging/LogHelper";
+import { NoLanguageFilesError } from "./Error";
 
 export async function getAlObjectsFromCurrentWorkspace(
   settings: Settings,
@@ -194,8 +195,9 @@ export function getLangXlfFiles(
     settings.translationFolderPath
   ).filter((filePath) => !filePath.endsWith(gXlfName));
   if (xlfFilePaths.length === 0) {
-    throw new Error(
-      `No language files found in the translation folder "${settings.translationFolderPath}"\nTo get started: Copy the file ${gXlfName} to a new file and change target-language`
+    throw new NoLanguageFilesError(
+      `No language files found in the translation folder "${settings.translationFolderPath}"\nTo get started: Copy the file ${gXlfName} to a new file and change target-language`,
+      settings.translationFolderPath
     );
   }
   return xlfFilePaths;

--- a/extension/src/Xliff/XLIFFDocument.ts
+++ b/extension/src/Xliff/XLIFFDocument.ts
@@ -56,6 +56,9 @@ export class Xliff implements XliffDocumentInterface {
     xml = Xliff.validateXml(xml);
     const dom = xmldom.DOMParser;
     const xlfDom = new dom().parseFromString(xml);
+    if (xlfDom === undefined) {
+      throw new InvalidXmlError("Invalid XML", "", 0, 0);
+    }
     const xliff = Xliff.fromDocument(xlfDom);
     xliff.lineEnding = Xliff.detectLineEnding(xml);
     return xliff;

--- a/extension/src/Xliff/XLIFFDocument.ts
+++ b/extension/src/Xliff/XLIFFDocument.ts
@@ -296,9 +296,9 @@ export class Xliff implements XliffDocumentInterface {
       xlf = Xliff.fromString(fs.readFileSync(filepath, encoding));
     } catch (error) {
       if (error instanceof InvalidXmlError) {
-        error.message = `The xml in ${path.basename(filepath)} is invalid. (${
+        error.message = `The xml in ${path.basename(filepath)} is invalid (${
           error.message
-        })`;
+        }).`;
         error.path = filepath;
       }
       throw error;

--- a/extension/src/externalresources/ExternalResources.ts
+++ b/extension/src/externalresources/ExternalResources.ts
@@ -119,7 +119,9 @@ export class BlobContainer implements BlobContainerInterface {
         }
 
         downloadFailed = true;
-        fs.unlinkSync(writeStream.path);
+        if (fs.existsSync(writeStream.path)) {
+          fs.unlinkSync(writeStream.path);
+        }
       });
 
       if (downloadFailed) {
@@ -133,7 +135,9 @@ export class BlobContainer implements BlobContainerInterface {
           `Failed to parse: ${blob.name}. Error: ${(e as Error).message}`
         );
         downloadResult.failed.push(blob.name);
-        fs.unlinkSync(writeStream.path);
+        if (fs.existsSync(writeStream.path)) {
+          fs.unlinkSync(writeStream.path);
+        }
         continue;
       }
       downloadResult.succeeded.push(blob.name);

--- a/extension/src/test/XLIFFTypes.test.ts
+++ b/extension/src/test/XLIFFTypes.test.ts
@@ -25,9 +25,9 @@ suite("Xliff Types - Deserialization", function () {
         ),
       (err) => {
         assert.ok(err instanceof InvalidXmlError);
-        assert.strictEqual(
-          err.message,
-          "The xml in invalid-xml.xlf is invalid."
+        assert.ok(
+          err.message.startsWith("The xml in invalid-xml.xlf is invalid"),
+          `Unexpected error message (${err.message})`
         );
         assert.strictEqual(
           err.index,

--- a/extension/src/test/XlfHighlighter.test.ts
+++ b/extension/src/test/XlfHighlighter.test.ts
@@ -71,7 +71,10 @@ suite("Xlf Highlighter", function () {
       },
       (err) => {
         assert.strictEqual(err.name, "InvalidXmlError");
-        assert.strictEqual(err.message, "The xml in invalid.xlf is invalid.");
+        assert.ok(
+          err.message.startsWith("The xml in invalid.xlf is invalid"),
+          `Unexpected error message (${err.message})`
+        );
         return true;
       }
     );


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. If there's no open issue, consider opening one first. -->

A few issues that was identified by analyzing telemetry has been fixed

- Check if a file exists before deleting
- Log json syntax errors to better understand what kind of issues we need to address
- Skip some unnecessary telemetry logging of exceptions (more or less expected errors)
- Improved some error message
- Throw error if xlf file is empty
- Handle some error of xlf file syntax
