### PR TITLE
feat: enhance getTextsByKeyword tool to support searching in target texts

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -12,7 +12,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Added:
   - Added `NAB.PreserveOriginalAttribute` setting: When enabled, the 'original' attribute in translated XLIFF files will match the 'original' attribute from the source .g.xlf file (e.g., 'MyApp'). When disabled (default), the 'original' attribute will include the .g.xlf file extension (e.g., 'MyApp.g.xlf') for compatibility with Dynamics Translation Service. Enable this setting if you're using translation tools like Crowdin that require matching 'original' attributes between source and target files. Fixes [issue 294](https://github.com/jwikman/nab-al-tools/issues/294).
   - Added new Language Model Tools for improved translation workflow in GitHub Copilot Chat:
-    - `nab-al-tools-getTextsByKeyword` — Search source texts by keyword or regex to review terminology and locate related units (includes untranslated).
+    - `nab-al-tools-getTextsByKeyword` — Search source or target texts by keyword or regex to review terminology and locate related units. By default searches source (includes untranslated); when `searchInTarget` is true, searches only target (excludes untranslated).
     - `nab-al-tools-createLanguageXlf` — Create new XLF files for target languages based on generated XLF files, with optional base app translation matching.
   - `nab-al-tools-getGlossaryTerms` — Return Business Central glossary term pairs for a target language (optional source language), to enforce consistent terminology during translation and review.
   - Added support for a MCP server. This enables, not only integration with GitHub Copilot Chat, but also other MCP clients like Claude Desktop or GitHub Coding Agent. See [MCP_SERVER.md](MCP_SERVER.md) for details.

--- a/extension/MCP_SERVER.md
+++ b/extension/MCP_SERVER.md
@@ -192,7 +192,7 @@ The MCP server is bundled with the NAB AL Tools VS Code extension and can be run
 
 ### 7. getTextsByKeyword
 
-**Purpose**: Search source texts in an XLF file for a given keyword or regular expression and return matching translation units. This tool searches only the `<source>` element and includes untranslated units as well. It can be used to discover how a specific word or phrase is used across the application and to inspect how that word or phrase has been translated in different contexts, which helps when reviewing terminology, ensuring consistency, or preparing glossary entries.
+**Purpose**: Search source or target texts in an XLF file for a given keyword or regular expression and return matching translation units. By default, this tool searches the `<source>` element and includes untranslated units. When `searchInTarget` is true, it searches only the `<target>` element and excludes untranslated units. This tool can be used to discover how a specific word or phrase is used across the application and to inspect how that word or phrase has been translated in different contexts, which helps when reviewing terminology, ensuring consistency, or preparing glossary entries.
 
 **Annotations**:
 
@@ -207,6 +207,7 @@ The MCP server is bundled with the NAB AL Tools VS Code extension and can be run
 - `keyword` (required): The keyword or phrase to search for. When `isRegex` is true this is treated as a regular expression.
 - `caseSensitive` (optional): Enable case-sensitive matching (default: false)
 - `isRegex` (optional): Treat `keyword` as a regular expression (default: false)
+- `searchInTarget` (optional): Search in target text instead of source text (default: false). When true, only translated units with matching target text are returned.
 
 **Returns**: JSON array of objects containing:
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -379,9 +379,10 @@ This tool takes a generated XLF file path, target language code, and optional ba
 
 #### nab-al-tools-getTextsByKeyword
 
-Searches source texts in an XLF file for a given keyword or regular expression and returns matching translation units.
+Searches source or target texts in an XLF file for a given keyword or regular expression and returns matching translation units.
 
-- Searches only the `<source>` element; includes untranslated units as well
+- By default, searches the `<source>` element and includes untranslated units
+- When `searchInTarget` is true, searches only the `<target>` element and excludes untranslated units
 - Useful for terminology reviews, ensuring consistency, and locating related units
 - Supports case sensitivity toggle and regex-based searches
 - Supports pagination with offset/limit (limit 0 returns all matches)

