### PR TITLE
fix: Improved error message for SecurityFilter

### DIFF
--- a/extension/src/PermissionSet/XmlPermissionSet.ts
+++ b/extension/src/PermissionSet/XmlPermissionSet.ts
@@ -76,7 +76,7 @@ export class XmlPermissionSets {
           securityFilter[0].hasChildNodes()
         ) {
           throw new Error(
-            `PermissionSet ${permissionSet.roleID} har defined some SecurityFilter, which is unsupported by this function`
+            `PermissionSet ${permissionSet.roleID} has a SecurityFilter defined. This is currently not supported by the PermissionSet object (please log an issue on https://github.com/jwikman/nab-al-tools/ if this is not the case).`
           );
         }
         if (!objectType || objectType === "") {


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. If there's no open issue, consider opening one first. -->

Related to #384.

Changes proposed in this pull request:

- Improved the error message shown when a SecurityFilter is defined in a XML PermissionSet and it is being converted to a PermissionSet object

Additional comments
Is it clear enough?
Grammatically correct?