### PR TITLE
Renamed main to NABALTools.js

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -50,7 +50,7 @@
     "workspaceContains:al.template.json",
     "onCommand:al.go"
   ],
-  "main": "./dist/extension.js",
+  "main": "./dist/NABALTools.js",
   "files": [
     "./frontend/**",
     "./syntaxes/**"

--- a/extension/webpack.config.js
+++ b/extension/webpack.config.js
@@ -14,7 +14,7 @@ const config = {
   entry: {
     extension: {
       import: "./src/extension.ts",
-      filename: "extension.js",
+      filename: "NABALTools.js",
     },
     cliCreateDocumentation: {
       import: "./src/cli/CreateDocumentation.ts",
@@ -28,7 +28,7 @@ const config = {
   output: {
     // the bundle is stored in the 'dist' folder (check package.json), 📖 -> https://webpack.js.org/configuration/output/
     path: path.resolve(__dirname, "dist"),
-    filename: "extension.js",
+    filename: "NABALTools.js",
     libraryTarget: "commonjs2",
   },
   devtool: "nosources-source-map",


### PR DESCRIPTION
Related to #405 .

Changes proposed in this pull request:

When looking into CPU Profile files, there isn't much more information than the filename of the executing file. Most VSCode extensions are using the name `extension.js`, since that is the default when creating a VSCode extension from a template.
Having hundreds of `extension.js` in the CPU profile does not help when we are trying to identify what calls are caused by our extension. Having webpack to bundle everything inside this `extension.js` does not help either...

- Renamed `extension.js` to `NABALTools.js`

When we receive a CPU profile in the future, this will probably help us.