### PR TITLE
feat: refactor SymbolReference to improve conversion logic and add missing objects

### DIFF
--- a/extension/src/SymbolReference/SymbolReferenceReader.ts
+++ b/extension/src/SymbolReference/SymbolReferenceReader.ts
@@ -7,6 +7,7 @@ import {
 import {
   ControlDefinition,
   ControlKind,
+  LanguageElementWithProperties,
   NamespaceDefinition,
   PageDefinition,
   SymbolProperty,
@@ -47,6 +48,32 @@ function parseObjectsInAppPackage(appPackage: AppPackage): void {
   // Objects without namespace:
   parseTables(appPackage.symbolReference.Tables, objects);
   parsePages(appPackage.symbolReference.Pages, objects);
+  parseObjects(
+    ALObjectType.report,
+    appPackage.symbolReference.Reports,
+    objects
+  );
+  parseObjects(
+    ALObjectType.codeunit,
+    appPackage.symbolReference.Codeunits,
+    objects
+  );
+  parseObjects(
+    ALObjectType.controladdin,
+    appPackage.symbolReference.ControlAddIns,
+    objects
+  );
+  parseObjects(
+    ALObjectType.interface,
+    appPackage.symbolReference.Interfaces,
+    objects
+  );
+  parseObjects(ALObjectType.query, appPackage.symbolReference.Queries, objects);
+  parseObjects(
+    ALObjectType.xmlPort,
+    appPackage.symbolReference.XmlPorts,
+    objects
+  );
 
   objects.filter((obj) =>
     obj
@@ -80,6 +107,12 @@ function parseNamespaces(
     parseNamespaces(namespace.Namespaces, objects);
     parseTables(namespace.Tables, objects);
     parsePages(namespace.Pages, objects);
+    parseObjects(ALObjectType.report, namespace.Reports, objects);
+    parseObjects(ALObjectType.codeunit, namespace.Codeunits, objects);
+    parseObjects(ALObjectType.controladdin, namespace.ControlAddIns, objects);
+    parseObjects(ALObjectType.interface, namespace.Interfaces, objects);
+    parseObjects(ALObjectType.query, namespace.Queries, objects);
+    parseObjects(ALObjectType.xmlPort, namespace.XmlPorts, objects);
   });
 }
 function parsePages(pages: PageDefinition[], objects: ALObject[]): void {
@@ -104,6 +137,38 @@ function parsePages(pages: PageDefinition[], objects: ALObject[]): void {
   });
 }
 
+function parseObjects(
+  objectType: ALObjectType,
+  symbolObjects: LanguageElementWithProperties[],
+  objects: ALObject[]
+): void {
+  if (!symbolObjects) {
+    return;
+  }
+  symbolObjects.forEach((symbolObject) => {
+    const obj = symbolToObject(objectType, symbolObject);
+    obj.alObjects = objects;
+    objects.push(obj);
+  });
+}
+
+function symbolToObject(
+  objectType: ALObjectType,
+  symbolObject: LanguageElementWithProperties
+): ALObject {
+  const obj = new ALObject(
+    [],
+    objectType,
+    0,
+    symbolObject.Name,
+    symbolObject.Id
+  );
+  obj.generatedFromSymbol = true;
+  symbolObject.Properties?.forEach((prop) => {
+    addProperty(prop, obj);
+  });
+  return obj;
+}
 function parseTables(tables: TableDefinition[], objects: ALObject[]): void {
   if (!tables) {
     return;

--- a/extension/src/SymbolReference/interfaces/SymbolReference.ts
+++ b/extension/src/SymbolReference/interfaces/SymbolReference.ts
@@ -5,9 +5,6 @@
 // To change quicktype's target language, run command:
 //
 //   "Set quicktype target language"
-
-import { LanguageConfiguration } from "vscode";
-
 export interface SymbolReference extends SymbolsContainer {
   InternalsVisibleToModules: SymbolInternalsVisibleToModule[];
   AppId: string;
@@ -47,12 +44,9 @@ interface PageCustomizationDefinition extends LanguageElement {
   TargetObject: string;
   ViewChanges?: ExtensionViewDefinition[];
 }
-interface CodeunitDefinition {
+interface CodeunitDefinition extends LanguageElementWithProperties {
   Methods?: MethodDefinition[];
   ReferenceSourceFileName: string;
-  Properties?: SymbolProperty[];
-  Id: number;
-  Name: string;
   Variables?: CodeunitVariable[];
   ImplementedInterfaces?: string[];
   Attributes?: AttributeDefinition[];
@@ -245,7 +239,7 @@ interface VariableDefinition extends LanguageElement {
   Type: string;
   TypeDefinition: TypeDefinition;
 }
-interface LanguageElementWithProperties extends LanguageElement {
+export interface LanguageElementWithProperties extends LanguageElement {
   Properties: SymbolProperty[];
 }
 interface LanguageElement {
@@ -326,7 +320,7 @@ interface KeyDefinition extends LanguageElementWithProperties {
   FieldNames: string[];
 }
 
-interface XmlPortDefinition extends LanguageConfiguration {
+interface XmlPortDefinition extends LanguageElementWithProperties {
   Methods: MethodDefinition[];
   ReferenceSourceFileName: string;
   RequestPage: RequestPageDefinition;


### PR DESCRIPTION
This pull request introduces enhancements to the `PermissionSetFunctions` and `SymbolReferenceReader` modules, focusing on improving functionality for handling AL objects and XML permission sets. Key changes include adding new helper methods, extending existing interfaces, and refining object parsing logic.

### Enhancements to `PermissionSetFunctions`:

* Added a new `runConversion` function to streamline the conversion of XML permission sets into AL objects. This includes logging success and error messages for better debugging and user feedback.
* Refactored `startConversion` to delegate conversion logic to `runConversion` and removed redundant code for opening text documents and displaying information messages.
* Exported the `getObjectName` function to make it accessible outside the module.

### Enhancements to `SymbolReferenceReader`:

* Added support for parsing additional AL object types (e.g., reports, codeunits, control add-ins, interfaces, queries, and XML ports) in both app packages and namespaces. [[1]](diffhunk://#diff-cde40f05a681b5c332d6eb7f574356fc73a2b9581949706a190b079c65baf83eR51-R76) [[2]](diffhunk://#diff-cde40f05a681b5c332d6eb7f574356fc73a2b9581949706a190b079c65baf83eR110-R115)
* Introduced new helper functions `parseObjects` and `symbolToObject` to simplify the parsing process and enhance code modularity.

### Changes to SymbolReference interfaces:

* Extended `LanguageElementWithProperties` to include properties for AL objects, enabling more detailed object definitions.
* Updated `CodeunitDefinition` and `XmlPortDefinition` to inherit from `LanguageElementWithProperties`, improving consistency and reusability. [[1]](diffhunk://#diff-bcc9ea29de861026f0a6fd0d48a217046951977d579e5884eb34398f3bb18175L50-L55) [[2]](diffhunk://#diff-bcc9ea29de861026f0a6fd0d48a217046951977d579e5884eb34398f3bb18175L329-R323)

Related to #509 .
