### PR TITLE
fix: Support List of Dictionary

### DIFF
--- a/extension/src/constants.ts
+++ b/extension/src/constants.ts
@@ -13,9 +13,11 @@ const simpleDataTypePattern = `\\w+(\\[\\d+\\])?`; // Text[50]
 const optionValuePattern = `((${wordPattern})|)`;
 const optionDataTypePattern = `Option${anyWhiteSpacePattern}+(?<optionValues>(${optionValuePattern})(,${anyWhiteSpacePattern}*(${optionValuePattern}))*)`; // Option Option1,"Option 2"
 const dotNetTypePattern = `DotNet${anyWhiteSpacePattern}+(?<dotNameAssemblyName>${wordPattern})`; // DotNet UserInfo"
-const listDataTypePattern = `List${anyWhiteSpacePattern}+of${anyWhiteSpacePattern}+\\[(${simpleDataTypePattern}|${removeGroupNamesFromRegex(
+const listDataTypePatternBase = `List${anyWhiteSpacePattern}+of${anyWhiteSpacePattern}+\\[(${simpleDataTypePattern}|${removeGroupNamesFromRegex(
   objectDataTypePattern
-)})\\]`; // List of [Text]
+)}`; // List of [Text]
+const listDataTypePatternEnding = ")\\]";
+const listDataTypeWithoutDictionaryPattern = `${listDataTypePatternBase}${listDataTypePatternEnding}`;
 const dictionaryDataTypePattern = `Dictionary${anyWhiteSpacePattern}+of${anyWhiteSpacePattern}+\\[(${simpleDataTypePattern}|${removeGroupNamesFromRegex(
   objectDataTypePattern
 )}),\\s*((${simpleDataTypePattern}|${removeGroupNamesFromRegex(
@@ -24,13 +26,13 @@ const dictionaryDataTypePattern = `Dictionary${anyWhiteSpacePattern}+of${anyWhit
   objectDataTypePattern
 )}),\\s*(${simpleDataTypePattern}|${removeGroupNamesFromRegex(
   objectDataTypePattern
-)})\\]|${listDataTypePattern})\\]`; // Dictionary of [Integer, Text]
+)})\\]|${listDataTypeWithoutDictionaryPattern})\\]`; // Dictionary of [Integer, Text]
 const arrayDataTypePattern = `Array\\[(?<dimensions>\\d+(${anyWhiteSpacePattern}*,${anyWhiteSpacePattern}*\\d+)*)\\]${anyWhiteSpacePattern}+of${anyWhiteSpacePattern}+((?<objectArrayType>${removeGroupNamesFromRegex(
   objectDataTypePattern
 )})|(?<optionArrayType>${removeGroupNamesFromRegex(
   optionDataTypePattern
 )})|(?<simpleDataArrayType>${simpleDataTypePattern}))`; // 'Array[10] of Text' or 'array[32] of Record "Cause of Absence"'
-
+const listDataTypePattern = `${listDataTypePatternBase}|(${dictionaryDataTypePattern})${listDataTypePatternEnding}`;
 const variableDatatypePattern = `\\s*(?<datatype>(?<objectDataType>${objectDataTypePattern})|(?<optionDatatype>${optionDataTypePattern})|(?<dotNetDatatype>${dotNetTypePattern})|(?<dictionary>${dictionaryDataTypePattern})|(?<list>${listDataTypePattern})|(?<array>${arrayDataTypePattern})|(?<simpleDatatype>${simpleDataTypePattern}))${anyWhiteSpacePattern}*`;
 export const parameterPattern = `(?<byRef>\\s*\\bvar\\b\\s*)?(?<name>${wordPattern})\\s*:${variableDatatypePattern}`;
 export const returnVariablePattern = `((?<name>${wordPattern})?\\s*:${variableDatatypePattern})`;
@@ -78,6 +80,7 @@ export const controlPattern = controlPatterns.join("|");
 
 // Used for troubleshooting regex nightmare:
 // console.log("dictionaryDataTypePattern:\n", dictionaryDataTypePattern);
+// console.log("listDataTypePattern:\n", listDataTypePattern);
 // console.log("wordPattern:\n", wordPattern);
 // console.log("optionValuePattern:\n", optionValuePattern);
 // console.log("optionDataTypePattern:\n", optionDataTypePattern);

--- a/extension/src/test/ALParser.test.ts
+++ b/extension/src/test/ALParser.test.ts
@@ -536,6 +536,30 @@ suite("Classes.AL Functions Tests", function () {
 
   test("Procedure parsing", function () {
     testProcedure(
+      `local procedure CreateDefaultDimSourcesFromDimArray(No: array[10] of Code[20])`,
+      0,
+      ALAccessModifier.local,
+      "CreateDefaultDimSourcesFromDimArray",
+      1,
+      0
+    );
+    testProcedure(
+      `local procedure CreateDefaultDimSourcesFromDimArray(var DefaultDimSource: List of [Dictionary of [Integer, Code[20]]])`,
+      0,
+      ALAccessModifier.local,
+      "CreateDefaultDimSourcesFromDimArray",
+      1,
+      0
+    );
+    testProcedure(
+      `local procedure CreateDefaultDimSourcesFromDimArray(var DefaultDimSource: List of [Dictionary of [Integer, Code[20]]]; TableID: array[10] of Integer; No: array[10] of Code[20])`,
+      0,
+      ALAccessModifier.local,
+      "CreateDefaultDimSourcesFromDimArray",
+      3,
+      0
+    );
+    testProcedure(
       `local procedure AddSoapActionHeader(SoapAction: Text; var DotNet_HttpWebRequest: DotNet HttpWebRequest);
 var
 `,
@@ -957,6 +981,13 @@ local procedure OnCalcDateBOCOnAfterGetCalendarCodes(var CustomCalendarChange: A
     }
   }
   test("Parameter parsing", function () {
+    testParameter(
+      "var DefaultDimSource: List of [Dictionary of [Integer, Code[20]]]",
+      true,
+      "DefaultDimSource",
+      "List of [Dictionary of [Integer, Code[20]]]",
+      undefined
+    );
     testParameter(
       'NewAmountField: array[8] of Option " ","Budget Price","Usage Price","Billable Price","Invoiced Price","Budget Cost","Usage Cost","Billable Cost","Invoiced Cost","Budget Profit","Usage Profit","Billable Profit","Invoiced Profit"',
       false,

--- a/extension/src/test/PermissionSet.test.ts
+++ b/extension/src/test/PermissionSet.test.ts
@@ -63,6 +63,8 @@ suite("PermissionSet", function () {
   });
 
   test("Convert XML PermissionSet", async function () {
+    this.timeout(3000);
+
     const filePaths = getPermissionSetFiles(testFilesPath);
     const prefix = "NAB ";
     const xmlPermissionSets = await PermissionSetFunctions.getXmlPermissionSets(


### PR DESCRIPTION
Changes proposed in this pull request:

- Added support for Lists with Dictionary like `List of [Dictionary of [Integer, Code[20]]]` and alike


Additional comments
The regex constants is getting even worse. This was because I already had support for Dictionaries with Lists and ended up with an endless loop... 😅
This might be refactored one day to use a recursive function to build this regex with support for n levels of nested dictionaries and/or lists. But I think this is enough for now. I believe that I successfully parsed the complete BaseApp with this change.

Known limitation: We do not support "Dictionaries with Lists of Dictionaries", or "Lists with Dictionaries of Lists" and similar constructs.