### PR TITLE
Create stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -49,4 +49,4 @@ jobs:
           close-pr-message: |
             🪦 This PR has been laid to rest due to inactivity. It lived a good life, full of potential and promise.
             If you’d like to bring it back from the dead, we’re just a comment away. 🧛‍♂️
-          debug-only: $DEBUG_MODE
+          debug-only: ${{ env.DEBUG_MODE }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,7 +23,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Sätt debug-mode
+      - name: Set debug mode variable
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "DEBUG_MODE=${{ github.event.inputs.debug }}" >> $GITHUB_ENV

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,18 +6,17 @@
 name: Mark stale issues and pull requests
 
 on:
-#   schedule:
-#   - cron: '22 8 * * *'
+  #   schedule:
+  #   - cron: '22 8 * * 2'
   workflow_dispatch:
     inputs:
       debug:
         type: boolean
-        description: 'Dry run. If checked, no issues will actually be modified.'
-        default: 'true'
+        description: "Dry run. If checked, no issues will actually be modified."
+        default: true
 
 jobs:
   stale:
-
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -33,7 +32,7 @@ jobs:
           fi
       - uses: actions/stale@v5
         with:
-          exempt-issue-assignees: 'jwikman'
+          exempt-issue-assignees: "jwikman"
           days-before-stale: 365
           days-before-close: 7
           stale-issue-message: |
@@ -42,8 +41,8 @@ jobs:
           stale-pr-message: |
             🕰️ This pull request has been sitting around so long, it’s eligible for a pension.
             If you’re still working on it, let us know! Otherwise, it might retire peacefully in a few days.
-          stale-issue-label: 'stale'
-          stale-pr-label: 'stale'
+          stale-issue-label: "stale"
+          stale-pr-label: "stale"
           close-issue-message: |
             🧹 We’ve done some spring cleaning and this issue didn’t make the cut.
             If this was a mistake, feel free to resurrect it like a bug-hunting necromancer. Thanks for your contribution!
@@ -51,4 +50,3 @@ jobs:
             🪦 This PR has been laid to rest due to inactivity. It lived a good life, full of potential and promise.
             If you’d like to bring it back from the dead, we’re just a comment away. 🧛‍♂️
           debug-only: $DEBUG_MODE
-  

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,54 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+#   schedule:
+#   - cron: '22 8 * * *'
+  workflow_dispatch:
+    inputs:
+      debug:
+        type: boolean
+        description: 'Dry run. If checked, no issues will actually be modified.'
+        default: 'true'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Sätt debug-mode
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "DEBUG_MODE=${{ github.event.inputs.debug }}" >> $GITHUB_ENV
+          else
+            echo "DEBUG_MODE=true" >> $GITHUB_ENV
+          fi
+      - uses: actions/stale@v5
+        with:
+          exempt-issue-assignees: 'jwikman'
+          days-before-stale: 365
+          days-before-close: 7
+          stale-issue-message: |
+            👋 Hey there! This issue has been chilling in the backlog for a while and is starting to grow a beard.
+            If you're still interested, give it a poke! Otherwise, it might wander off into the land of forgotten tickets.
+          stale-pr-message: |
+            🕰️ This pull request has been sitting around so long, it’s eligible for a pension.
+            If you’re still working on it, let us know! Otherwise, it might retire peacefully in a few days.
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          close-issue-message: |
+            🧹 We’ve done some spring cleaning and this issue didn’t make the cut.
+            If this was a mistake, feel free to resurrect it like a bug-hunting necromancer. Thanks for your contribution!
+          close-pr-message: |
+            🪦 This PR has been laid to rest due to inactivity. It lived a good life, full of potential and promise.
+            If you’d like to bring it back from the dead, we’re just a comment away. 🧛‍♂️
+          debug-only: $DEBUG_MODE
+  


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to manage stale issues and pull requests. The workflow is designed to mark inactive items as stale and eventually close them after a defined period of inactivity. It includes customizable messages and a debug mode for dry runs.

### New GitHub Actions Workflow for Stale Issues and PRs:
* [`.github/workflows/stale.yml`](diffhunk://#diff-b5e0854ed0838024d5cc25b4e030922e34648b9ea8c432807e35495fb805b894R1-R54): Added a workflow named "Mark stale issues and pull requests" to automatically identify and handle inactive issues and PRs. It includes options for exempting certain assignees, customizable messages for stale and closed items, and a debug mode for testing without modifying any issues.