### PR TITLE
build: clean up dependencies

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -795,15 +795,6 @@
         "@types/node": "*"
       }
     },
-    "@types/applicationinsights": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@types/applicationinsights/-/applicationinsights-0.20.0.tgz",
-      "integrity": "sha512-dQ3Hb58ERe5YNKFVyvU9BrEvpgKeb6Ht9HkCyBvsOZxhx6yKSwF3e+xml3PJQ3JiVOvf6gM/PmE3MdWDl1L6aA==",
-      "dev": true,
-      "requires": {
-        "applicationinsights": "*"
-      }
-    },
     "@types/eslint": {
       "version": "7.2.10",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.10.tgz",
@@ -916,15 +907,6 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-iotVxtCCsPLRAvxMFFgxL8HD2l4mAZ2Oin7/VJ2ooWO0VOK4EGOGmZWZn1uCq7RofR3I/1IOSjCHlFT71eVK0Q==",
       "dev": true
-    },
-    "@types/strip-json-comments": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-3.0.0.tgz",
-      "integrity": "sha512-+vSlZeCCGm/1Q3WwBJDUSGHvADTQjRl4Fve0AG9H+A4+xgJ7yAkWKoc4g7I9UoVqtwCzjv2g/GZn4xipokMYyQ==",
-      "dev": true,
-      "requires": {
-        "strip-json-comments": "*"
-      }
     },
     "@types/tunnel": {
       "version": "0.0.3",
@@ -3283,11 +3265,6 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
-    },
-    "javascript": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/javascript/-/javascript-1.0.0.tgz",
-      "integrity": "sha512-PnTGALRCw+1vqPQj5iE1xxZnEOPraSjIZ9LEZGjqP9I9iyjgRAXN7FYLDgPqZi7PhZxb3oLyYTJBttQpGCrMtg=="
     },
     "jest-worker": {
       "version": "26.6.2",

--- a/extension/package.json
+++ b/extension/package.json
@@ -736,7 +736,6 @@
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@types/adm-zip": "^0.4.34",
-    "@types/applicationinsights": "^0.20.0",
     "@types/format-duration": "^1.0.1",
     "@types/glob": "^7.1.3",
     "@types/js-yaml": "^4.0.5",
@@ -746,7 +745,6 @@
     "@types/node": "^12.20.12",
     "@types/node-powershell": "^3.1.1",
     "@types/semver": "^7.3.5",
-    "@types/strip-json-comments": "^3.0.0",
     "@types/uuid": "^8.3.3",
     "@types/vscode": "^1.63.0",
     "@types/xmldom": "^0.1.30",

--- a/extension/package.json
+++ b/extension/package.json
@@ -721,7 +721,6 @@
     "applicationinsights": "^2.2.0",
     "compare-versions": "^3.6.0",
     "format-duration": "^1.3.1",
-    "javascript": "^1.0.0",
     "lodash": "^4.17.21",
     "minimatch": "^3.0.4",
     "node-powershell": "^3.3.1",

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -1,13 +1,10 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "ES2019",
+    "target": "es2020",
     "outDir": "out",
     "lib": [
-      "ES2019",
-      "dom",
-      "es2018.regexp",
-      "ES2020.String"
+      "es2020"
     ],
     "sourceMap": true,
     "rootDir": "src",


### PR DESCRIPTION
So this might be a bit scary but all seems fine on my end;

:heavy_check_mark:  installs
:heavy_check_mark:  compiles
:heavy_check_mark:  tests; passing :ok_hand: 

(cleared `out`, `dist` and `node_modules` before hand)

Changes proposed in this pull request:

- Bump target to `es2020`
  - Removed some libs
- Remove some deprecated and unnecessary dependencies.


