### PR TITLE
build(deps): bump @xmldom/xmldom to 0.7.9

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.28.0",
       "license": "MIT",
       "dependencies": {
-        "@xmldom/xmldom": "^0.7.5",
+        "@xmldom/xmldom": "^0.7.9",
         "adm-zip": "^0.5.5",
         "applicationinsights": "^2.2.0",
         "compare-versions": "^3.6.0",
@@ -1536,9 +1536,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.5.tgz",
-      "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==",
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.9.tgz",
+      "integrity": "sha512-yceMpm/xd4W2a85iqZyO09gTnHvXF6pyiWjD2jcOJs7hRoZtNNOO1eJlhHj1ixA+xip2hOyGn+LgcvLCMo5zXA==",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -8234,9 +8234,9 @@
       "requires": {}
     },
     "@xmldom/xmldom": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.5.tgz",
-      "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A=="
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.9.tgz",
+      "integrity": "sha512-yceMpm/xd4W2a85iqZyO09gTnHvXF6pyiWjD2jcOJs7hRoZtNNOO1eJlhHj1ixA+xip2hOyGn+LgcvLCMo5zXA=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -744,7 +744,7 @@
     "coverage:report": "npx nyc report --reporter=lcov --reporter=text-summary --check-coverage"
   },
   "dependencies": {
-    "@xmldom/xmldom": "^0.7.5",
+    "@xmldom/xmldom": "^0.7.9",
     "adm-zip": "^0.5.5",
     "applicationinsights": "^2.2.0",
     "compare-versions": "^3.6.0",

--- a/extension/src/ALObject/ALXmlComment.ts
+++ b/extension/src/ALObject/ALXmlComment.ts
@@ -34,6 +34,7 @@ export class ALXmlComment {
     }
 
     const dom = xmldom.DOMParser;
+    xml = `<root>${xml}</root>`; // Create a well-formed xml document, with a single root element
     const xlfDom = new dom().parseFromString(xml);
     const alXmlComment = ALXmlComment.fromDocument(xlfDom);
     return alXmlComment;


### PR DESCRIPTION
Supersedes #414 

Changes proposed in this pull request:

- Bumps [@xmldom/xmldom](https://github.com/xmldom/xmldom) from 0.7.5 to 0.7.9.
- More information found in #414

Additional comments
I had to add a workaround to transform xml comments with multiple root elements to a well-formed xml.
