### PR TITLE
test: some unit tests

### DIFF
--- a/extension/src/Dictionary.ts
+++ b/extension/src/Dictionary.ts
@@ -99,10 +99,6 @@ export class Dictionary implements IDictionary {
     return replacement;
   }
 
-  exists(word: string): boolean {
-    return this.find(word) !== undefined;
-  }
-
   defaultSetting(wordSettings?: WordSetting): WordSetting {
     const defaultSetting: WordSetting = {
       matchWholeWord: true,

--- a/extension/src/test/Common.test.ts
+++ b/extension/src/test/Common.test.ts
@@ -29,4 +29,24 @@ suite("Common", function () {
       "Unexpected output of sorting object"
     );
   });
+
+  test("htmlEscape", function () {
+    const actual = `&"'<>`;
+    const expected = "&amp;&quot;&#39;&lt;&gt;";
+    assert.strictEqual(
+      Common.htmlEscape(actual),
+      expected,
+      "Unexpected result of string escape"
+    );
+  });
+
+  test("htmlUnescape", function () {
+    const actual = "&amp;&quot;&#39;&lt;&gt;";
+    const expected = `&"'<>`;
+    assert.strictEqual(
+      Common.htmlUnescape(actual),
+      expected,
+      "Unexpected result of string escape"
+    );
+  });
 });

--- a/extension/src/test/Dictionary.test.ts
+++ b/extension/src/test/Dictionary.test.ts
@@ -19,6 +19,7 @@ suite("Dictionary Tests", () => {
       3,
       "Unexpected length of wordList"
     );
+
     leDict.addWord("Kontrakt", "Whatever");
     assert.strictEqual(
       leDict.wordList.length,
@@ -47,6 +48,7 @@ suite("Dictionary Tests", () => {
       false,
       "Expected setting to be false"
     );
+
     // Delete test word
     leDict.deleteWord("Hello");
     // Restore setting for word

--- a/extension/src/test/FileFunctions.test.ts
+++ b/extension/src/test/FileFunctions.test.ts
@@ -5,6 +5,7 @@ import * as path from "path";
 import * as fs from "fs";
 import * as Common from "../Common";
 import { BinaryReader } from "../SymbolReference/BinaryReader";
+import { InvalidJsonError } from "../Error";
 
 const WORKFLOW = process.env.GITHUB_ACTION; // Only run in GitHub Workflow
 suite("FileFunctions Tests", function () {
@@ -146,6 +147,33 @@ suite("FileFunctions Tests", function () {
       actualContent.length,
       rawContent.length - 1, // BOM
       "Strings should not be equal. Test file might have been saved without BOM."
+    );
+  });
+
+  test("loadJson(): InvalidJsonError", function () {
+    const filepath = path.resolve(testResourcesPath, "invalid-json.json");
+    assert.throws(
+      () => FileFunctions.loadJson(filepath),
+      (err) => {
+        assert.ok(err instanceof InvalidJsonError);
+        assert.strictEqual(
+          err.message,
+          "Unexpected token i in JSON at position 0",
+          "Unexpected error message."
+        );
+        assert.strictEqual(
+          err.name,
+          "InvalidJsonError",
+          "Unexpected name in error."
+        );
+        assert.strictEqual(
+          err.content,
+          "invalid-json.json",
+          "Unexpected content in error."
+        );
+        assert.strictEqual(err.path, filepath, "Unexpected path in error.");
+        return true;
+      }
     );
   });
 

--- a/extension/src/test/resources/invalid-json.json
+++ b/extension/src/test/resources/invalid-json.json
@@ -1,0 +1,1 @@
+invalid-json.json


### PR DESCRIPTION
Adding missing tests.

Changes proposed in this pull request:

- Removes unused `exists` function in Dictionary.ts
- Adds tests for `htmlEscape` and `htmlUnescape` in Common.ts
- Adds test for error path of `loadJson` of FileFunctions.ts


