### PR TITLE
Testing of cache branches

### DIFF
--- a/extension/src/test/SymbolReference/SymbolReferenceCache.test.ts
+++ b/extension/src/test/SymbolReference/SymbolReferenceCache.test.ts
@@ -26,6 +26,16 @@ suite("Symbol Reference Cache", () => {
     assert.ok(cache.isCached(appPackage));
   });
 
+  test("SymbolReferenceCache.set(): isCached", function () {
+    const cache = new SymbolReferenceCache();
+    cache.set(appPackage);
+    assert.strictEqual(cache.size, 1);
+    assert.ok(cache.isCached(appPackage));
+    cache.set(appPackage);
+    assert.strictEqual(cache.size, 1);
+    assert.ok(cache.isCached(appPackage));
+  });
+
   test("SymbolReferenceCache.isCached()", function () {
     const cache = new SymbolReferenceCache();
     cache.set(appPackage);

--- a/extension/src/test/Xliff/XliffCache.test.ts
+++ b/extension/src/test/Xliff/XliffCache.test.ts
@@ -26,6 +26,25 @@ suite("XliffCache Unit Tests", () => {
     assert.strictEqual(cache.isEnabled, false, "Cache was not disabled");
   });
 
+  test("XliffCache.update(): Error reading filepath", function () {
+    const badPath = path.join(__dirname, "this", "path", "is", "no.xlf");
+    const cache = new XliffCache(SettingsLoader.getSettings());
+    assert.throws(
+      () => cache.get(badPath),
+      (error) => {
+        assert.ok(error instanceof Error, "Unexpected error.");
+        assert.strictEqual(
+          error.message,
+          `ENOENT: no such file or directory, open '${badPath}'`,
+          "Unexpected error message."
+        );
+
+        return true;
+      },
+      "Expected error to be thrown"
+    );
+  });
+
   test("XliffCache.update()", function () {
     const expectedText = "Is it me you're looking for";
     const cache = new XliffCache(SettingsLoader.getSettings());
@@ -69,7 +88,8 @@ suite("XliffCache Unit Tests", () => {
           "Unexpected error message."
         );
         return true;
-      }
+      },
+      "Expected error to be thrown"
     );
   });
 });

--- a/extension/src/test/Xliff/XliffCache.test.ts
+++ b/extension/src/test/Xliff/XliffCache.test.ts
@@ -1,15 +1,19 @@
 import { XliffCache, xliffCache } from "../../Xliff/XLIFFCache";
 import * as path from "path";
+import * as fs from "fs";
 import { Xliff } from "../../Xliff/XLIFFDocument";
 import * as assert from "assert";
 import * as SettingsLoader from "../../Settings/SettingsLoader";
+import { InvalidXmlError } from "../../Error";
 
 suite("XliffCache Unit Tests", () => {
-  const xlfFilePath = path.join(
+  const testResourcesPath = path.join(
     __dirname,
     "../../../",
-    "src/test/resources/XliffCacheTest.da-DK.xlf"
+    "src/test/resources"
   );
+  const xlfFilePath = path.join(testResourcesPath, "XliffCacheTest.da-DK.xlf");
+
   test("XliffCache.isEnabled", function () {
     const settings = SettingsLoader.getSettings();
     let cache = new XliffCache(settings);
@@ -47,6 +51,26 @@ suite("XliffCache Unit Tests", () => {
       cache.get(xlfFilePath).transunit[0].source,
       expectedText,
       "Cached content should be not updated if disabled."
+    );
+  });
+
+  test("XliffCache.update(): InvalidXmlError", function () {
+    const invalidXlfPath = path.join(testResourcesPath, "invalid-xml.xlf");
+    const cache = new XliffCache(SettingsLoader.getSettings());
+    assert.throws(
+      () =>
+        cache.update(invalidXlfPath, fs.readFileSync(invalidXlfPath, "utf8")),
+      (error) => {
+        assert.ok(error instanceof InvalidXmlError, "Unexpected Error.");
+        assert.ok(error.path, "Expected path to be ok");
+        assert.strictEqual(error.path, invalidXlfPath, "Unexpected path.");
+        assert.strictEqual(
+          error.message,
+          "Invalid XML found at position 996.",
+          "Unexpected error message."
+        );
+        return true;
+      }
     );
   });
 });

--- a/extension/src/test/Xliff/XliffCache.test.ts
+++ b/extension/src/test/Xliff/XliffCache.test.ts
@@ -64,9 +64,8 @@ suite("XliffCache Unit Tests", () => {
         assert.ok(error instanceof InvalidXmlError, "Unexpected Error.");
         assert.ok(error.path, "Expected path to be ok");
         assert.strictEqual(error.path, invalidXlfPath, "Unexpected path.");
-        assert.strictEqual(
-          error.message,
-          "Invalid XML found at position 996.",
+        assert.ok(
+          error.message.startsWith("Invalid XML found at position "),
           "Unexpected error message."
         );
         return true;

--- a/extension/src/test/Xliff/XliffCache.test.ts
+++ b/extension/src/test/Xliff/XliffCache.test.ts
@@ -34,6 +34,21 @@ suite("XliffCache Unit Tests", () => {
       "Cached content was not updated."
     );
   });
+
+  test("XliffCache.update(): enabled = false", function () {
+    const settings = SettingsLoader.getSettings();
+    settings.enableXliffCache = false;
+    const cache = new XliffCache(settings);
+    const cachedXlf = cache.get(xlfFilePath);
+    const expectedText = cachedXlf.transunit[0].source;
+    cachedXlf.transunit[0].source = "Is it me you're looking for";
+    cache.update(xlfFilePath, cachedXlf.toString());
+    assert.strictEqual(
+      cache.get(xlfFilePath).transunit[0].source,
+      expectedText,
+      "Cached content should be not updated if disabled."
+    );
+  });
 });
 
 suite("XliffCache Sequential Tests", () => {

--- a/extension/src/test/Xliff/XliffCache.test.ts
+++ b/extension/src/test/Xliff/XliffCache.test.ts
@@ -26,7 +26,7 @@ suite("XliffCache Unit Tests", () => {
     assert.strictEqual(cache.isEnabled, false, "Cache was not disabled");
   });
 
-  test("XliffCache.update(): Error reading filepath", function () {
+  test("XliffCache.get(): Error reading filepath", function () {
     const badPath = path.join(__dirname, "this", "path", "is", "no.xlf");
     const cache = new XliffCache(SettingsLoader.getSettings());
     assert.throws(


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. If there's no open issue, consider opening one first. -->
Closes #375.

Changes proposed in this pull request:

- Improve testing of branches in XliffCache & SymbolReferenceCache

