### PR TITLE
ci: bump node version 14.x->16.x

### DIFF
--- a/.github/workflows/nerd-stuff.yml
+++ b/.github/workflows/nerd-stuff.yml
@@ -10,7 +10,7 @@ jobs:
   report:
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     runs-on: ubuntu-latest
     env:
       working-directory: ./extension/


### PR DESCRIPTION
VS Code 1.66  bumps Nodejs version to 16.x.