### PR TITLE
ci: Enable forced push to master

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ on:
         required: true
 jobs:
     release:
-      if: github.ref == 'refs/heads/dev/workflow-pat'
+      if: github.ref == 'refs/heads/master'
       runs-on: windows-latest
       env:
         working-directory: ./extension/
@@ -72,7 +72,7 @@ jobs:
         - name: Push Commits on pre-release on release
           if: ${{env.RELEASE_TYPE == 'release'}}
           run: |
-            git push
+            git push --force
             git push --tags
 
         - name: "Package: ${{ env.RELEASE_TYPE }}"
@@ -89,19 +89,19 @@ jobs:
             path: ./extension/*.vsix
             retention-days: 7
 
-        # - name: Publish ${{env.RELEASE_TYPE }} to Visual Studio Marketplace
-        #   shell: pwsh
-        #   run: |
-        #     if ($env:RELEASE_TYPE -eq 'pre-release') {
-        #         Write-Host "publish pre-release"
-        #         vsce publish  --pre-release --packagePath ${{ steps.packageVSIX.outputs.vsixPath }} --baseContentUrl $env:BASE_CONTENT_URL
-        #     }
-        #     elseif ($env:RELEASE_TYPE -eq 'release') {
-        #         Write-Host "publish release"
-        #         vsce publish --packagePath ${{ steps.packageVSIX.outputs.vsixPath }} --baseContentUrl $env:BASE_CONTENT_URL
-        #     } else {
-        #         Write-Error "Release type '$($env:RELEASE_TYPE)' is not supported." -ErrorAction Stop
-        #     }
+        - name: Publish ${{env.RELEASE_TYPE }} to Visual Studio Marketplace
+          shell: pwsh
+          run: |
+            if ($env:RELEASE_TYPE -eq 'pre-release') {
+                Write-Host "publish pre-release"
+                vsce publish  --pre-release --packagePath ${{ steps.packageVSIX.outputs.vsixPath }} --baseContentUrl $env:BASE_CONTENT_URL
+            }
+            elseif ($env:RELEASE_TYPE -eq 'release') {
+                Write-Host "publish release"
+                vsce publish --packagePath ${{ steps.packageVSIX.outputs.vsixPath }} --baseContentUrl $env:BASE_CONTENT_URL
+            } else {
+                Write-Error "Release type '$($env:RELEASE_TYPE)' is not supported." -ErrorAction Stop
+            }
 
         - name: Push Commits
           run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ on:
         required: true
 jobs:
     release:
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/dev/workflow-pat'
       runs-on: windows-latest
       env:
         working-directory: ./extension/
@@ -29,7 +29,11 @@ jobs:
           shell: pwsh
           run: |
             Write-Error "Remember to update the changelog before creating a release!" -ErrorAction Stop
+
         - uses: actions/checkout@v2
+          with:
+            token: ${{ secrets.PAT }}
+
         - uses: actions/setup-node@v2
           with:
             node-version: 16.x
@@ -85,19 +89,19 @@ jobs:
             path: ./extension/*.vsix
             retention-days: 7
 
-        - name: Publish ${{env.RELEASE_TYPE }} to Visual Studio Marketplace
-          shell: pwsh
-          run: |
-            if ($env:RELEASE_TYPE -eq 'pre-release') {
-                Write-Host "publish pre-release"
-                vsce publish  --pre-release --packagePath ${{ steps.packageVSIX.outputs.vsixPath }} --baseContentUrl $env:BASE_CONTENT_URL
-            }
-            elseif ($env:RELEASE_TYPE -eq 'release') {
-                Write-Host "publish release"
-                vsce publish --packagePath ${{ steps.packageVSIX.outputs.vsixPath }} --baseContentUrl $env:BASE_CONTENT_URL
-            } else {
-                Write-Error "Release type '$($env:RELEASE_TYPE)' is not supported." -ErrorAction Stop
-            }
+        # - name: Publish ${{env.RELEASE_TYPE }} to Visual Studio Marketplace
+        #   shell: pwsh
+        #   run: |
+        #     if ($env:RELEASE_TYPE -eq 'pre-release') {
+        #         Write-Host "publish pre-release"
+        #         vsce publish  --pre-release --packagePath ${{ steps.packageVSIX.outputs.vsixPath }} --baseContentUrl $env:BASE_CONTENT_URL
+        #     }
+        #     elseif ($env:RELEASE_TYPE -eq 'release') {
+        #         Write-Host "publish release"
+        #         vsce publish --packagePath ${{ steps.packageVSIX.outputs.vsixPath }} --baseContentUrl $env:BASE_CONTENT_URL
+        #     } else {
+        #         Write-Error "Release type '$($env:RELEASE_TYPE)' is not supported." -ErrorAction Stop
+        #     }
 
         - name: Push Commits
           run: |
@@ -107,7 +111,7 @@ jobs:
         - name: Create GitHub Release
           uses: ncipollo/release-action@v1
           with:
-            token: ${{ secrets.GITHUB_TOKEN }}
+            token: ${{ secrets.PAT }}
             tag: ${{ steps.packageVSIX.outputs.tagName }}
             prerelease: ${{env.RELEASE_TYPE == 'pre-release'}}
             artifacts: "${{ steps.packageVSIX.outputs.vsixPath }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,8 +40,8 @@ jobs:
 
         - name: Git config
           run: |
-            git config user.name 'github-actions[bot]'
-            git config user.email 'github-actions[bot]@users.noreply.github.com'
+            git config user.name 'jwikman'
+            git config user.email 'jwikman@users.noreply.github.com'
             git config advice.addIgnoredFile false
 
         - name: Install dependencies
@@ -105,7 +105,7 @@ jobs:
 
         - name: Push Commits
           run: |
-            git push
+            git push --force
             git push --tags
 
         - name: Create GitHub Release

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nab-al-tools",
-  "version": "1.21.204042120",
+  "version": "1.21.204080745",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nab-al-tools",
-      "version": "1.21.204042120",
+      "version": "1.21.204080745",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.7.5",

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nab-al-tools",
-  "version": "1.21.204080745",
+  "version": "1.21.204080754",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nab-al-tools",
-      "version": "1.21.204080745",
+      "version": "1.21.204080754",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.7.5",

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "nab-al-tools",
   "displayName": "NAB AL Tools",
   "description": "Development and translation management tool for AL language and Microsoft Dynamics 365 Business Central extensions.",
-  "version": "1.21.204042120",
+  "version": "1.21.204080745",
   "publisher": "nabsolutions",
   "repository": {
     "type": "git",

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "nab-al-tools",
   "displayName": "NAB AL Tools",
   "description": "Development and translation management tool for AL language and Microsoft Dynamics 365 Business Central extensions.",
-  "version": "1.21.204080745",
+  "version": "1.21.204080754",
   "publisher": "nabsolutions",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Changes proposed in this pull request:

- Use PAT for git commands, to enable push to master

Additional comments
This is just temporary, we should switch to creating a release branch to trigger this workflow, and then auto complete a PR back to master.