### PR TITLE
fix: Support brackets in path names for templates

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -7,6 +7,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 -->
 
+## [1.23]
+
+- Fixes:
+  - Fixed a bug where the `NAB: Create AL Project from Template (preview)` failed if there where brackets (`[` or `]`) in the folder or file names. Thanks to [Joriek](https://github.com/Joriek) for reporting this issue! ([issue 343](https://github.com/jwikman/nab-al-tools/issues/343))
+
 ## [1.22]
 
 - New features:

--- a/extension/src/Template/TemplateFunctions.ts
+++ b/extension/src/Template/TemplateFunctions.ts
@@ -55,6 +55,7 @@ export async function startConversion(
             files: filePaths,
             from: regex,
             to: value,
+            disableGlobs: true, // To enable paths with brackets in folder or file names
             encoding: "UTF8",
           });
         }

--- a/extension/src/test/DocumentFunctions.test.ts
+++ b/extension/src/test/DocumentFunctions.test.ts
@@ -7,6 +7,8 @@ import * as SettingsLoader from "../Settings/SettingsLoader";
 
 suite("DocumentFunctions", function () {
   test("openTextFileWithSelection()", async function () {
+    this.timeout(5000);
+
     await assert.doesNotReject(async () => {
       await DocumentFunctions.openTextFileWithSelection(__filename, 0, 34);
     }, "Unexpected rejection of promise");


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. If there's no open issue, consider opening one first. -->

Related to #343.

Changes proposed in this pull request:

- Support for brackets ([ and ]) in folder or file names when using the template features
