### PR TITLE
fix: Support XmlPermissionSet exported from Client

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -14,6 +14,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Fixes:
   - Fixes an issue where the provided values where reset to default if the focus was changed to another tab. This affected the WebViews used by `NAB: Create AL Project from Template (preview)` and `NAB: Convert to PermissionSet objects` ([issue 382](https://github.com/jwikman/nab-al-tools/issues/382)).
   - Improved support for Xml PermissionSets that are exported from the Web Client. Thanks to [kenmoto8](https://github.com/kenmoto8) for reporting this! ([issue 384](https://github.com/jwikman/nab-al-tools/issues/384))
+    - Support for `TenantPermissions` elements
+    - Support for permissions on `System`
+    - Support for names instead of numbers in `ObjectType`
+    - Support for `Yes` and `Indirect` instead of numbers for the different permissions
+    - Support for missing permission elements
 
 ## [1.24]
 

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -13,6 +13,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
   - The `info.json` file created by `NAB: Generate External Documentation` is updated to include `id`, `publisher`,`application`, `platform` and `runtime` from `app.json`.
 - Fixes:
   - Fixes an issue where the provided values where reset to default if the focus was changed to another tab. This affected the WebViews used by `NAB: Create AL Project from Template (preview)` and `NAB: Convert to PermissionSet objects` ([issue 382](https://github.com/jwikman/nab-al-tools/issues/382)).
+  - Improved support for Xml PermissionSets that are exported from the Web Client. Thanks to [kenmoto8](https://github.com/kenmoto8) for reporting this! ([issue 384](https://github.com/jwikman/nab-al-tools/issues/384))
 
 ## [1.24]
 

--- a/extension/src/ALObject/Enums.ts
+++ b/extension/src/ALObject/Enums.ts
@@ -19,6 +19,7 @@ export enum ALObjectType {
   interface = "Interface",
   permissionSet = "PermissionSet",
   permissionSetExtension = "PermissionSetExtension",
+  system = "System",
 }
 export enum ALPropertyType {
   unknown,

--- a/extension/src/ALObject/Maps.ts
+++ b/extension/src/ALObject/Maps.ts
@@ -13,7 +13,7 @@ export const alObjectTypeMap = new Map<string, ALObjectType>([
   ["report", ALObjectType.report],
   ["requestpage", ALObjectType.requestPage],
   ["table", ALObjectType.table],
-  ["tableData", ALObjectType.tableData],
+  ["tabledata", ALObjectType.tableData],
   ["xmlport", ALObjectType.xmlPort],
   ["enum", ALObjectType.enum],
   ["pageextension", ALObjectType.pageExtension],
@@ -25,6 +25,7 @@ export const alObjectTypeMap = new Map<string, ALObjectType>([
   ["pagecustomization", ALObjectType.pageCustomization],
   ["permissionset", ALObjectType.permissionSet],
   ["permissionsetextension", ALObjectType.permissionSetExtension],
+  ["system", ALObjectType.system],
 ]);
 
 export const multiLanguageTypeMap = new Map<string, MultiLanguageType>([

--- a/extension/src/PermissionSet/PermissionSetFunctions.ts
+++ b/extension/src/PermissionSet/PermissionSetFunctions.ts
@@ -9,8 +9,11 @@ import {
   ALPermissionSet,
 } from "../ALObject/ALElementTypes";
 import { ALControlType, ALObjectType } from "../ALObject/Enums";
-import { XmlPermissionSet, XmlPermissionSets } from "./XmlPermissionSet";
-import { alObjectTypeNumberMap } from "../ALObject/Maps";
+import {
+  Permission,
+  XmlPermissionSet,
+  XmlPermissionSets,
+} from "./XmlPermissionSet";
 import * as SettingsLoader from "../Settings/SettingsLoader";
 import { logger } from "../Logging/LogHelper";
 
@@ -129,12 +132,8 @@ async function convertToPermissionSet(
     lastUsedId = newPermissionSet.objectId;
     for (const permission of xmlPermissionSet.permissions) {
       const newPermission: ALPermission = new ALPermission(
-        getType(permission.objectType),
-        getObjectName(
-          alObjects,
-          getType(permission.objectType),
-          permission.objectID
-        ),
+        permission.objectType,
+        getObjectName(alObjects, permission.objectType, permission.objectID),
         getPermissions(
           permission.readPermission,
           permission.insertPermission,
@@ -282,20 +281,12 @@ function getFirstAvailableObjectId(
   return 50000; // Fallback if no free Id's found, let the compiler complain.
 }
 
-function getType(objectTypeText: string): ALObjectType {
-  const objectTypeNumber: number = Number.parseInt(objectTypeText);
-  const objectType = alObjectTypeNumberMap.get(objectTypeNumber);
-  if (!objectType) {
-    throw new Error(`No object type found for "${objectTypeText}"`);
-  }
-  return objectType;
-}
 function getPermissions(
-  readPermission: string,
-  insertPermission: string,
-  modifyPermission: string,
-  deletePermission: string,
-  executePermission: string
+  readPermission: Permission,
+  insertPermission: Permission,
+  modifyPermission: Permission,
+  deletePermission: Permission,
+  executePermission: Permission
 ): string {
   return `${getPermissionCasing("r", readPermission)}${getPermissionCasing(
     "i",
@@ -306,11 +297,14 @@ function getPermissions(
   )}${getPermissionCasing("x", executePermission)}`;
 }
 
-function getPermissionCasing(character: string, permission: string): string {
+function getPermissionCasing(
+  character: string,
+  permission: Permission
+): string {
   switch (permission) {
-    case "1":
+    case Permission.yes:
       return character.toUpperCase();
-    case "2":
+    case Permission.indirect:
       return character.toLowerCase();
     default:
       return "";

--- a/extension/src/PermissionSet/PermissionSetFunctions.ts
+++ b/extension/src/PermissionSet/PermissionSetFunctions.ts
@@ -242,6 +242,15 @@ function getObjectName(
   if (objectID === 0) {
     return "*";
   }
+  if (objectType === ALObjectType.system) {
+    const permission = systemPermissionsMap.get(objectID);
+    if (permission) {
+      return permission;
+    }
+    throw new Error(
+      `System permission ${objectID} is not supported. Please register an issue on https://github.com/jwikman/nab-al-tools/.`
+    );
+  }
   const searchObjectType: ALObjectType =
     objectType === ALObjectType.tableData ? ALObjectType.table : objectType;
   const obj = alObjects.find(
@@ -410,3 +419,67 @@ function createUpgradeCodeunit(
   fs.writeFileSync(filePath, code, { encoding: "utf8" });
   return filePath;
 }
+
+const systemPermissionsMap = new Map<number, string>([
+  [1310, "File, Import, Binary"],
+  [1320, "File, Import, Text"],
+  [1330, "File, Export, Binary"],
+  [1340, "File, Export, Text"],
+  [1350, "Run table"],
+  [1530, "File, Database, Test"],
+  [1540, "Allow Action Export Report Dat"],
+  [1550, "File, Database, Delete"],
+  [1570, "File, Database, Information"],
+  [1580, "File, Database, Options"],
+  [1610, "Create a new company"],
+  [1630, "Rename an existing company"],
+  [1640, "Delete a company"],
+  [1650, "Force Unlock"],
+  [2510, "Edit, Find"],
+  [2520, "Edit, Replace"],
+  [3220, "View, Table Filter"],
+  [3230, "View, FlowFilter"],
+  [3410, "View, Sort"],
+  [3510, "View, Design"],
+  [5210, "Tools, Object Designer"],
+  [5310, "Tools, Debugger"],
+  [5315, "Tools, Code Coverage"],
+  [5320, "Tools, Client Monitor"],
+  [5330, "Tools, Zoom"],
+  [5410, "Export Data to Data File"],
+  [5420, "Import Data from Data File"],
+  [5510, "Tools, Clear Old Versions"],
+  [5620, "Tools, Renumber"],
+  [5630, "Tools, Cross Reference"],
+  [5710, "Tools, Translate"],
+  [5810, "Tools, Security, Roles"],
+  [5820, "Tools, Security, DB Logins"],
+  [5821, "Tools, Security, Win. Logins"],
+  [5830, "Tools, Security, Password"],
+  [5910, "Tools, License Information"],
+  [6110, "Allow Action Export To Excel"],
+  [6300, "Per-database License"],
+  [9010, "Design, Table, Basic"],
+  [9015, "Design, Table, Advanced"],
+  [9020, "Design, Page, Basic"],
+  [9025, "Design, Page, Advanced"],
+  [9030, "Design, Report, Basic"],
+  [9035, "Design, Report, Advanced"],
+  [9040, "Design, Dataport, Basic"],
+  [9045, "Design, Dataport, Advanced"],
+  [9050, "Design, Codeunit, Basic"],
+  [9055, "Design, Codeunit, Advanced"],
+  [9060, "Design, XMLport, Basic"],
+  [9065, "Design, XMLport, Advanced"],
+  [9070, "Design, MenuSuite, Basic"],
+  [9075, "Design, MenuSuite, Advanced"],
+  [9090, "Design, Query, Basic"],
+  [9095, "Design, Query, Advanced"],
+  [9100, "Microsoft Dynamics NAV Server"],
+  [9500, "TestPartner Integration"],
+  [9600, "SmartList Designer API"],
+  [9605, "SmartList Designer Preview"],
+  [9610, "SmartList Management"],
+  [9615, "SmartList Import/Export"],
+  [9620, "Snapshot debugging"],
+]);

--- a/extension/src/PermissionSet/XmlPermissionSet.ts
+++ b/extension/src/PermissionSet/XmlPermissionSet.ts
@@ -29,9 +29,14 @@ export class XmlPermissionSets {
         filePath: filePath,
         suggestedNewName: prefix + roleId,
       };
-      const permissionsNodeList = permissionSetNode.getElementsByTagName(
+      let permissionsNodeList = permissionSetNode.getElementsByTagName(
         "Permission"
       );
+      if (permissionsNodeList.length === 0) {
+        permissionsNodeList = permissionSetNode.getElementsByTagName(
+          "TenantPermission"
+        );
+      }
       for (let i = 0; i < permissionsNodeList.length; i++) {
         const permissionsNode = permissionsNodeList[i];
         const objectType = XmlPermissionSets.getPermissionValue(

--- a/extension/src/PermissionSet/XmlPermissionSet.ts
+++ b/extension/src/PermissionSet/XmlPermissionSet.ts
@@ -1,5 +1,4 @@
 import * as xmldom from "@xmldom/xmldom";
-import { isNumber } from "lodash";
 import { ALObjectType } from "../ALObject/Enums";
 import { alObjectTypeMap, alObjectTypeNumberMap } from "../ALObject/Maps";
 
@@ -136,13 +135,11 @@ export class XmlPermissionSets {
   }
 
   private getALObjectType(objectTypeText: string): ALObjectType {
-    if (!isNumber(objectTypeText)) {
-      const alObjectType = alObjectTypeMap.get(
-        objectTypeText.replace(" ", "").toLowerCase()
-      );
-      if (alObjectType) {
-        return alObjectType;
-      }
+    const alObjectType = alObjectTypeMap.get(
+      objectTypeText.replace(" ", "").toLowerCase()
+    );
+    if (alObjectType) {
+      return alObjectType;
     }
     const objectTypeNumber: number = Number.parseInt(objectTypeText);
     const objectType = alObjectTypeNumberMap.get(objectTypeNumber);

--- a/extension/src/PermissionSet/XmlPermissionSet.ts
+++ b/extension/src/PermissionSet/XmlPermissionSet.ts
@@ -1,4 +1,7 @@
 import * as xmldom from "@xmldom/xmldom";
+import { isNumber } from "lodash";
+import { ALObjectType } from "../ALObject/Enums";
+import { alObjectTypeMap, alObjectTypeNumberMap } from "../ALObject/Maps";
 
 export class XmlPermissionSets {
   permissionSets: XmlPermissionSet[] = [];
@@ -32,30 +35,41 @@ export class XmlPermissionSets {
       );
       for (let i = 0; i < permissionsNodeList.length; i++) {
         const permissionsNode = permissionsNodeList[i];
-        const objectType = permissionsNode.getElementsByTagName("ObjectType")[0]
-          .childNodes[0].nodeValue;
-
-        const objectId = permissionsNode.getElementsByTagName("ObjectID")[0]
-          .childNodes[0].nodeValue;
-        const readPermission =
-          permissionsNode.getElementsByTagName("ReadPermission")[0]
-            .childNodes[0].nodeValue ?? "";
-        const insertPermission =
-          permissionsNode.getElementsByTagName("InsertPermission")[0]
-            .childNodes[0].nodeValue ?? "";
-        const modifyPermission =
-          permissionsNode.getElementsByTagName("ModifyPermission")[0]
-            .childNodes[0].nodeValue ?? "";
-        const deletePermission =
-          permissionsNode.getElementsByTagName("DeletePermission")[0]
-            .childNodes[0].nodeValue ?? "";
-        const executePermission =
-          permissionsNode.getElementsByTagName("ExecutePermission")[0]
-            .childNodes[0].nodeValue ?? "";
+        const objectType = XmlPermissionSets.getPermissionValue(
+          permissionsNode,
+          "ObjectType"
+        );
+        const objectId = XmlPermissionSets.getPermissionValue(
+          permissionsNode,
+          "ObjectID"
+        );
+        const readPermission = XmlPermissionSets.getPermissionValue(
+          permissionsNode,
+          "ReadPermission"
+        );
+        const insertPermission = XmlPermissionSets.getPermissionValue(
+          permissionsNode,
+          "InsertPermission"
+        );
+        const modifyPermission = XmlPermissionSets.getPermissionValue(
+          permissionsNode,
+          "ModifyPermission"
+        );
+        const deletePermission = XmlPermissionSets.getPermissionValue(
+          permissionsNode,
+          "DeletePermission"
+        );
+        const executePermission = XmlPermissionSets.getPermissionValue(
+          permissionsNode,
+          "ExecutePermission"
+        );
+        const securityFilter = permissionsNode.getElementsByTagName(
+          "SecurityFilter"
+        );
         if (
-          permissionsNode
-            .getElementsByTagName("SecurityFilter")[0]
-            .hasChildNodes()
+          securityFilter &&
+          securityFilter[0] &&
+          securityFilter[0].hasChildNodes()
         ) {
           throw new Error(
             `PermissionSet ${permissionSet.roleID} har defined some SecurityFilter, which is unsupported by this function`
@@ -72,18 +86,70 @@ export class XmlPermissionSets {
           );
         }
         const permission: XmlPermission = {
-          objectType: objectType,
+          objectType: this.getALObjectType(objectType),
           objectID: Number.parseInt(objectId),
-          readPermission: readPermission,
-          insertPermission: insertPermission,
-          modifyPermission: modifyPermission,
-          deletePermission: deletePermission,
-          executePermission: executePermission,
+          readPermission: XmlPermissionSets.stringToPermission(readPermission),
+          insertPermission: XmlPermissionSets.stringToPermission(
+            insertPermission
+          ),
+          modifyPermission: XmlPermissionSets.stringToPermission(
+            modifyPermission
+          ),
+          deletePermission: XmlPermissionSets.stringToPermission(
+            deletePermission
+          ),
+          executePermission: XmlPermissionSets.stringToPermission(
+            executePermission
+          ),
         };
         permissionSet.permissions.push(permission);
       }
       this.permissionSets.push(permissionSet);
     }
+  }
+
+  static getPermissionValue(
+    permissionsNode: Element,
+    permission: string
+  ): string {
+    const node = permissionsNode.getElementsByTagName(permission);
+    if (!node || !node[0] || !node[0].childNodes || !node[0].childNodes[0]) {
+      return "";
+    }
+    return node[0].childNodes[0].nodeValue ?? "";
+  }
+
+  static stringToPermission(permissionString: string): Permission {
+    switch (permissionString.toLocaleLowerCase()) {
+      case "0":
+      case "":
+        return Permission.none;
+      case "1":
+      case "yes":
+        return Permission.yes;
+      case "2":
+      case "indirect":
+        return Permission.indirect;
+      default:
+        throw new Error(`Unexpected permission value: ${permissionString}`);
+    }
+  }
+
+  private getALObjectType(objectTypeText: string): ALObjectType {
+    if (!isNumber(objectTypeText)) {
+      const alObjectType = alObjectTypeMap.get(
+        objectTypeText.replace(" ", "").toLowerCase()
+      );
+      if (alObjectType) {
+        return alObjectType;
+      }
+    }
+    const objectTypeNumber: number = Number.parseInt(objectTypeText);
+    const objectType = alObjectTypeNumberMap.get(objectTypeNumber);
+    if (!objectType) {
+      throw new Error(`No object type found for "${objectTypeText}"`);
+    }
+    return objectType;
   }
 }
 
@@ -96,11 +162,17 @@ export interface XmlPermissionSet {
 }
 
 export interface XmlPermission {
-  objectType: string;
+  objectType: ALObjectType;
   objectID: number;
-  readPermission: string;
-  insertPermission: string;
-  modifyPermission: string;
-  deletePermission: string;
-  executePermission: string;
+  readPermission: Permission;
+  insertPermission: Permission;
+  modifyPermission: Permission;
+  deletePermission: Permission;
+  executePermission: Permission;
+}
+
+export enum Permission {
+  none = 0,
+  yes = 1,
+  indirect = 2,
 }

--- a/extension/src/test/PermissionSet.test.ts
+++ b/extension/src/test/PermissionSet.test.ts
@@ -72,7 +72,7 @@ suite("PermissionSet", function () {
         readPermission: Permission.none,
         insertPermission: Permission.none,
         modifyPermission: Permission.none,
-        deletePermission: Permission.none,
+        deletePermission: Permission.indirect,
         executePermission: Permission.yes,
       },
       "Unexpected permission[1]"
@@ -150,7 +150,7 @@ suite("PermissionSet", function () {
     );
     assert.strictEqual(
       xmlPermissionSets[1].roleName,
-      "Al 2",
+      "",
       "Unexpected roleName 1"
     );
   });
@@ -164,6 +164,7 @@ suite("PermissionSet", function () {
       filePaths,
       prefix
     );
+    xmlPermissionSets[1].roleName = "A Name";
     PermissionSetFunctions.validateData(xmlPermissionSets);
     await PermissionSetFunctions.startConversion(
       prefix,

--- a/extension/src/test/PermissionSet.test.ts
+++ b/extension/src/test/PermissionSet.test.ts
@@ -26,14 +26,14 @@ suite("PermissionSet", function () {
 
   test("Parse PermissionSet XML Files", async function () {
     const filePaths = getPermissionSetFiles(testFilesPath);
-    assert.strictEqual(filePaths.length, 2, "Unexpected number of files");
+    assert.strictEqual(filePaths.length, 3, "Unexpected number of files");
     const xmlPermissionSets = await PermissionSetFunctions.getXmlPermissionSets(
       filePaths,
       ""
     );
     assert.strictEqual(
       xmlPermissionSets.length,
-      2,
+      3,
       "Unexpected number of permission sets"
     );
     assert.strictEqual(
@@ -49,7 +49,7 @@ suite("PermissionSet", function () {
     assert.strictEqual(
       xmlPermissionSets[0].permissions.length,
       26,
-      "Unexpected number of permissions"
+      "Unexpected number of permissions [0]"
     );
     assert.deepStrictEqual(
       xmlPermissionSets[0].permissions[0],
@@ -152,6 +152,35 @@ suite("PermissionSet", function () {
       xmlPermissionSets[1].roleName,
       "",
       "Unexpected roleName 1"
+    );
+
+    assert.strictEqual(
+      xmlPermissionSets[2].roleID,
+      "AL-TENANT",
+      "Unexpected roleId 0"
+    );
+    assert.strictEqual(
+      xmlPermissionSets[2].roleName,
+      "TenantPermissions",
+      "Unexpected roleName 0"
+    );
+    assert.strictEqual(
+      xmlPermissionSets[2].permissions.length,
+      5,
+      "Unexpected number of permissions [2]"
+    );
+    assert.deepStrictEqual(
+      xmlPermissionSets[2].permissions[0],
+      {
+        objectType: ALObjectType.tableData,
+        objectID: 50003,
+        readPermission: Permission.yes,
+        insertPermission: Permission.indirect,
+        modifyPermission: Permission.yes,
+        deletePermission: Permission.yes,
+        executePermission: Permission.none,
+      },
+      "Unexpected permission[2][0]"
     );
   });
 

--- a/extension/src/test/PermissionSet.test.ts
+++ b/extension/src/test/PermissionSet.test.ts
@@ -107,7 +107,7 @@ suite("PermissionSet", function () {
       xmlPermissionSets[0].permissions[4],
       {
         objectType: ALObjectType.query,
-        objectID: 776,
+        objectID: 50001,
         readPermission: Permission.none,
         insertPermission: Permission.none,
         modifyPermission: Permission.none,
@@ -120,7 +120,7 @@ suite("PermissionSet", function () {
       xmlPermissionSets[0].permissions[5],
       {
         objectType: ALObjectType.page,
-        objectID: 9560,
+        objectID: 50007,
         readPermission: Permission.none,
         insertPermission: Permission.none,
         modifyPermission: Permission.none,
@@ -133,7 +133,7 @@ suite("PermissionSet", function () {
       xmlPermissionSets[0].permissions[6],
       {
         objectType: ALObjectType.codeunit,
-        objectID: 9223,
+        objectID: 50002,
         readPermission: Permission.none,
         insertPermission: Permission.none,
         modifyPermission: Permission.none,

--- a/extension/src/test/PermissionSet.test.ts
+++ b/extension/src/test/PermissionSet.test.ts
@@ -4,8 +4,9 @@ import * as assert from "assert";
 import * as FileFunctions from "../FileFunctions";
 import * as SettingsLoader from "../Settings/SettingsLoader";
 import * as PermissionSetFunctions from "../PermissionSet/PermissionSetFunctions";
-
 import { getPermissionSetFiles } from "../WorkspaceFunctions";
+import { ALObjectType } from "../ALObject/Enums";
+import { Permission } from "../PermissionSet/XmlPermissionSet";
 
 const testOrgFiles = path.resolve(
   __dirname,
@@ -47,9 +48,101 @@ suite("PermissionSet", function () {
     );
     assert.strictEqual(
       xmlPermissionSets[0].permissions.length,
-      22,
+      26,
       "Unexpected number of permissions"
     );
+    assert.deepStrictEqual(
+      xmlPermissionSets[0].permissions[0],
+      {
+        objectType: ALObjectType.tableData,
+        objectID: 50002,
+        readPermission: Permission.yes,
+        insertPermission: Permission.yes,
+        modifyPermission: Permission.yes,
+        deletePermission: Permission.yes,
+        executePermission: Permission.none,
+      },
+      "Unexpected permission[0]"
+    );
+    assert.deepStrictEqual(
+      xmlPermissionSets[0].permissions[1],
+      {
+        objectType: ALObjectType.table,
+        objectID: 50002,
+        readPermission: Permission.none,
+        insertPermission: Permission.none,
+        modifyPermission: Permission.none,
+        deletePermission: Permission.none,
+        executePermission: Permission.yes,
+      },
+      "Unexpected permission[1]"
+    );
+    assert.deepStrictEqual(
+      xmlPermissionSets[0].permissions[2],
+      {
+        objectType: ALObjectType.tableData,
+        objectID: 50003,
+        readPermission: Permission.yes,
+        insertPermission: Permission.indirect,
+        modifyPermission: Permission.yes,
+        deletePermission: Permission.yes,
+        executePermission: Permission.none,
+      },
+      "Unexpected permission[2]"
+    );
+    assert.deepStrictEqual(
+      xmlPermissionSets[0].permissions[3],
+      {
+        objectType: ALObjectType.system,
+        objectID: 3510,
+        readPermission: Permission.none,
+        insertPermission: Permission.none,
+        modifyPermission: Permission.none,
+        deletePermission: Permission.none,
+        executePermission: Permission.yes,
+      },
+      "Unexpected permission[3]"
+    );
+    assert.deepStrictEqual(
+      xmlPermissionSets[0].permissions[4],
+      {
+        objectType: ALObjectType.query,
+        objectID: 776,
+        readPermission: Permission.none,
+        insertPermission: Permission.none,
+        modifyPermission: Permission.none,
+        deletePermission: Permission.none,
+        executePermission: Permission.yes,
+      },
+      "Unexpected permission[4]"
+    );
+    assert.deepStrictEqual(
+      xmlPermissionSets[0].permissions[5],
+      {
+        objectType: ALObjectType.page,
+        objectID: 9560,
+        readPermission: Permission.none,
+        insertPermission: Permission.none,
+        modifyPermission: Permission.none,
+        deletePermission: Permission.none,
+        executePermission: Permission.yes,
+      },
+      "Unexpected permission[5]"
+    );
+    assert.deepStrictEqual(
+      xmlPermissionSets[0].permissions[6],
+      {
+        objectType: ALObjectType.codeunit,
+        objectID: 9223,
+        readPermission: Permission.none,
+        insertPermission: Permission.none,
+        modifyPermission: Permission.none,
+        deletePermission: Permission.none,
+        executePermission: Permission.yes,
+      },
+      "Unexpected permission[6]"
+    );
+
     assert.strictEqual(
       xmlPermissionSets[1].roleID,
       "AL-2",

--- a/extension/src/test/resources/permissionset/permissionSet.xml
+++ b/extension/src/test/resources/permissionset/permissionSet.xml
@@ -36,17 +36,17 @@
     </Permission>
     <Permission>
       <ObjectType>Query</ObjectType>
-      <ObjectID>776</ObjectID>
+      <ObjectID>50001</ObjectID>
       <ExecutePermission>Yes</ExecutePermission>
     </Permission>
     <Permission>
       <ObjectType>Page</ObjectType>
-      <ObjectID>9560</ObjectID>
+      <ObjectID>50007</ObjectID>
       <ExecutePermission>Yes</ExecutePermission>
     </Permission>
     <Permission>
       <ObjectType>Codeunit</ObjectType>
-      <ObjectID>9223</ObjectID>
+      <ObjectID>50002</ObjectID>
       <ExecutePermission>Yes</ExecutePermission>
     </Permission>
     <Permission>

--- a/extension/src/test/resources/permissionset/permissionSet.xml
+++ b/extension/src/test/resources/permissionset/permissionSet.xml
@@ -15,7 +15,7 @@
       <ObjectID>50002</ObjectID>
       <ObjectType>1</ObjectType>
       <ModifyPermission>0</ModifyPermission>
-      <DeletePermission>0</DeletePermission>
+      <DeletePermission>2</DeletePermission>
       <ExecutePermission>1</ExecutePermission>
       <SecurityFilter />
     </Permission>

--- a/extension/src/test/resources/permissionset/permissionSet.xml
+++ b/extension/src/test/resources/permissionset/permissionSet.xml
@@ -14,8 +14,6 @@
     <Permission>
       <ObjectID>50002</ObjectID>
       <ObjectType>1</ObjectType>
-      <ReadPermission>0</ReadPermission>
-      <InsertPermission>0</InsertPermission>
       <ModifyPermission>0</ModifyPermission>
       <DeletePermission>0</DeletePermission>
       <ExecutePermission>1</ExecutePermission>
@@ -23,18 +21,38 @@
     </Permission>
     <Permission>
       <ObjectID>50003</ObjectID>
-      <ObjectType>0</ObjectType>
-      <ReadPermission>1</ReadPermission>
-      <InsertPermission>1</InsertPermission>
-      <ModifyPermission>1</ModifyPermission>
-      <DeletePermission>1</DeletePermission>
-      <ExecutePermission>0</ExecutePermission>
+      <ObjectType>Table Data</ObjectType>
+      <ReadPermission>Yes</ReadPermission>
+      <InsertPermission>Indirect</InsertPermission>
+      <ModifyPermission>Yes</ModifyPermission>
+      <DeletePermission>Yes</DeletePermission>
+      <ExecutePermission/>
       <SecurityFilter />
+    </Permission>
+    <Permission>
+      <ObjectType>System</ObjectType>
+      <ObjectID>3510</ObjectID>
+      <ExecutePermission>Yes</ExecutePermission>
+    </Permission>
+    <Permission>
+      <ObjectType>Query</ObjectType>
+      <ObjectID>776</ObjectID>
+      <ExecutePermission>Yes</ExecutePermission>
+    </Permission>
+    <Permission>
+      <ObjectType>Page</ObjectType>
+      <ObjectID>9560</ObjectID>
+      <ExecutePermission>Yes</ExecutePermission>
+    </Permission>
+    <Permission>
+      <ObjectType>Codeunit</ObjectType>
+      <ObjectID>9223</ObjectID>
+      <ExecutePermission>Yes</ExecutePermission>
     </Permission>
     <Permission>
       <ObjectID>50003</ObjectID>
       <ObjectType>1</ObjectType>
-      <ReadPermission>0</ReadPermission>
+      <ReadPermission/>
       <InsertPermission>0</InsertPermission>
       <ModifyPermission>0</ModifyPermission>
       <DeletePermission>0</DeletePermission>

--- a/extension/src/test/resources/permissionset/permissionSet2.xml
+++ b/extension/src/test/resources/permissionset/permissionSet2.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <PermissionSets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <PermissionSet RoleID="AL-2" RoleName="Al 2">
+  <PermissionSet RoleID="AL-2">
     <Permission>
       <ObjectID>50002</ObjectID>
       <ObjectType>0</ObjectType>

--- a/extension/src/test/resources/permissionset/permissionSet3.xml
+++ b/extension/src/test/resources/permissionset/permissionSet3.xml
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<PermissionSets>
+  <PermissionSet RoleID="AL-TENANT" RoleName="TenantPermissions" Scope="Tenant">
+    <TenantPermission>
+      <ObjectID>50003</ObjectID>
+      <ObjectType>Table Data</ObjectType>
+      <ReadPermission>Yes</ReadPermission>
+      <InsertPermission>Indirect</InsertPermission>
+      <ModifyPermission>Yes</ModifyPermission>
+      <DeletePermission>Yes</DeletePermission>
+      <ExecutePermission/>
+      <SecurityFilter />
+    </TenantPermission>
+    <TenantPermission>
+      <ObjectType>System</ObjectType>
+      <ObjectID>3510</ObjectID>
+      <ExecutePermission>Yes</ExecutePermission>
+    </TenantPermission>
+    <TenantPermission>
+      <ObjectType>Query</ObjectType>
+      <ObjectID>50001</ObjectID>
+      <ExecutePermission>Yes</ExecutePermission>
+    </TenantPermission>
+    <TenantPermission>
+      <ObjectType>Page</ObjectType>
+      <ObjectID>50007</ObjectID>
+      <ExecutePermission>Yes</ExecutePermission>
+    </TenantPermission>
+    <TenantPermission>
+      <ObjectType>Codeunit</ObjectType>
+      <ObjectID>50002</ObjectID>
+      <ExecutePermission>Yes</ExecutePermission>
+    </TenantPermission>
+  </PermissionSet>
+</PermissionSets>

--- a/test-app/Xliff-test/app.json
+++ b/test-app/Xliff-test/app.json
@@ -11,15 +11,17 @@
   "url": "",
   "logo": "",
   "application": "17.0.0.0",
-  "dependencies": [
-
-  ],
+  "dependencies": [],
   "screenshots": [],
   "platform": "17.0.0.0",
   "idRanges": [
     {
       "from": 50000,
       "to": 50049
+    },
+    {
+      "from": 50100,
+      "to": 50149
     }
   ],
   "features": [


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. If there's no open issue, consider opening one first. -->

Related to #384 .

Changes proposed in this pull request:

- Support for the XML Permission Set format generated when exporting a Permission Set from the Web Client.
  - Support for `TenantPermissions` elements
  - Support for permissions on `System`
  - Support for names instead of numbers in `ObjectType`
  - Support for `Yes` and `Indirect` instead of numbers for the different permissions
  - Support for missing permission elements