### PR TITLE
fix: Support for "E" tag in certificate subject

### DIFF
--- a/extension/src/PowerShellFunctions.ts
+++ b/extension/src/PowerShellFunctions.ts
@@ -162,7 +162,7 @@ $SignCertName = "${signCertName}"
 $TimeStampServer = "${timeStampServer}"
 $AppPath = "${appPath}"
 
-if(!(Get-ChildItem 'Cert:\\CurrentUser\\My'| Where-Object Subject -Like "CN=$SignCertName*")) {
+if(!(Get-ChildItem 'Cert:\\CurrentUser\\My'| Where-Object Subject -Like "*CN=$SignCertName*")) {
     Write-Error "The certificate '$SignCertName' is not found in the current user's personal certificate store"
 }
 


### PR DESCRIPTION
A common case where certificates subject begins with other properties then CN. This change will support them as well. For example, our sign certificate subject is `E=d365support@theta.co.nz, CN=Theta Systems Limited, OU=Dynamics 365, O=Theta Systems Limited, L=Auckland, S=Auckland, C=NZ`

Related to #397 .