### PR TITLE
feat: getTextsByKeyword tool

### DIFF
--- a/extension/MCP_SERVER.md
+++ b/extension/MCP_SERVER.md
@@ -50,7 +50,7 @@ The MCP server is bundled with the NAB AL Tools VS Code extension and can be run
 
 - `generatedXlfFilePath` (required): Path to the generated XLF file (\*.g.xlf) created by AL compilation
 - `filePath` (required): Path to the target XLF file to be refreshed/synchronized
-- `workspaceFilePath` (optional): Path to workspace file for additional context
+- `workspaceFilePath` (optional): Path to workspace file for additional context and settings
 
 **Example**:
 
@@ -77,7 +77,6 @@ The MCP server is bundled with the NAB AL Tools VS Code extension and can be run
 - `offset` (required): Starting position for pagination (0-based index, min: 0)
 - `limit` (required): Maximum number of texts to retrieve (min: 1)
 - `sourceLanguageFilePath` (optional): Path to source language XLF file for reference
-- `workspaceFilePath` (optional): Path to workspace file for additional context
 
 **Returns**: JSON array of objects containing:
 
@@ -103,7 +102,6 @@ The MCP server is bundled with the NAB AL Tools VS Code extension and can be run
 - `offset` (required): Starting position for pagination (0-based index, min: 0)
 - `limit` (required): Maximum number of translation groups to retrieve (min: 1)
 - `sourceLanguageFilePath` (optional): Path to source language XLF file for reference
-- `workspaceFilePath` (optional): Path to workspace file for additional context
 
 **Returns**: JSON array of translation objects:
 
@@ -128,7 +126,6 @@ The MCP server is bundled with the NAB AL Tools VS Code extension and can be run
 - `translationStateFilter` (optional): Filter by state ("needs-review", "translated", "final", "signed-off")
 - `sourceText` (optional): Filter to find translations containing this source text
 - `sourceLanguageFilePath` (optional): Path to source language XLF file for reference
-- `workspaceFilePath` (optional): Path to workspace file for additional context
 
 **Returns**: JSON array of objects containing:
 
@@ -159,7 +156,7 @@ The MCP server is bundled with the NAB AL Tools VS Code extension and can be run
   - `id`: Unique identifier of the translation unit to update
   - `targetText`: The translated text to save
   - `targetState` (optional): State to set ("needs-review-translation", "translated", "final", "signed-off")
-- `workspaceFilePath` (optional): Path to workspace file for additional context
+- `workspaceFilePath` (optional): Path to workspace file for additional context and settings
 
 ### 6. nab-al-tools-getTextsByKeyword
 

--- a/extension/MCP_SERVER.md
+++ b/extension/MCP_SERVER.md
@@ -161,6 +161,49 @@ The MCP server is bundled with the NAB AL Tools VS Code extension and can be run
   - `targetState` (optional): State to set ("needs-review-translation", "translated", "final", "signed-off")
 - `workspaceFilePath` (optional): Path to workspace file for additional context
 
+### 6. nab-al-tools-getTextsByKeyword
+
+**Purpose**: Search source texts in an XLF file for a given keyword or regular expression and return matching translation units. This tool searches only the `<source>` element and includes untranslated units as well. It can be used to discover how a specific word or phrase is used across the application and to inspect how that word or phrase has been translated in different contexts, which helps when reviewing terminology, ensuring consistency, or preparing glossary entries.
+
+**Annotations**:
+
+- `readOnlyHint`: true (read-only operation)
+- `openWorldHint`: false (works with local files only)
+
+**Parameters**:
+
+- `filePath` (required): Path to the XLF file to search in
+- `offset` (required): Starting position for pagination (0-based index, min: 0)
+- `limit` (required): Maximum number of texts to retrieve (min: 0). Use `0` to return all matches.
+- `keyword` (required): The keyword or phrase to search for. When `isRegex` is true this is treated as a regular expression.
+- `caseSensitive` (optional): Enable case-sensitive matching (default: false)
+- `isRegex` (optional): Treat `keyword` as a regular expression (default: false)
+
+**Returns**: JSON array of objects containing:
+
+- `id`: Unique identifier
+- `sourceText`: Source text
+- `sourceLanguage`: Source language code
+- `targetText`: Translated text (may be empty for untranslated units)
+- `translationState`: Translation state (if available)
+- `reviewReason`: Review reason (if available)
+- `type`: Context description
+- `maxLength`: Character limit (if applicable)
+- `comment`: Contextual comments
+
+**Example**:
+
+```json
+{
+  "filePath": "d:/project/app/Translations/MyApp.sv-SE.xlf",
+  "offset": 0,
+  "limit": 0,
+  "keyword": "This is a test",
+  "caseSensitive": false,
+  "isRegex": false
+}
+```
+
 ## Usage
 
 ### Command Line

