### PR TITLE
ci: run tests against node 18.x which next LTS version.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
     runs-on: ${{ matrix.os }}
     env:
       working-directory: ./extension/


### PR DESCRIPTION
Changes proposed in this pull request:

- Run tests against Node.js 18.x which is has active LTS start on 2022-10-25.
  - https://nodejs.org/en/about/releases/
- Removes Node.js 14.x from the matrix.
