### PR TITLE
feat: Support for "approved" attribute in Xliff trans-unit

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -7,6 +7,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 -->
 
+## [1.29]
+
+- New Features:
+  - The Xliff trans-unit element now supports the "approved" attribute. Thanks to [JSebastianN](https://github.com/JSebastianN) for suggesting this in [discussion 420](https://github.com/jwikman/nab-al-tools/discussions/420)
+
 ## [1.28]
 
 - New Features:

--- a/extension/src/Xliff/XLIFFDocument.ts
+++ b/extension/src/Xliff/XLIFFDocument.ts
@@ -592,12 +592,7 @@ export class TransUnit implements TransUnitInterface {
     let _approved: boolean | undefined = undefined;
     const _approvedText = transUnit.getAttributeNode("approved")?.value;
     if (_approvedText) {
-      _approved =
-        _approvedText === null ||
-        _approvedText === undefined ||
-        _approvedText.toLowerCase() === "no"
-          ? false
-          : true;
+      _approved = _approvedText.toLowerCase() === "yes";
     }
     const _notes: Array<Note> = [];
     const _id = transUnit.getAttributeNode("id")?.value ?? "";
@@ -606,9 +601,8 @@ export class TransUnit implements TransUnitInterface {
     const _sizeUnit = transUnit.getAttributeNode("size-unit")?.value;
     const _xmlSpace =
       transUnit.getAttributeNode("xml:space")?.value ?? "preserve";
-    const t = transUnit.getAttributeNode("translate")?.value;
-    const _translate =
-      t === null || t === undefined || t.toLowerCase() === "no" ? false : true;
+    const _translateText = transUnit.getAttributeNode("translate")?.value;
+    const _translate = _translateText?.toLowerCase() === "yes";
     const _source =
       transUnit.getElementsByTagName("source")[0]?.childNodes[0]?.nodeValue ??
       "";

--- a/extension/src/Xliff/XLIFFDocument.ts
+++ b/extension/src/Xliff/XLIFFDocument.ts
@@ -508,6 +508,7 @@ export class TransUnit implements TransUnitInterface {
   xmlSpace: string;
   maxwidth: number | undefined;
   alObjectTarget: string | undefined;
+  approved: boolean | undefined;
 
   constructor(
     id: string,
@@ -518,7 +519,8 @@ export class TransUnit implements TransUnitInterface {
     xmlSpace: string,
     notes?: Note[],
     maxwidth?: number | undefined,
-    alObjectTarget?: string | undefined
+    alObjectTarget?: string | undefined,
+    approved?: boolean | undefined
   ) {
     this.id = id;
     this.translate = translate;
@@ -532,6 +534,7 @@ export class TransUnit implements TransUnitInterface {
     this.sizeUnit = sizeUnit;
     this.xmlSpace = xmlSpace;
     this.maxwidth = maxwidth;
+    this.approved = approved;
     this.alObjectTarget = alObjectTarget;
   }
 
@@ -586,6 +589,16 @@ export class TransUnit implements TransUnitInterface {
     if (_maxwidthText) {
       _maxwidth = Number.parseInt(_maxwidthText);
     }
+    let _approved: boolean | undefined = undefined;
+    const _approvedText = transUnit.getAttributeNode("approved")?.value;
+    if (_approvedText) {
+      _approved =
+        _approvedText === null ||
+        _approvedText === undefined ||
+        _approvedText.toLowerCase() === "no"
+          ? false
+          : true;
+    }
     const _notes: Array<Note> = [];
     const _id = transUnit.getAttributeNode("id")?.value ?? "";
     const _alObjectTarget =
@@ -612,7 +625,8 @@ export class TransUnit implements TransUnitInterface {
       _xmlSpace,
       _notes,
       _maxwidth,
-      _alObjectTarget
+      _alObjectTarget,
+      _approved
     );
     const _targets: Target[] = [];
     const targetElmnt = transUnit.getElementsByTagName("target");
@@ -644,6 +658,9 @@ export class TransUnit implements TransUnitInterface {
     transUnit.setAttribute("xml:space", this.xmlSpace);
     if (this.alObjectTarget !== undefined) {
       transUnit.setAttribute("al-object-target", this.alObjectTarget);
+    }
+    if (this.approved !== undefined) {
+      transUnit.setAttribute("approved", this.approvedAttributeYesNo());
     }
     const source = new xmldom.DOMImplementation()
       .createDocument(null, null, null)
@@ -727,6 +744,10 @@ export class TransUnit implements TransUnitInterface {
 
   private translateAttributeYesNo(): string {
     return this.translate ? "yes" : "no";
+  }
+
+  private approvedAttributeYesNo(): string {
+    return this.approved ? "yes" : "no";
   }
 
   public insertCustomNote(customNoteType: CustomNoteType, text: string): void {

--- a/extension/src/test/ExternalResources.test.ts
+++ b/extension/src/test/ExternalResources.test.ts
@@ -39,7 +39,7 @@ suite("External Resources Tests", function () {
     );
     assert.deepStrictEqual(
       writeStream.bytesWritten,
-      7384660,
+      7732799,
       "unexpected byte number of bytes written"
     ); // This needs to be updated in the future
   });

--- a/extension/src/test/Xliff/TransUnit.test.ts
+++ b/extension/src/test/Xliff/TransUnit.test.ts
@@ -1,5 +1,5 @@
 import * as assert from "assert";
-import { TransUnit } from "../../Xliff/XLIFFDocument";
+import { TransUnit, Xliff } from "../../Xliff/XLIFFDocument";
 import { TransUnitElementType } from "../../Enums";
 
 suite("TransUnit Tests", function () {
@@ -52,6 +52,65 @@ suite("TransUnit Tests", function () {
       TransUnit.lineType(testStrings.customNote),
       TransUnitElementType.customNote,
       "Expected 'customNote'"
+    );
+  });
+
+  test.only("TransUnit.approved", function () {
+    let transUnitText = `<trans-unit id="Table 1365275863 - Field 1296262074 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" approved="yes"><source>MyField</source><note from="Developer" annotates="general" priority="2"></note><note from="Xliff Generator" annotates="general" priority="3">Table Empty - Field MyField - Property Caption</note></trans-unit>`;
+    let tu = TransUnit.fromString(transUnitText);
+    assert.strictEqual(
+      Xliff.replaceSelfClosingTags(tu.toString()),
+      transUnitText,
+      "1. Unexpected TransUnit value"
+    );
+    transUnitText = `<trans-unit id="Table 1365275863 - Field 1296262074 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve"><source>MyField</source><note from="Developer" annotates="general" priority="2"></note><note from="Xliff Generator" annotates="general" priority="3">Table Empty - Field MyField - Property Caption</note></trans-unit>`;
+    tu = TransUnit.fromString(transUnitText);
+    assert.strictEqual(
+      Xliff.replaceSelfClosingTags(tu.toString()),
+      transUnitText,
+      "2. Unexpected TransUnit value"
+    );
+
+    let xliffText = `<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en-US" target-language="en-US" original="Al">
+    <body>
+      <group id="body">
+        <trans-unit id="Table 1365275863 - Field 1296262074 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>MyField</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Table Empty - Field MyField - Property Caption</note>
+        </trans-unit>
+      </group>
+    </body>
+  </file>
+</xliff>`;
+    let xliff = Xliff.fromString(xliffText);
+    assert.strictEqual(
+      xliff.toString(true, true),
+      xliffText,
+      "3. Unexpected TransUnit value"
+    );
+
+    xliffText = `<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en-US" target-language="en-US" original="Al">
+    <body>
+      <group id="body">
+        <trans-unit id="Table 1365275863 - Field 1296262074 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" approved="no">
+          <source>MyField</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Table Empty - Field MyField - Property Caption</note>
+        </trans-unit>
+      </group>
+    </body>
+  </file>
+</xliff>`;
+    xliff = Xliff.fromString(xliffText);
+    assert.strictEqual(
+      xliff.toString(true, true),
+      xliffText,
+      "4. Unexpected TransUnit value"
     );
   });
 

--- a/extension/src/test/Xliff/TransUnit.test.ts
+++ b/extension/src/test/Xliff/TransUnit.test.ts
@@ -71,6 +71,14 @@ suite("TransUnit Tests", function () {
       "2. Unexpected TransUnit value"
     );
 
+    transUnitText = `<trans-unit id="Table 1365275863 - Field 1296262074 - Property 2879900210" size-unit="char" translate="no" xml:space="preserve"><source>MyField</source><note from="Developer" annotates="general" priority="2"></note><note from="Xliff Generator" annotates="general" priority="3">Table Empty - Field MyField - Property Caption</note></trans-unit>`;
+    tu = TransUnit.fromString(transUnitText);
+    assert.strictEqual(
+      Xliff.replaceSelfClosingTags(tu.toString()),
+      transUnitText,
+      "2.1 Unexpected TransUnit value"
+    );
+
     let xliffText = `<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="en-US" original="Al">

--- a/extension/src/test/Xliff/TransUnit.test.ts
+++ b/extension/src/test/Xliff/TransUnit.test.ts
@@ -55,7 +55,7 @@ suite("TransUnit Tests", function () {
     );
   });
 
-  test.only("TransUnit.approved", function () {
+  test("TransUnit.approved", function () {
     let transUnitText = `<trans-unit id="Table 1365275863 - Field 1296262074 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve" approved="yes"><source>MyField</source><note from="Developer" annotates="general" priority="2"></note><note from="Xliff Generator" annotates="general" priority="3">Table Empty - Field MyField - Property Caption</note></trans-unit>`;
     let tu = TransUnit.fromString(transUnitText);
     assert.strictEqual(


### PR DESCRIPTION
Related to #424.

Changes proposed in this pull request:

- Supports the "approved" attribute in trans-unit elements
