### PR TITLE
fix: Transform with Remove spaces and then Lowercase

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -7,6 +7,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 -->
 
+## [1.27]
+
+- Fixes:
+  - Fixes an issue when running `NAB: Create AL Project from Template (preview)` with a template with renameFiles with `"transformation": ["RemoveSpaces", "LowerCase"]`. Thanks to [fvet](https://github.com/fvet) for reporting this in [issue 388](https://github.com/jwikman/nab-al-tools/issues/388).
+
 ## [1.26]
 
 - New Features:

--- a/extension/src/Template/TemplateFunctions.ts
+++ b/extension/src/Template/TemplateFunctions.ts
@@ -81,7 +81,7 @@ export async function startConversion(
   }
   const appManifestPaths = FileFunctions.findFiles("**/app.json", folderPath);
 
-  createXlfFiles(templateSettings.createXlfLanguages, appManifestPaths);
+  createXlfFiles(appManifestPaths, templateSettings.createXlfLanguages);
   if (templateSettings.renumberObjects) {
     renumberObjects(appManifestPaths);
   }
@@ -117,10 +117,10 @@ function renameFile(filePath: string, match: string, value: string): void {
 }
 
 function createXlfFiles(
-  createXlfLanguages: string[],
-  appManifestPaths: string[]
+  appManifestPaths: string[],
+  createXlfLanguages?: string[]
 ): void {
-  if (createXlfLanguages.length === 0) {
+  if (!createXlfLanguages || createXlfLanguages.length === 0) {
     return;
   }
   if (appManifestPaths.length === 0) {

--- a/extension/src/Template/TemplateFunctions.ts
+++ b/extension/src/Template/TemplateFunctions.ts
@@ -183,7 +183,7 @@ function transformValue(
           value = _.kebabCase(value);
           break;
         case Transformation.lowerCase:
-          value = _.lowerCase(value);
+          value = value.toLocaleLowerCase();
           break;
         case Transformation.snakeCase:
           value = _.snakeCase(value);
@@ -192,7 +192,7 @@ function transformValue(
           value = _.startCase(value);
           break;
         case Transformation.upperCase:
-          value = _.upperCase(value);
+          value = value.toLocaleUpperCase();
           break;
         case Transformation.removeSpaces:
           value = value.replace(/ /g, "");


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. If there's no open issue, consider opening one first. -->

Related to #388 .

Changes proposed in this pull request:

- Changed implementation of toLowerCase from https://docs-lodash.com/v4/lowercase/, to regular string.toLocaleLowerCase(), since the lodash implementation added spaces :)
- Similar change to toUpperCase
- Support for omitted createXlfLanguages element