--- a/extension/package.json
+++ b/extension/package.json
@@ -1166,6 +1166,51 @@
         }
       },
       {
+        "name": "getTextsByKeyword",
+        "displayName": "Get Texts By Keyword from an XLF file",
+        "modelDescription": "This tool searches source texts in a specified XLF file for a given keyword or regular expression and returns matching translation units (includes untranslated units). It can be used to discover how a specific word or phrase is used across the application and to inspect how that word or phrase has been translated in different contexts.",
+        "tags": [
+          "dynamics-365"
+        ],
+        "userDescription": "(beta) Search source texts by keyword or regex in an XLF file. Use this to discover where a word or phrase appears and how it has been translated across contexts.",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "nab-al-tools-getTextsByKeyword",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "filePath": {
+              "type": "string",
+              "description": "The absolute path to the XLF file to search."
+            },
+            "offset": {
+              "type": "number",
+              "description": "The starting position (zero-based index) for retrieving results. Used for pagination to skip a specific number of translation units before returning results."
+            },
+            "limit": {
+              "type": "number",
+              "description": "The maximum number of texts to return in a single request. Set to 0 to retrieve all available translations."
+            },
+            "keyword": {
+              "type": "string",
+              "description": "The keyword or regex pattern to search for in the source text."
+            },
+            "caseSensitive": {
+              "type": "boolean",
+              "description": "Enable case-sensitive matching (default false)."
+            },
+            "isRegex": {
+              "type": "boolean",
+              "description": "Treat the 'keyword' parameter as a regular expression (default false)."
+            }
+          },
+          "required": [
+            "filePath",
+            "limit",
+            "keyword"
+          ]
+        }
+      },
+      {
         "name": "getTranslatedTextsByState",
         "displayName": "Get Translated Texts By State from an XLF file",
         "modelDescription": "This tool retrieves translated texts from a specified XLF file, filtered by their translation state. It returns a JSON array of objects containing: id (unique identifier), source text, source language, target text, type (describes the context of what is being translated, such as 'Table Customer - Field Name - Property Caption' or 'Page Sales Order - Action Post - Property Caption'), translation state, review reason (if available), maxLength (character limit if applicable), and contextual comments (explains placeholders like %1, %2, %3 etc.). The type field provides crucial context by identifying the specific AL object (table, page, codeunit, etc.), element (field, action, control), and property (caption, tooltip, etc.) being translated, enabling better understanding of existing translations and their business context. This tool streamlines the translation workflow by allowing you to filter translations by their state (e.g., 'needs-review', 'translated', 'final', 'signed-off') and providing comprehensive context for accurate localization.",

--- a/extension/src/ChatTools/GetTextsByKeywordTool.ts
+++ b/extension/src/ChatTools/GetTextsByKeywordTool.ts
@@ -1,0 +1,82 @@
+import * as vscode from "vscode";
+import * as Telemetry from "../Telemetry/Telemetry";
+import { getTextsByKeywordCore } from "./shared/XliffToolsCore";
+
+export interface IGetTextsByKeywordParameters {
+  filePath: string;
+  offset?: number;
+  limit: number;
+  keyword: string;
+  caseSensitive?: boolean;
+  isRegex?: boolean;
+}
+
+export class GetTextsByKeywordTool
+  implements vscode.LanguageModelTool<IGetTextsByKeywordParameters> {
+  async invoke(
+    options: vscode.LanguageModelToolInvocationOptions<IGetTextsByKeywordParameters>,
+    _token: vscode.CancellationToken
+  ): Promise<vscode.LanguageModelToolResult> {
+    const params = options.input;
+    const maxCount = params.limit;
+    const offset = params.offset || 0;
+    try {
+      const result = getTextsByKeywordCore(
+        params.filePath,
+        offset,
+        maxCount,
+        params.keyword,
+        params.caseSensitive || false,
+        params.isRegex || false
+      );
+
+      if (_token.isCancellationRequested) {
+        return new vscode.LanguageModelToolResult([
+          new vscode.LanguageModelTextPart("Operation cancelled by user."),
+        ]);
+      }
+
+      Telemetry.trackEvent("GetTextsByKeywordTool", result.telemetry);
+
+      const jsonText = JSON.stringify(result.data);
+      return new vscode.LanguageModelToolResult([
+        new vscode.LanguageModelTextPart(jsonText),
+      ]);
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      return new vscode.LanguageModelToolResult([
+        new vscode.LanguageModelTextPart(`Error: ${errorMessage}`),
+      ]);
+    }
+  }
+
+  async prepareInvocation(
+    options: vscode.LanguageModelToolInvocationPrepareOptions<IGetTextsByKeywordParameters>,
+    _token: vscode.CancellationToken
+  ): Promise<{
+    invocationMessage: string;
+    confirmationMessages: {
+      title: string;
+      message: vscode.MarkdownString;
+    };
+  }> {
+    const confirmationMessages = {
+      title: "Get Texts by Keyword?",
+      message: new vscode.MarkdownString(
+        `Find texts containing **${options.input.keyword}** in file **${options.input.filePath}**?`
+      ),
+    };
+
+    if (_token.isCancellationRequested) {
+      return {
+        invocationMessage: "Operation cancelled by user.",
+        confirmationMessages,
+      };
+    }
+    return {
+      invocationMessage: "Searching texts by keyword...",
+      confirmationMessages,
+    };
+  }
+}

--- a/extension/src/ChatTools/shared/XliffToolsCore.ts
+++ b/extension/src/ChatTools/shared/XliffToolsCore.ts
@@ -620,7 +620,7 @@ export function getTextsByKeywordCore(
       response.push({
         id: tu.id,
         sourceText: tu.source,
-        sourceLanguage: xliffDoc.targetLanguage || "en-US",
+        sourceLanguage: xliffDoc.sourceLanguage,
         targetText: tu.target.textContent,
         maxLength: maxLength,
         comment: !tu.developerNote()

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -19,6 +19,7 @@ import { GetTranslatedTextsMapTool } from "./ChatTools/GetTranslatedTextsMapTool
 import { SaveTranslatedTextsTool } from "./ChatTools/SaveTranslatedTextsTool";
 import { RefreshXlfTool } from "./ChatTools/RefreshXlfTool";
 import { GetTranslatedTextsByStateTool } from "./ChatTools/GetTranslatedTextsByStateTool";
+import { GetTextsByKeywordTool } from "./ChatTools/GetTextsByKeywordTool";
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -295,6 +296,9 @@ function registerChatTools(context: vscode.ExtensionContext): void {
   );
   context.subscriptions.push(
     vscode.lm.registerTool("refreshXlf", new RefreshXlfTool())
+  );
+  context.subscriptions.push(
+    vscode.lm.registerTool("getTextsByKeyword", new GetTextsByKeywordTool())
   );
 }
 

--- a/extension/src/mcp/server.ts
+++ b/extension/src/mcp/server.ts
@@ -107,12 +107,6 @@ const getTextsToTranslateSchema = z.object({
     .string()
     .optional()
     .describe("Optional path to the source language XLF file for reference"),
-  workspaceFilePath: z
-    .string()
-    .optional()
-    .describe(
-      "Path to the workspace (.code-workspace) file for additional settings. This parameter is MANDATORY when the app is part of a VS Code workspace, as critical translation settings (like target language configuration, custom translation rules, and formatting options) are often defined in the workspace file. Omitting this parameter when a workspace file exists may result in incorrect translation behavior or missing essential configuration."
-    ),
 });
 
 const getTranslatedTextsMapSchema = z.object({
@@ -131,12 +125,6 @@ const getTranslatedTextsMapSchema = z.object({
     .string()
     .optional()
     .describe("Optional path to the source language XLF file for reference"),
-  workspaceFilePath: z
-    .string()
-    .optional()
-    .describe(
-      "Path to the workspace (.code-workspace) file for additional settings. This parameter is MANDATORY when the app is part of a VS Code workspace, as critical translation settings (like target language configuration, custom translation rules, and formatting options) are often defined in the workspace file. Omitting this parameter when a workspace file exists may result in incorrect translation behavior or missing essential configuration."
-    ),
 });
 
 const getTranslatedTextsByStateSchema = z.object({
@@ -167,12 +155,6 @@ const getTranslatedTextsByStateSchema = z.object({
     .string()
     .optional()
     .describe("Optional path to the source language XLF file for reference"),
-  workspaceFilePath: z
-    .string()
-    .optional()
-    .describe(
-      "Path to the workspace (.code-workspace) file for additional settings. This parameter is MANDATORY when the app is part of a VS Code workspace, as critical translation settings (like target language configuration, custom translation rules, and formatting options) are often defined in the workspace file. Omitting this parameter when a workspace file exists may result in incorrect translation behavior or missing essential configuration."
-    ),
 });
 
 const getTextsByKeywordSchema = z.object({

--- a/extension/src/test/ChatTools/GetTextsByKeywordTool.test.ts
+++ b/extension/src/test/ChatTools/GetTextsByKeywordTool.test.ts
@@ -1,0 +1,108 @@
+import * as assert from "assert";
+import * as path from "path";
+// fs not required here
+import {
+  getTextsByKeywordCore,
+  ITranslatedTextWithState,
+} from "../../ChatTools/shared/XliffToolsCore";
+
+const sampleXlf = path.resolve(
+  __dirname,
+  "../../../src/test/resources/NAB_AL_Tools.sv-SE.xlf"
+);
+
+suite("getTextsByKeywordCore", function () {
+  test("substring match (case-insensitive) returns matching units", function () {
+    const result = getTextsByKeywordCore(
+      sampleXlf,
+      0,
+      0,
+      "this is a test",
+      false,
+      false
+    );
+    const data = result.data as ITranslatedTextWithState[];
+    assert.ok(Array.isArray(data), "Expected result data to be an array");
+    // Expect at least two units from sample that contain 'This is a test'
+    assert.ok(
+      data.length >= 2,
+      `Expected at least 2 matches, got ${data.length}`
+    );
+    const ids = data.map((d) => d.id);
+    assert.ok(
+      ids.some((id) => id.includes("NamedType")),
+      "Expected some id containing NamedType"
+    );
+  });
+
+  test("case-sensitive match respects caseSensitive flag", function () {
+    const resultInsensitive = getTextsByKeywordCore(
+      sampleXlf,
+      0,
+      0,
+      "This is a test",
+      false,
+      false
+    );
+    const resultSensitive = getTextsByKeywordCore(
+      sampleXlf,
+      0,
+      0,
+      "This is a test",
+      true,
+      false
+    );
+    // Both should match since the source text has capitalized 'This'
+    assert.ok(
+      resultInsensitive.data.length >= 2,
+      "Expected insensitive match to find items"
+    );
+    assert.ok(
+      resultSensitive.data.length >= 2,
+      "Expected sensitive match to find items"
+    );
+
+    // Now search for lower-case 'this is a test' with caseSensitive=true -> should find none
+    const resultLowerCaseSensitive = getTextsByKeywordCore(
+      sampleXlf,
+      0,
+      0,
+      "this is a test",
+      true,
+      false
+    );
+    assert.strictEqual(
+      resultLowerCaseSensitive.data.length,
+      0,
+      "Expected no matches for case-sensitive lower-case search"
+    );
+  });
+
+  test("regex match works and invalid regex throws", function () {
+    const result = getTextsByKeywordCore(
+      sampleXlf,
+      0,
+      0,
+      "This.*test",
+      false,
+      true
+    );
+    const data = result.data as ITranslatedTextWithState[];
+    assert.ok(data.length >= 2, "Expected regex to match multiple items");
+
+    // Invalid regex
+    assert.throws(() =>
+      getTextsByKeywordCore(sampleXlf, 0, 0, "[unclosed", false, true)
+    );
+  });
+
+  test("limit=0 returns all matches and pagination works", function () {
+    const all = getTextsByKeywordCore(sampleXlf, 0, 0, "This", false, false);
+    const page = getTextsByKeywordCore(sampleXlf, 1, 2, "This", false, false);
+    const allData = all.data as ITranslatedTextWithState[];
+    const pageData = page.data as ITranslatedTextWithState[];
+    assert.ok(allData.length >= 2, "Expected at least 2 matches in total");
+    // pageData should be at most 2 items
+    assert.ok(pageData.length <= 2, "Expected page size <= 2");
+  });
+});


### PR DESCRIPTION
This pull request introduces a new feature that allows users to search for source texts in XLF files by keyword or regular expression, returning matching translation units (including untranslated ones). The update includes the implementation of the core logic, integration with the MCP server and chat tools, schema updates, documentation, and comprehensive tests. Additionally, some minor improvements and clean-up were made to related schemas and documentation.

The most important changes are:

**New Feature: Search Texts by Keyword/Regex**
- Implemented `getTextsByKeywordCore` in `XliffToolsCore` to search XLF files for source texts matching a keyword or regex, supporting pagination, case sensitivity, and regex options. Returns translation units with metadata.
- Added `GetTextsByKeywordTool` for chat tools, enabling invocation and user confirmation for the new search functionality.
- Registered the new tool in the MCP server (`nab-al-tools-mcp-getTextsByKeyword`) with input validation, result formatting, and error handling.
- Extended the VS Code extension manifest (`package.json`) to describe and expose the new tool for language model integration.

**Documentation Updates**
- Updated `MCP_SERVER.md` to document the new `nab-al-tools-getTextsByKeyword` tool, its parameters, return values, and usage examples. Also clarified that `workspaceFilePath` parameters provide context and settings where relevant. [[1]](diffhunk://#diff-22fcee782d569b094bc8d50026b8f71d6dd2b2480e0eb01c4c3da096b5def7ccL162-R202) [[2]](diffhunk://#diff-22fcee782d569b094bc8d50026b8f71d6dd2b2480e0eb01c4c3da096b5def7ccL53-R53)

**Testing**
- Added comprehensive tests for `getTextsByKeywordCore`, covering substring, case sensitivity, regex matching, pagination, and error handling.

**Schema and Clean-up**
- Added schema validation for the new tool, and removed unused or redundant `workspaceFilePath` parameters from other tool schemas where they are not required. [[1]](diffhunk://#diff-648ff4dcf3f1fe0df5b120aefc40232886cc9db6869b80ba36605c9d768c5f62L109-L114) [[2]](diffhunk://#diff-648ff4dcf3f1fe0df5b120aefc40232886cc9db6869b80ba36605c9d768c5f62L133-L138) [[3]](diffhunk://#diff-648ff4dcf3f1fe0df5b120aefc40232886cc9db6869b80ba36605c9d768c5f62L169-R181)

**Minor Improvements**
- Refactored and relocated the `getTranslationState` helper to support the new tool and maintain consistency.