### PR TITLE
feat: Fallback to field names for system tables

### DIFF
--- a/extension/src/ALObject/ALPageField.ts
+++ b/extension/src/ALObject/ALPageField.ts
@@ -11,7 +11,17 @@ export class ALPageField extends ALPageControl {
 
     // Check table for caption
     const field = this.getSourceTableField();
-    return field ? field.caption : "";
+    if (!field) {
+      return "";
+    }
+    if (field.caption !== "") {
+      return field.caption;
+    }
+    const sourceObject = this.getObject().getSourceObject();
+    if (sourceObject) {
+      return sourceObject.objectId > 2000000000 ? field.name : "";
+    }
+    return "";
   }
 
   public get readOnly(): boolean {


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. If there's no open issue, consider opening one first. -->

Changes proposed in this pull request:

- When getting a caption for a page field on a page with a system table as `SourceTable`, we now fallback to the table fields' name - just as BC does.