### PR TITLE
feat: AL Template improvements

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -18,8 +18,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
       - `NAB.documentation.yamlTitle.enabled`: When creating external documentation, this setting specifies if a title should be created in a Yaml Header in each generated md file.
       - `NAB.documentation.yamlTitle.prefix`: When creating external documentation, this setting specifies a prefix to the YAML title created in the Yaml Header in each generated md file. This settings is only used if the `NAB.documentation.yamlTitle.enabled` setting is enabled. The special containers `{appName}`, `{publisher}` and `{version}` can be used in this setting, they will be replaced by the values from app.json when the title is created.
       - `NAB.documentation.yamlTitle.suffix`: When creating external documentation, this setting specifies a suffix to the YAML title created in the Yaml Header in each generated md file. This settings is only used if the `NAB.documentation.yamlTitle.enabled` setting is enabled. The special containers `{appName}`, `{publisher}` and `{version}` can be used in this setting, they will be replaced by the values from app.json when the title is created.
+  - `NAB: Create AL Project from Template (preview)` supports a maximum length for a mapping in the `al.template.json` file. This will make sure the user does not enter to many characters in an input field.
 - Fixes:
   - Fixed a bug where the `NAB: Create AL Project from Template (preview)` failed if there where brackets (`[` or `]`) in the folder or file names. Thanks to [Joriek](https://github.com/Joriek) for reporting this issue! ([issue 343](https://github.com/jwikman/nab-al-tools/issues/343))
+  - Fixed a issue where the `NAB: Create AL Project from Template (preview)` did not render special characters (as < and >) in the description or example fields.
   - Improved identification of curly bracket to better handle code like:
     - `modify("My Field") { Visible = true; }`
     - `modify("My Field") { Visible = true; } // My Comment`

--- a/extension/src/Common.ts
+++ b/extension/src/Common.ts
@@ -21,6 +21,24 @@ export function escapeRegex(text: string): string {
   return text.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
 }
 
+export function htmlEscape(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+export function htmlUnescape(str: string): string {
+  return str
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}
+
 /**
  *
  * @param date Default Today

--- a/extension/src/Template/TemplatePanel.ts
+++ b/extension/src/Template/TemplatePanel.ts
@@ -4,6 +4,7 @@ import * as Telemetry from "../Telemetry/Telemetry";
 import * as TemplateFunctions from "./TemplateFunctions";
 import { IMapping, IMappingMessage, TemplateSettings } from "./TemplateTypes";
 import { logger } from "../Logging/LogHelper";
+import { htmlEscape } from "../Common";
 
 /**
  * Manages TemplateEditorPanel webview panels
@@ -226,14 +227,14 @@ export class TemplateEditorPanel {
           {
             content: html.div(
               { id: `${mapping.id}-Description` },
-              mapping.description
+              htmlEscape(mapping.description)
             ),
             a: undefined,
           },
           {
             content: html.div(
               { id: `${mapping.id}-example`, type: "text" },
-              mapping.example
+              htmlEscape(mapping.example)
             ),
             a: undefined,
           },

--- a/extension/src/Template/TemplatePanel.ts
+++ b/extension/src/Template/TemplatePanel.ts
@@ -240,7 +240,13 @@ export class TemplateEditorPanel {
           },
           {
             content: html.textArea(
-              { id: `${mapping.id}-value`, type: "text" },
+              mapping.maxLength
+                ? {
+                    id: `${mapping.id}-value`,
+                    type: "text",
+                    maxLength: `${mapping.maxLength}`,
+                  }
+                : { id: `${mapping.id}-value`, type: "text" },
               mapping.value ?? ""
             ),
             a: { class: "target-cell" },

--- a/extension/src/Template/TemplateTypes.ts
+++ b/extension/src/Template/TemplateTypes.ts
@@ -82,6 +82,7 @@ export interface IMapping {
   renameFiles: IRenameFiles[];
   placeholderSubstitutions: IPlaceholderSubstitutions[];
   hidden: boolean;
+  maxLength: number;
 }
 
 export interface IMappingMessage {

--- a/extension/src/XliffEditor/HTML.ts
+++ b/extension/src/XliffEditor/HTML.ts
@@ -88,6 +88,7 @@ export interface HTMLAttributes {
   disabled?: boolean;
   title?: string;
   align?: string;
+  maxLength?: string;
 }
 export interface HTMLTag {
   content: string;

--- a/extension/syntaxes/templateSettingsSyntax.json
+++ b/extension/syntaxes/templateSettingsSyntax.json
@@ -58,6 +58,14 @@
             "type": "boolean",
             "default": false
           },
+          "maxLength": {
+            "$id": "#root/mappings/items/maxLength",
+            "title": "Max Length",
+            "description": "Specifies the maximum length of the text that the user can supply.",
+            "type": "integer",
+            "minimum": 1,
+            "pattern": "^\\d*$"
+          },
           "placeholderSubstitutions": {
             "$id": "#root/mappings/items/placeholderSubstitutions",
             "title": "Search and replace",


### PR DESCRIPTION
Related to #365 .

Changes proposed in this pull request:

- [x] Support special characters (as < and >) in `description `and `example` fields
  - `asdf <a.b@c.d>` only shows as `asdf`
- [x] Support for a max length for the text supplied in a mapping

Additional comments
The other things in #365 will wait until #324 is completed :)