### PR TITLE
fix: WorkspaceFileFolderPath for TaskRunner

### DIFF
--- a/extension/src/NABfunctions.ts
+++ b/extension/src/NABfunctions.ts
@@ -1485,8 +1485,8 @@ function activeTextEditorIsXlf(): boolean {
 }
 
 export async function runTaskItems(): Promise<void> {
-  const workspaceFolderPath = SettingsLoader.getWorkspaceFolderPath();
-  const taskRunner = TaskRunner.importTaskRunnerItems(workspaceFolderPath);
+  const workspaceFileFolderPath = SettingsLoader.getWorkspaceFileFolderPath();
+  const taskRunner = TaskRunner.importTaskRunnerItems(workspaceFileFolderPath);
   const foundTasks = taskRunner.taskList.length;
   if (foundTasks < 1) {
     return;

--- a/extension/src/Settings/SettingsLoader.ts
+++ b/extension/src/Settings/SettingsLoader.ts
@@ -1,3 +1,4 @@
+import * as path from "path";
 import * as vscode from "vscode";
 import {
   AppManifest,
@@ -57,6 +58,16 @@ export function getAppManifestForFolder(
 export function getAppManifest(): AppManifest {
   const workspaceFolderPath = getWorkspaceFolderPath();
   return getAppManifestForFolder(workspaceFolderPath);
+}
+
+export function getWorkspaceFileFolderPath(): string {
+  const workspaceFilePath = vscode.workspace.workspaceFile;
+  if (workspaceFilePath && !workspaceFilePath.fsPath.startsWith("untitled")) {
+    return path.dirname(workspaceFilePath.fsPath);
+  }
+
+  // Not a workspace file opened (at least not on disk), fallback
+  return getWorkspaceFolderPath();
 }
 
 export function getWorkspaceFolderPath(): string {

--- a/extension/src/Template/TaskRunner.ts
+++ b/extension/src/Template/TaskRunner.ts
@@ -58,7 +58,7 @@ export class TaskRunner {
   }
 
   async executeAll(): Promise<void> {
-    this.workspaceFilePath = SettingsLoader.getWorkspaceFolderPath();
+    this.workspaceFilePath = SettingsLoader.getWorkspaceFileFolderPath();
     for (const task of this.taskList) {
       await this.execute(task);
     }

--- a/extension/src/test/TaskRunner.test.ts
+++ b/extension/src/test/TaskRunner.test.ts
@@ -101,7 +101,7 @@ suite("Task Runner Tests", function () {
       {
         description: "Show release notes.",
         command: "update.showCurrentReleaseNotes",
-        openFile: "app.json",
+        openFile: "Xliff-test//app.json",
       },
     ];
     const taskRunner = new TaskRunner(taskList);

--- a/extension/src/test/TaskRunner.test.ts
+++ b/extension/src/test/TaskRunner.test.ts
@@ -101,7 +101,7 @@ suite("Task Runner Tests", function () {
       {
         description: "Show release notes.",
         command: "update.showCurrentReleaseNotes",
-        openFile: "Xliff-test//app.json",
+        openFile: "Xliff-test/app.json",
       },
     ];
     const taskRunner = new TaskRunner(taskList);


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. If there's no open issue, consider opening one first. -->

Related to #324 .

I that this one is on me, since I tricked you into this, @theschitz ...

But `getWorkspaceFolderPath()` did not do what I thought it did... 

I added `WorkspaceFileFolderPath()` that will return the folder of the workspace file, with a fallback to `getWorkspaceFolderPath()`, if no workspace file is being used.

I've tested it a few times, and now it seems to work.

PS. This "fire & forget" thing is really interesting, far from all commands implement the async part in a perfect way... 😂
So even if we do our best to await, it most probably wont wait until the complete command is finished. But I'd say that this is as good as it gets on this approach. 

And I quickly found out that I want the parameters for this... I believe that we could create a few PRs to Waldo, to improve his commands. :)
