### PR TITLE
feat: TranslationFilenamePattern setting

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -13,9 +13,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
   - Permission Sets are now included when running `NAB: Generate External Documentation`. All Permission Sets that are `Assignable` are included with any provided XmlComments.
 - Fixes:
   - Fixed bug in `NAB: Refresh XLF files from g.xlf` where notes highlighting empty sources were not exported. Big thanks to [phenno1](https://github.com/phenno1) for reporting this in [issue 333](https://github.com/jwikman/nab-al-tools/issues/333).
+  - Added support for parameters with a datatype like `List of [Dictionary of [Integer, Code[20]]]`
 - New settings:
   - `NAB.PreferLockedTranslations` Specifies if \"NAB: Refresh XLF files from g.xlf\" should be opinionated about locked translations e.g. when both source and target consists of only whitespace.
-  - Added support for parameters with a datatype like `List of [Dictionary of [Integer, Code[20]]]`
+  - `NAB.TranslationFilenamePattern` Specifies a filename pattern for the translation xliff files. This could be useful to change if the Translation folder contains translations for other apps. The default pattern is "\*.xlf".
 
 ## [1.20]
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -644,6 +644,7 @@ This extension contributes the following settings:
 - `NAB.Xliff CSV Export Path`: sets the export path for `NAB: Export Translations to .csv`. Default path for export is the Translation file directory.
 - `NAB.Xliff CSV Import Target State` Sets how the Target State property should be set when importing from a .csv file into a XLIFF file. Only the State of Targets that has been changed will get updated. This will setting will only be in effect when the setting `NAB.UseExternalTranslationTool` is enabled.
 - `NAB.PreferLockedTranslations` Specifies if \"NAB: Refresh XLF files from g.xlf\" should be opinionated about locked translations e.g. when both source and target consists of only whitespace.
+- `NAB.TranslationFilenamePattern` Specifies a filename pattern for the translation xliff files. This could be useful to change if the Translation folder contains translations for other apps.
 
 ## Contributing
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -515,6 +515,12 @@
             "default": true,
             "description": "Specifies if \"NAB: Refresh XLF files from g.xlf\" should be opinionated about locked translations e.g. when both source and target consists of only whitespace.",
             "scope": "resource"
+          },
+          "NAB.TranslationFilenamePattern": {
+            "type": "string",
+            "default": "*.xlf",
+            "description": "Specifies a filename pattern for the translation xliff files. This could be useful to change if the Translation folder contains translations for other apps.",
+            "scope": "resource"
           }
         }
       },

--- a/extension/src/Settings/Settings.ts
+++ b/extension/src/Settings/Settings.ts
@@ -64,6 +64,7 @@ export class Settings {
   public useDictionaryInDTSImport = true;
   public enableXliffCache = true;
   public preferLockedTranslations = true;
+  public translationFilenamePattern = "*.xlf";
   // Other extension's settings:
   public packageCachePath = undefined;
 

--- a/extension/src/Settings/SettingsMap.ts
+++ b/extension/src/Settings/SettingsMap.ts
@@ -64,6 +64,7 @@ export const settingsMap = new Map<string, keyof Settings>([
   ["NAB.EnableTroubleshootingCommands", "enableTroubleshootingCommands"],
   ["NAB.EnableXliffCache", "enableXliffCache"],
   ["NAB.PreferLockedTranslations", "preferLockedTranslations"],
+  ["NAB.TranslationFilenamePattern", "translationFilenamePattern"],
 
   // Other extension's settings:
   ["al.packageCachePath", "packageCachePath"],

--- a/extension/src/WorkspaceFunctions.ts
+++ b/extension/src/WorkspaceFunctions.ts
@@ -191,7 +191,7 @@ export function getLangXlfFiles(
   const gXlfName = getgXlfFileName(appManifest);
 
   const xlfFilePaths = FileFunctions.findFiles(
-    "*.xlf",
+    settings.translationFilenamePattern,
     settings.translationFolderPath
   ).filter((filePath) => !filePath.endsWith(gXlfName));
   if (xlfFilePaths.length === 0) {


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. If there's no open issue, consider opening one first. -->

Related to #345 .

Changes proposed in this pull request:

- Added a new setting, `TranslationFilenamePattern`, that can be used to limit the matching of xlf files when performing xliff related tasks.
- Instead of adding the setting as an array of patterns that should be ignored (as requested in issue), I decided to add a pattern for the files that should be used.
