### PR TITLE
fix: Escape pipe character in formatMarkDown method

### DIFF
--- a/extension/src/ALObject/ALXmlComment.ts
+++ b/extension/src/ALObject/ALXmlComment.ts
@@ -91,6 +91,8 @@ export class ALXmlComment {
       text = text.replace(/<code>\s*(.*?)\s*<\/code>/gis, "`$1`");
       // Parameter ref.
       text = text.replace(/<paramref\s*name\s*=\s*"(.*?)"\s*\/>/gi, `$1`);
+      // Escape pipe
+      text = text.replace(/\|/g, "\\|");
     } else {
       // Paragraph
       text = text.replace(/<para>\s*(.*?)\s*<\/para>/gi, "\n\n$1\n\n"); // .*? = non-greedy match all

--- a/test-app/Xliff-test/docs/info.json
+++ b/test-app/Xliff-test/docs/info.json
@@ -1,6 +1,6 @@
 {
   "generated-date": "2025-05-01",
-  "generator": "NAB AL Tools v1.37.504292307",
+  "generator": "NAB AL Tools v1.37.505011214",
   "app-id": "ed43c16b-7d86-4b49-ab59-d1660c4ef64f",
   "app-name": "Al",
   "app-publisher": "Default publisher",

--- a/test-app/Xliff-test/docs/table-nab-test-table/index.md
+++ b/test-app/Xliff-test/docs/table-nab-test-table/index.md
@@ -16,7 +16,8 @@ title: Table Test Table | Al
 
 | Name | Description |
 | ----- | ------ |
-| [TestMethod()](test-method.md#test_method) |  |
+| [TestMethod()](test-method.md#test_method) | This is a test method |
+| [TestMethod(Integer)](test-method.md#test_method_integer) | This is a test method with pipe (\|) in the summary |
 
 ## Fields
 

--- a/test-app/Xliff-test/docs/table-nab-test-table/test-method.md
+++ b/test-app/Xliff-test/docs/table-nab-test-table/test-method.md
@@ -2,12 +2,39 @@
 uid: table_nab_test_table_test_method
 title: TestMethod | Table Test Table | Al
 ---
-# <a name="test_method"></a>TestMethod Procedure
+# TestMethod Procedure
 
 [Table Test Table](index.md)
 
-## <a name="signature"></a>Signature
+This is a test method
+
+## Overloads
+
+| Name | Description |
+| ----- | ------ |
+| [TestMethod()](#test_method) | This is a test method |
+| [TestMethod(Integer)](#test_method_integer) | This is a test method with pipe (\|) in the summary |
+
+## <a name="test_method"></a>TestMethod() Procedure
+
+This is a test method
+
+### <a name="test_method_signature"></a>Signature
 
 ```al
 TestMethod()
 ```
+
+## <a name="test_method_integer"></a>TestMethod(Integer) Procedure
+
+This is a test method with pipe (|) in the summary
+
+### <a name="test_method_integer_signature"></a>Signature
+
+```al
+TestMethod(Parameter: Integer)
+```
+
+### <a name="test_method_integer_parameters"></a>Parameters
+
+#### <a name="test_method_integer_Parameter"></a>`Parameter`  Integer

--- a/test-app/Xliff-test/src/TestReport.Report.al
+++ b/test-app/Xliff-test/src/TestReport.Report.al
@@ -83,8 +83,6 @@ report 50000 "NAB Test Report"
     end;
 
     procedure TestMethod(Parameter: Integer)
-    var
-        LocalTestLabelTxt: Label 'Local Test Label';
     begin
     end;
 

--- a/test-app/Xliff-test/src/TestTable.Table.al
+++ b/test-app/Xliff-test/src/TestTable.Table.al
@@ -74,10 +74,23 @@ table 50000 "NAB Test Table"
 
     end;
 
+    /// <summary>
+    /// This is a test method
+    /// </summary>
     procedure TestMethod()
     var
         LocalTestLabelTxt: Label 'Local Test Label';
     begin
+        LocalTestMethod();
+    end;
+
+    /// <summary>
+    /// This is a test method with pipe (|) in the summary
+    /// </summary>
+    /// <param name="Parameter"></param>
+    procedure TestMethod(Parameter: Integer)
+    begin
+        LocalTestMethod();
     end;
 
     local procedure LocalTestMethod()


### PR DESCRIPTION
<!-- If there's an open issue please reference this here. If there's no open issue, consider opening one first. -->

Fixes #484

Changes proposed in this pull request:

- Escape the pipe character when in markdown tables