--- a/extension/package.json
+++ b/extension/package.json
@@ -1174,11 +1174,11 @@
       {
         "name": "getTextsByKeyword",
         "displayName": "Get Texts By Keyword from an XLF file",
-        "modelDescription": "This tool searches source texts in a specified XLF file for a given keyword or regular expression and returns matching translation units (includes untranslated units). It can be used to discover how a specific word or phrase is used across the application and to inspect how that word or phrase has been translated in different contexts.",
+        "modelDescription": "This tool searches source or target texts in a specified XLF file for a given keyword or regular expression and returns matching translation units. By default, it searches in source texts (includes untranslated units). When searchInTarget is true, it searches only in target texts (excludes untranslated units). Use this to discover how a specific word or phrase is used across the application and to inspect how it has been translated in different contexts.",
         "tags": [
           "dynamics-365"
         ],
-        "userDescription": "(beta) Search source texts by keyword or regex in an XLF file. Use this to discover where a word or phrase appears and how it has been translated across contexts.",
+        "userDescription": "(beta) Search source or target texts by keyword or regex in an XLF file. Use this to discover where a word or phrase appears and how it has been translated across contexts.",
         "canBeReferencedInPrompt": true,
         "toolReferenceName": "nab-al-tools-getTextsByKeyword",
         "inputSchema": {
@@ -1198,7 +1198,7 @@
             },
             "keyword": {
               "type": "string",
-              "description": "The keyword or regex pattern to search for in the source text."
+              "description": "The keyword or regex pattern to search for in the source or target text."
             },
             "caseSensitive": {
               "type": "boolean",
@@ -1207,6 +1207,10 @@
             "isRegex": {
               "type": "boolean",
               "description": "Treat the 'keyword' parameter as a regular expression (default false)."
+            },
+            "searchInTarget": {
+              "type": "boolean",
+              "description": "Search in target text instead of source text (default false). When true, only translated units with matching target text are returned."
             }
           },
           "required": [

--- a/extension/src/ChatTools/GetTextsByKeywordTool.ts
+++ b/extension/src/ChatTools/GetTextsByKeywordTool.ts
@@ -9,6 +9,7 @@ export interface IGetTextsByKeywordParameters {
   keyword: string;
   caseSensitive?: boolean;
   isRegex?: boolean;
+  searchInTarget?: boolean;
 }
 
 export class GetTextsByKeywordTool
@@ -27,7 +28,8 @@ export class GetTextsByKeywordTool
         maxCount,
         params.keyword,
         params.caseSensitive || false,
-        params.isRegex || false
+        params.isRegex || false,
+        params.searchInTarget || false
       );
 
       if (_token.isCancellationRequested) {

--- a/extension/src/ChatTools/shared/XliffToolsCore.ts
+++ b/extension/src/ChatTools/shared/XliffToolsCore.ts
@@ -541,9 +541,9 @@ export function getTranslatedTextsByStateCore(
 }
 
 /**
- * Core logic for finding texts by keyword/phrase or regex in the source text.
+ * Core logic for finding texts by keyword/phrase or regex in the source or target text.
  * Returns the same shape as getTranslatedTextsByStateCore but matches by substring/regex
- * on the source text and includes untranslated units as well.
+ * on the source or target text and includes untranslated units (when searching source only).
  */
 export function getTextsByKeywordCore(
   filePath: string,
@@ -551,7 +551,8 @@ export function getTextsByKeywordCore(
   limit: number,
   keyword: string,
   caseSensitive = false,
-  isRegex = false
+  isRegex = false,
+  searchInTarget = false
 ): ICoreResult<ITranslatedTextWithState[]> {
   // Validation
   if (!filePath) {
@@ -597,14 +598,16 @@ export function getTextsByKeywordCore(
   }
 
   const matches = xliffDoc.transunit.filter((tu) => {
-    const src = tu.source || "";
+    const textToSearch = searchInTarget
+      ? tu.target.textContent || ""
+      : tu.source || "";
     if (isRegex && regex) {
-      return regex.test(src);
+      return regex.test(textToSearch);
     }
     if (caseSensitive) {
-      return src.includes(keyword);
+      return textToSearch.includes(keyword);
     }
-    return src.toLowerCase().includes(keyword.toLowerCase());
+    return textToSearch.toLowerCase().includes(keyword.toLowerCase());
   });
 
   matches.forEach((tu) => {
@@ -643,6 +646,7 @@ export function getTextsByKeywordCore(
     keyword: keyword,
     caseSensitive: caseSensitive,
     isRegex: isRegex,
+    searchInTarget: searchInTarget,
   };
 
   return {

--- a/extension/src/mcp/server.ts
+++ b/extension/src/mcp/server.ts
@@ -213,7 +213,9 @@ const getTextsByKeywordSchema = z.object({
   keyword: z
     .string()
     .min(1)
-    .describe("The keyword or regex pattern to search for in the source text."),
+    .describe(
+      "The keyword or regex pattern to search for in the source or target text."
+    ),
   caseSensitive: z
     .boolean()
     .optional()
@@ -223,6 +225,12 @@ const getTextsByKeywordSchema = z.object({
     .optional()
     .describe(
       "Treat the 'keyword' parameter as a regular expression (default false)."
+    ),
+  searchInTarget: z
+    .boolean()
+    .optional()
+    .describe(
+      "Search in target text instead of source text (default false). When true, only translated units with matching target text are returned."
     ),
 });
 
@@ -494,7 +502,7 @@ server.registerTool(
   "getTextsByKeyword",
   {
     description:
-      "This tool searches source texts in an XLF file for a given keyword or regex and returns matching translation units (includes untranslated units). It can be used to discover how a specific word or phrase is used across the application and to inspect how that word or phrase has been translated in different contexts.",
+      "This tool searches source or target texts in an XLF file for a given keyword or regex and returns matching translation units. By default, it searches in source texts (includes untranslated units). When searchInTarget is true, it searches only in target texts (excludes untranslated units). Use this to discover how a specific word or phrase is used across the application and to inspect how it has been translated in different contexts.",
     inputSchema: getTextsByKeywordSchema.shape,
     annotations: {
       title: "Get Texts by Keyword",
@@ -512,6 +520,7 @@ server.registerTool(
         keyword,
         caseSensitive,
         isRegex,
+        searchInTarget,
       } = parsed;
       // Execute core function (no settings needed for read-only operation)
       const result = getTextsByKeywordCore(
@@ -520,7 +529,8 @@ server.registerTool(
         kwLimit,
         keyword,
         caseSensitive || false,
-        isRegex || false
+        isRegex || false,
+        searchInTarget || false
       );
 
       return {


### PR DESCRIPTION
This pull request enhances the `nab-al-tools-getTextsByKeyword` tool by adding support for searching in both source and target texts within XLIFF files. Previously, searches were limited to the source text and included untranslated units. With the new `searchInTarget` parameter, users can now search only translated units in the target text, allowing for more flexible and targeted terminology reviews. The update is reflected across documentation, tool schemas, and implementation.

**Enhancements to `getTextsByKeyword` tool:**

* Added a `searchInTarget` boolean parameter to allow searching in the target text instead of the source text. When enabled, only translated units with matching target text are returned; by default, the tool searches source text and includes untranslated units. [[1]](diffhunk://#diff-7d222c098ead672733e1ceed70bfd1f9793233caac6ad3754def425ab27227d0R12) [[2]](diffhunk://#diff-7d222c098ead672733e1ceed70bfd1f9793233caac6ad3754def425ab27227d0L30-R32) [[3]](diffhunk://#diff-2d8814831104c934326a409545df52bc9b89388a2e8a2660908154eda62c697fL544-R555) [[4]](diffhunk://#diff-2d8814831104c934326a409545df52bc9b89388a2e8a2660908154eda62c697fL600-R610) [[5]](diffhunk://#diff-2d8814831104c934326a409545df52bc9b89388a2e8a2660908154eda62c697fR649) [[6]](diffhunk://#diff-648ff4dcf3f1fe0df5b120aefc40232886cc9db6869b80ba36605c9d768c5f62L216-R218) [[7]](diffhunk://#diff-648ff4dcf3f1fe0df5b120aefc40232886cc9db6869b80ba36605c9d768c5f62R229-R234) [[8]](diffhunk://#diff-648ff4dcf3f1fe0df5b120aefc40232886cc9db6869b80ba36605c9d768c5f62R523) [[9]](diffhunk://#diff-648ff4dcf3f1fe0df5b120aefc40232886cc9db6869b80ba36605c9d768c5f62L523-R533)
* Updated documentation in `README.md`, `CHANGELOG.md`, and `MCP_SERVER.md` to describe the new parameter and clarify tool behavior for both source and target searches. [[1]](diffhunk://#diff-7a10f33fd65f6692603aa7fe85eb9cdb287ed5db10964d2d2cbe651960d7aa63L382-R385) [[2]](diffhunk://#diff-682040dd8485cc191806cdd148f4304a3bf088e96ec2f9505d461786b1e90a2dL15-R15) [[3]](diffhunk://#diff-22fcee782d569b094bc8d50026b8f71d6dd2b2480e0eb01c4c3da096b5def7ccL195-R195) [[4]](diffhunk://#diff-22fcee782d569b094bc8d50026b8f71d6dd2b2480e0eb01c4c3da096b5def7ccR210)
* Modified tool descriptions and input schemas in `package.json` and server registration to accurately reflect the new functionality and parameter. [[1]](diffhunk://#diff-0e96fc4c0e4b663545725cc50af120099cb873ea9e3f16eee74d074e39be13feL1177-R1181) [[2]](diffhunk://#diff-0e96fc4c0e4b663545725cc50af120099cb873ea9e3f16eee74d074e39be13feL1201-R1201) [[3]](diffhunk://#diff-0e96fc4c0e4b663545725cc50af120099cb873ea9e3f16eee74d074e39be13feR1210-R1213) [[4]](diffhunk://#diff-648ff4dcf3f1fe0df5b120aefc40232886cc9db6869b80ba36605c9d768c5f62L497-R505)