### PR TITLE
fix: Improved identification of curly brackets

### DIFF
--- a/extension/src/ALObject/ALParser.ts
+++ b/extension/src/ALObject/ALParser.ts
@@ -568,7 +568,7 @@ function getProperty(
 }
 
 export function matchIndentationDecreased(codeLine: ALCodeLine): boolean {
-  const indentationDecrease = /(^\s*}|}\s*\/{2}(.*)$|^\s*\bend\b)/i;
+  const indentationDecrease = /(^\s*}\s*$|(^[^{]*}\s*\/{2}(.*)$)|^\s*\bend\b)/i;
   const decreaseResult = codeLine.code.trim().match(indentationDecrease);
   return null !== decreaseResult;
 }

--- a/extension/src/test/ALObject/ALObject.test.ts
+++ b/extension/src/test/ALObject/ALObject.test.ts
@@ -376,6 +376,26 @@ suite("ALObject TransUnit Tests", function () {
 
   test("Match indentation increase", function () {
     assert.strictEqual(
+      ALParser.matchIndentationIncreased(
+        new ALCodeLine(
+          '                modify("Ongoing Sales Credit Memos") { Visible = true; }',
+          0
+        )
+      ),
+      false,
+      "{ }"
+    );
+    assert.strictEqual(
+      ALParser.matchIndentationIncreased(
+        new ALCodeLine(
+          '                modify("Ongoing Sales Credit Memos") { Visible = true; } // My comment',
+          0
+        )
+      ),
+      false,
+      "{ } // Comment"
+    );
+    assert.strictEqual(
       ALParser.matchIndentationIncreased(new ALCodeLine("  begin", 0)),
       true,
       "  begin"
@@ -506,6 +526,26 @@ suite("ALObject TransUnit Tests", function () {
   });
 
   test("Match indentation decrease", function () {
+    assert.strictEqual(
+      ALParser.matchIndentationDecreased(
+        new ALCodeLine(
+          '                modify("Ongoing Sales Credit Memos") { Visible = true; }',
+          0
+        )
+      ),
+      false,
+      "{ }"
+    );
+    assert.strictEqual(
+      ALParser.matchIndentationDecreased(
+        new ALCodeLine(
+          '                modify("Ongoing Sales Credit Memos") { Visible = true; } // My comment',
+          0
+        )
+      ),
+      false,
+      "{ } // Comment"
+    );
     assert.strictEqual(
       ALParser.matchIndentationDecreased(new ALCodeLine("end", 0)),
       true,


### PR DESCRIPTION
Changes proposed in this pull request:

- Better identification of curly bracket to better handle code like:
  - `modify("My Field") { Visible = true; }`
  - `modify("My Field") { Visible = true; } // My Comment`

